### PR TITLE
Add npm manager support to madari install

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ go install github.com/ankitvg/madari/cmd/madari@latest
 
 Notes:
 
-- `install` runs `uv tool install`, auto-registers the server, and syncs to Claude in one command.
-- `install` requires `uv` in PATH unless you use `--skip-install` and pass `--command`.
+- `install` runs package-manager install (`uv` by default, or `npm` via `--manager npm`), auto-registers the server, and syncs to Claude in one command.
+- `install` requires the selected package manager in PATH unless you use `--skip-install` and pass `--command`.
+- `install --manager npm` requires `--command` because npm package names can differ from executable names.
 - `add` resolves `--command` to an absolute executable path and stores that path in the manifest.
 - `sync` skips servers with missing/non-executable command paths and continues syncing others.
 - `export` writes a versioned JSON snapshot for backup/sharing (stdout by default).
@@ -44,6 +45,7 @@ Example:
 
 ```bash
 madari install stewreads-mcp
+madari install @modelcontextprotocol/server-sequential-thinking --manager npm --command mcp-server-sequential-thinking
 madari add stewreads --command /Users/me/.local/bin/stewreads-mcp --client claude-desktop
 madari list
 madari status
@@ -74,7 +76,7 @@ go test ./...
 - Only touches entries Madari registered; leaves everything else alone
 - Backup + atomic write on every sync; skips invalid entries rather than aborting
 - `doctor` and `status` for diagnostics
-- Works with any package manager (`uv`, `pip`, `npm`, etc.), runtime (Python, Node), or MCP framework
+- Supports `uv` and `npm` package manager installs, plus manual `add` for any runtime/framework
 - macOS, Linux, and Windows; Claude Desktop is the current sync target
 
 ## Principles

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -159,6 +159,17 @@ func (a cliApp) cmdInstall(args []string) error {
 		return fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " "))
 	}
 
+	manager = strings.TrimSpace(strings.ToLower(manager))
+	if manager == "" {
+		manager = "uv"
+	}
+	if !isSupportedInstallManager(manager) {
+		return fmt.Errorf("unsupported package manager %q (supported: uv, npm)", manager)
+	}
+	if manager == "npm" && strings.TrimSpace(command) == "" {
+		return fmt.Errorf("--command is required when --manager npm because npm package names may differ from executable names")
+	}
+
 	name = strings.TrimSpace(name)
 	if name == "" {
 		name = deriveServerName(packageName)
@@ -817,8 +828,28 @@ func runPackageInstall(manager, packageName string, stdout, stderr io.Writer) er
 			return fmt.Errorf("run uv tool install %q: %w", packageName, err)
 		}
 		return nil
+	case "npm":
+		if _, err := exec.LookPath("npm"); err != nil {
+			return fmt.Errorf("npm not found in PATH; install npm or rerun with --skip-install and --command <path>")
+		}
+		cmd := exec.Command("npm", "install", "-g", packageName)
+		cmd.Stdout = stdout
+		cmd.Stderr = stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("run npm install -g %q: %w", packageName, err)
+		}
+		return nil
 	default:
-		return fmt.Errorf("unsupported package manager %q (supported: uv)", manager)
+		return fmt.Errorf("unsupported package manager %q (supported: uv, npm)", manager)
+	}
+}
+
+func isSupportedInstallManager(manager string) bool {
+	switch manager {
+	case "uv", "npm":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -944,8 +975,8 @@ func printInstallHelp(out io.Writer) {
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Options:")
 	fmt.Fprintln(out, "  --name <name>              Server name (default: derived from package)")
-	fmt.Fprintln(out, "  --command <cmd>            Server command (default: package name)")
-	fmt.Fprintln(out, "  --manager <name>           Package manager (default: uv)")
+	fmt.Fprintln(out, "  --command <cmd>            Server command (default: package name; required for --manager npm)")
+	fmt.Fprintln(out, "  --manager <name>           Package manager (default: uv; supported: uv, npm)")
 	fmt.Fprintln(out, "  --client <client>          Target client id (repeatable, default: claude-desktop)")
 	fmt.Fprintln(out, "  --arg <value>              Command argument (repeatable)")
 	fmt.Fprintln(out, "  --env KEY=VALUE            Environment variable (repeatable)")
@@ -963,6 +994,7 @@ func printInstallHelp(out io.Writer) {
 	fmt.Fprintln(out, "  madari install stewreads-mcp")
 	fmt.Fprintln(out, "  madari install stewreads-mcp --required-env STEWREADS_GMAIL_APP_PASSWORD")
 	fmt.Fprintln(out, "  madari install stewreads-mcp --skip-install --command /Users/me/.local/bin/stewreads-mcp")
+	fmt.Fprintln(out, "  madari install @modelcontextprotocol/server-sequential-thinking --manager npm --command mcp-server-sequential-thinking")
 }
 
 func printListHelp(out io.Writer) {

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -520,6 +520,74 @@ func TestRunWithStoreInstallRunsUVInstaller(t *testing.T) {
 	}
 }
 
+func TestRunWithStoreInstallRunsNPMInstaller(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture for npm installer test is unix-specific")
+	}
+
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "npm-args.log")
+	npmPath := filepath.Join(binDir, "npm")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > '" + logPath + "'\n"
+	if err := os.WriteFile(npmPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake npm: %v", err)
+	}
+
+	originalPath := os.Getenv("PATH")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+originalPath)
+
+	packageName := "@modelcontextprotocol/server-sequential-thinking"
+	result := runCmd(
+		store,
+		"install", packageName,
+		"--manager", "npm",
+		"--no-sync",
+		"--command", commandPath,
+	)
+	if result.code != 0 {
+		t.Fatalf("install with npm failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "installed package: "+packageName) {
+		t.Fatalf("expected install output, got: %s", result.stdout)
+	}
+
+	argsPayload, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read fake npm args log: %v", err)
+	}
+	argsText := string(argsPayload)
+	if !strings.Contains(argsText, "install") || !strings.Contains(argsText, "-g") || !strings.Contains(argsText, packageName) {
+		t.Fatalf("expected npm args to include `install -g %s`, got: %s", packageName, argsText)
+	}
+}
+
+func TestRunWithStoreInstallNPMRequiresCommand(t *testing.T) {
+	store := newTestStore(t)
+
+	result := runCmd(store, "install", "stewreads-mcp", "--manager", "npm", "--no-sync")
+	if result.code == 0 {
+		t.Fatalf("expected install to fail when npm command is omitted")
+	}
+	if !strings.Contains(result.stderr, "--command is required when --manager npm") {
+		t.Fatalf("expected npm command requirement error, got: %s", result.stderr)
+	}
+}
+
+func TestRunWithStoreInstallRejectsUnsupportedManager(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	result := runCmd(store, "install", "stewreads-mcp", "--manager", "pipx", "--no-sync", "--command", commandPath)
+	if result.code == 0 {
+		t.Fatalf("expected install to fail for unsupported manager")
+	}
+	if !strings.Contains(result.stderr, "unsupported package manager \"pipx\" (supported: uv, npm)") {
+		t.Fatalf("expected unsupported manager error, got: %s", result.stderr)
+	}
+}
+
 func TestRunWithStoreInstallErrorsWhenUVMissing(t *testing.T) {
 	store := newTestStore(t)
 	t.Setenv("PATH", "")
@@ -530,6 +598,20 @@ func TestRunWithStoreInstallErrorsWhenUVMissing(t *testing.T) {
 	}
 	if !strings.Contains(result.stderr, "uv not found in PATH") {
 		t.Fatalf("expected uv missing error, got: %s", result.stderr)
+	}
+}
+
+func TestRunWithStoreInstallErrorsWhenNPMMissing(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+	t.Setenv("PATH", "")
+
+	result := runCmd(store, "install", "stewreads-mcp", "--manager", "npm", "--no-sync", "--command", commandPath)
+	if result.code == 0 {
+		t.Fatalf("expected install to fail when npm is missing")
+	}
+	if !strings.Contains(result.stderr, "npm not found in PATH") {
+		t.Fatalf("expected npm missing error, got: %s", result.stderr)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `npm` as a supported package manager for `madari install`
- keep `uv` as the default manager (non-breaking)
- require `--command` when `--manager npm` to avoid package-name vs binary-name mismatch
- update install help text and README examples for npm

## Implementation details
- `runPackageInstall` now supports:
  - `uv tool install <package>`
  - `npm install -g <package>`
- manager validation now allows `uv` and `npm` only
- unsupported-manager errors list both supported managers

## Tests
- added `TestRunWithStoreInstallRunsNPMInstaller`
- added `TestRunWithStoreInstallNPMRequiresCommand`
- added `TestRunWithStoreInstallRejectsUnsupportedManager`
- added `TestRunWithStoreInstallErrorsWhenNPMMissing`
- ran `go test -count=1 ./...`
