### PR TITLE
Allow dotted server names for package-derived installs

### DIFF
--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -832,10 +832,30 @@ func deriveServerName(packageName string) string {
 		name = parts[len(parts)-1]
 	}
 	name = strings.ToLower(name)
-	name = strings.ReplaceAll(name, "_", "-")
 	name = strings.TrimSpace(name)
+
+	var normalized strings.Builder
+	normalized.Grow(len(name))
+	prevSeparator := false
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			normalized.WriteRune(r)
+			prevSeparator = false
+			continue
+		}
+		separator := '-'
+		if r == '.' || r == '-' {
+			separator = r
+		}
+		if !prevSeparator {
+			normalized.WriteRune(separator)
+			prevSeparator = true
+		}
+	}
+
+	name = normalized.String()
 	name = strings.TrimSuffix(name, "-mcp")
-	name = strings.Trim(name, "-")
+	name = strings.Trim(name, "-.")
 	return name
 }
 

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -444,6 +444,41 @@ func TestRunWithStoreInstallSkipInstallAndNoSync(t *testing.T) {
 	}
 }
 
+func TestRunWithStoreInstallDerivesNameFromDottedPackage(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	result := runCmd(
+		store,
+		"install", "awslabs.core-mcp-server",
+		"--skip-install",
+		"--no-sync",
+		"--command", commandPath,
+	)
+	if result.code != 0 {
+		t.Fatalf("install failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "added awslabs.core-mcp-server") {
+		t.Fatalf("expected derived manifest name output, got: %s", result.stdout)
+	}
+
+	manifest, err := store.Get("awslabs.core-mcp-server")
+	if err != nil {
+		t.Fatalf("expected manifest to exist: %v", err)
+	}
+	if manifest.Command != commandPath {
+		t.Fatalf("expected command path %q, got: %q", commandPath, manifest.Command)
+	}
+
+	removeResult := runCmd(store, "remove", "awslabs.core-mcp-server")
+	if removeResult.code != 0 {
+		t.Fatalf("remove failed: %s", removeResult.stderr)
+	}
+	if !strings.Contains(removeResult.stdout, "removed awslabs.core-mcp-server") {
+		t.Fatalf("expected remove output, got: %s", removeResult.stdout)
+	}
+}
+
 func TestRunWithStoreInstallRunsUVInstaller(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell fixture for uv installer test is unix-specific")
@@ -890,5 +925,53 @@ func TestRunHelpMentionsConfigDefaults(t *testing.T) {
 	}
 	if !strings.Contains(output, "MADARI_CONFIG_DIR") {
 		t.Fatalf("expected help output to mention MADARI_CONFIG_DIR override, got: %s", output)
+	}
+}
+
+func TestDeriveServerName(t *testing.T) {
+	tests := []struct {
+		name        string
+		packageName string
+		expected    string
+	}{
+		{
+			name:        "strips mcp suffix",
+			packageName: "stewreads-mcp",
+			expected:    "stewreads",
+		},
+		{
+			name:        "preserves dots",
+			packageName: "awslabs.core-mcp-server",
+			expected:    "awslabs.core-mcp-server",
+		},
+		{
+			name:        "normalizes underscores and preserves dots",
+			packageName: "foo_bar.baz",
+			expected:    "foo-bar.baz",
+		},
+		{
+			name:        "uses final slash segment",
+			packageName: "@modelcontextprotocol/server-sequential-thinking",
+			expected:    "server-sequential-thinking",
+		},
+		{
+			name:        "collapses repeated separators",
+			packageName: "foo...__bar",
+			expected:    "foo.bar",
+		},
+		{
+			name:        "returns empty when no valid characters",
+			packageName: "._/@",
+			expected:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := deriveServerName(tt.packageName)
+			if actual != tt.expected {
+				t.Fatalf("deriveServerName(%q) = %q, expected %q", tt.packageName, actual, tt.expected)
+			}
+		})
 	}
 }

--- a/docs/manifest-spec.md
+++ b/docs/manifest-spec.md
@@ -42,7 +42,7 @@ keys = ["STEWREADS_GMAIL_APP_PASSWORD"]
 
 ## Validation Rules
 
-- `name` must be lowercase alphanumeric with `-` allowed.
+- `name` must be lowercase alphanumeric with `-` and `.` allowed as separators.
 - `clients` must contain unique values.
 - Unknown top-level keys are rejected.
 - Empty `command` is invalid.

--- a/internal/registry/manifest.go
+++ b/internal/registry/manifest.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	manifestNamePattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+	manifestNamePattern = regexp.MustCompile(`^[a-z0-9]+(?:[.-][a-z0-9]+)*$`)
 	envKeyPattern       = regexp.MustCompile(`^[A-Z_][A-Z0-9_]*$`)
 )
 

--- a/internal/registry/manifest_test.go
+++ b/internal/registry/manifest_test.go
@@ -26,6 +26,14 @@ func TestManifestValidateOK(t *testing.T) {
 	}
 }
 
+func TestManifestValidateAllowsDotsInName(t *testing.T) {
+	m := baseManifest()
+	m.Name = "awslabs.core-mcp-server"
+	if err := m.Validate(); err != nil {
+		t.Fatalf("expected dotted name to validate, got error: %v", err)
+	}
+}
+
 func TestManifestValidateErrors(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary
- allow `.` in manifest/server names
- preserve dots when deriving default server name from package input
- keep normalizing unsupported separators (for example `_` -> `-`)
- update manifest spec docs for dotted names

## Why
`madari install awslabs.core-mcp-server` should produce a server name that matches package identifier semantics and remains removable via the same dotted name.

## Tests
- `TestRunWithStoreInstallDerivesNameFromDottedPackage` now covers install + remove with `awslabs.core-mcp-server`
- `TestDeriveServerName` covers dot-preserving derivation behavior
- `TestManifestValidateAllowsDotsInName` validates dotted manifest names
- `go test -count=1 ./...`

Closes #9
