### PR TITLE
Add claude-code MCP client sync target

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,21 +25,42 @@ go install github.com/ankitvg/madari/cmd/madari@latest
 - `madari remove <name>`
 - `madari enable <name>`
 - `madari disable <name>`
-- `madari sync claude-desktop [--dry-run] [--config-path <path>]`
-- `madari doctor [--config-path <path>]`
-- `madari status [--config-path <path>]`
+- `madari sync <client> [--dry-run] [--config-path <path>]`
+- `madari doctor [--config-path <path>] [--claude-code-config-path <path>]`
+- `madari status [--config-path <path>] [--claude-code-config-path <path>]`
 - `madari export [--file <path>]`
 - `madari import --file <path> [--apply]`
 
 Notes:
 
-- `install` runs package-manager install (`uv` by default, or `npm` via `--manager npm`), auto-registers the server, and syncs to Claude in one command.
+- `install` runs package-manager install (`uv` by default, or `npm` via `--manager npm`), auto-registers the server, and syncs to configured clients in one command.
 - `install` requires the selected package manager in PATH unless you use `--skip-install` and pass `--command`.
 - `install --manager npm` requires `--command` because npm package names can differ from executable names.
 - `add` resolves `--command` to an absolute executable path and stores that path in the manifest.
 - `sync` skips servers with missing/non-executable command paths and continues syncing others.
+- Supported sync clients: `claude-desktop` and `claude-code`.
+- Default sync config paths:
+  - `claude-desktop`: platform-specific Claude Desktop config path.
+  - `claude-code`: `<current working directory>/.mcp.json`.
+- `install --config-path` can only be used when exactly one sync target is selected.
 - `export` writes a versioned JSON snapshot for backup/sharing (stdout by default).
 - `import` is dry-run by default and only adds/updates listed servers (`--apply` persists).
+
+Claude Code project config shape (`.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "stewreads": {
+      "command": "/Users/me/.local/bin/stewreads-mcp",
+      "args": ["--stdio"],
+      "env": {
+        "STEWREADS_CONFIG_PATH": "~/.config/stewreads/config.toml"
+      }
+    }
+  }
+}
+```
 
 Example:
 
@@ -47,9 +68,11 @@ Example:
 madari install stewreads-mcp
 madari install @modelcontextprotocol/server-sequential-thinking --manager npm --command mcp-server-sequential-thinking
 madari add stewreads --command /Users/me/.local/bin/stewreads-mcp --client claude-desktop
+madari add stewreads --command /Users/me/.local/bin/stewreads-mcp --client claude-code
 madari list
 madari status
 madari sync claude-desktop --dry-run
+madari sync claude-code --dry-run
 madari export --file madari-snapshot.json
 madari import --file madari-snapshot.json
 madari import --file madari-snapshot.json --apply
@@ -77,7 +100,7 @@ go test ./...
 - Backup + atomic write on every sync; skips invalid entries rather than aborting
 - `doctor` and `status` for diagnostics
 - Supports `uv` and `npm` package manager installs, plus manual `add` for any runtime/framework
-- macOS, Linux, and Windows; Claude Desktop is the current sync target
+- macOS, Linux, and Windows; supports Claude Desktop and Claude Code sync targets
 
 ## Principles
 

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -13,11 +13,17 @@ import (
 	"strings"
 
 	"github.com/ankitvg/madari/internal/clients/claude"
+	"github.com/ankitvg/madari/internal/clients/claudecode"
 	"github.com/ankitvg/madari/internal/doctor"
 	"github.com/ankitvg/madari/internal/registry"
 )
 
 const version = "0.0.0-dev"
+
+var supportedSyncTargets = []string{
+	claude.Target,
+	claudecode.Target,
+}
 
 func run(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
@@ -226,16 +232,25 @@ func (a cliApp) cmdInstall(args []string) error {
 		return nil
 	}
 
-	if !hasClaudeTarget(manifest.Clients) {
-		fmt.Fprintln(a.stdout, "sync skipped (no claude-desktop client configured)")
+	targets := syncTargetsForClients(manifest.Clients)
+	if len(targets) == 0 {
+		fmt.Fprintln(a.stdout, "sync skipped (no supported sync client configured)")
 		return nil
 	}
 
-	syncArgs := []string{claude.Target}
-	if strings.TrimSpace(configPath) != "" {
-		syncArgs = append(syncArgs, "--config-path", configPath)
+	if strings.TrimSpace(configPath) != "" && len(targets) > 1 {
+		return fmt.Errorf("--config-path cannot be used when automatic sync has multiple target clients; run `madari sync <client> --config-path <path>` per target")
 	}
-	return a.cmdSync(syncArgs)
+	for _, target := range targets {
+		syncArgs := []string{target}
+		if strings.TrimSpace(configPath) != "" {
+			syncArgs = append(syncArgs, "--config-path", configPath)
+		}
+		if err := a.cmdSync(syncArgs); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (a cliApp) cmdAdd(args []string) error {
@@ -444,50 +459,43 @@ func (a cliApp) cmdSync(args []string) error {
 	if fs.NArg() != 0 {
 		return fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " "))
 	}
-	if target != claude.Target {
-		return fmt.Errorf("unsupported sync target %q (supported: %s)", target, claude.Target)
+	if !isSupportedSyncTarget(target) {
+		return fmt.Errorf("unsupported sync target %q (supported: %s)", target, strings.Join(supportedSyncTargets, ", "))
 	}
 
 	manifests, err := a.store.List()
 	if err != nil {
 		return err
 	}
-	syncable, skipped := filterSyncableClaudeManifests(manifests)
+	syncable, skipped := filterSyncableManifests(manifests, target)
 
 	statePath := filepath.Join(filepath.Dir(a.store.ServersDir()), "state", target+"-managed.json")
-	result, err := claude.Sync(syncable, claude.SyncOptions{
-		ConfigPath: configPath,
-		StatePath:  statePath,
-		DryRun:     dryRun,
-	})
-	if err != nil {
-		return err
-	}
-
-	mode := "applied"
-	if result.DryRun {
-		mode = "dry-run"
-	}
-
-	fmt.Fprintf(a.stdout, "sync target: %s\n", target)
-	fmt.Fprintf(a.stdout, "config path: %s\n", result.ConfigPath)
-	fmt.Fprintf(a.stdout, "mode: %s\n", mode)
-	fmt.Fprintf(a.stdout, "added: %s\n", formatNameList(result.Added))
-	fmt.Fprintf(a.stdout, "updated: %s\n", formatNameList(result.Updated))
-	fmt.Fprintf(a.stdout, "removed: %s\n", formatNameList(result.Removed))
-	if len(skipped) > 0 {
-		fmt.Fprintf(a.stdout, "skipped: %s\n", formatNameList(skipped))
-		for _, name := range skipped {
-			fmt.Fprintf(a.stderr, "warning: skipped %s because command path is not an executable file\n", name)
+	switch target {
+	case claude.Target:
+		result, err := claude.Sync(syncable, claude.SyncOptions{
+			ConfigPath: configPath,
+			StatePath:  statePath,
+			DryRun:     dryRun,
+		})
+		if err != nil {
+			return err
 		}
+		printSyncSummary(a.stdout, a.stderr, target, result.ConfigPath, result.DryRun, result.Added, result.Updated, result.Removed, result.Unchanged, skipped)
+		return nil
+	case claudecode.Target:
+		result, err := claudecode.Sync(syncable, claudecode.SyncOptions{
+			ConfigPath: configPath,
+			StatePath:  statePath,
+			DryRun:     dryRun,
+		})
+		if err != nil {
+			return err
+		}
+		printSyncSummary(a.stdout, a.stderr, target, result.ConfigPath, result.DryRun, result.Added, result.Updated, result.Removed, result.Unchanged, skipped)
+		return nil
+	default:
+		return fmt.Errorf("unsupported sync target %q (supported: %s)", target, strings.Join(supportedSyncTargets, ", "))
 	}
-	if len(result.Unchanged) > 0 {
-		fmt.Fprintf(a.stdout, "unchanged: %s\n", formatNameList(result.Unchanged))
-	}
-	if !result.HasChanges() {
-		fmt.Fprintln(a.stdout, "no changes")
-	}
-	return nil
 }
 
 func (a cliApp) cmdDoctor(args []string) error {
@@ -499,7 +507,9 @@ func (a cliApp) cmdDoctor(args []string) error {
 	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	var configPath string
+	var claudeCodeConfigPath string
 	fs.StringVar(&configPath, "config-path", "", "Override Claude Desktop config path")
+	fs.StringVar(&claudeCodeConfigPath, "claude-code-config-path", "", "Override Claude Code config path")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			printDoctorHelp(a.stdout)
@@ -512,7 +522,8 @@ func (a cliApp) cmdDoctor(args []string) error {
 	}
 
 	report, err := doctor.Run(a.store, doctor.Options{
-		ClaudeConfigPath: configPath,
+		ClaudeConfigPath:     configPath,
+		ClaudeCodeConfigPath: claudeCodeConfigPath,
 	})
 	if err != nil {
 		return err
@@ -522,6 +533,12 @@ func (a cliApp) cmdDoctor(args []string) error {
 	fmt.Fprintf(a.stdout, "claude config: %s [%s]\n", report.ClaudeConfig.Path, report.ClaudeConfig.Status)
 	if report.ClaudeConfig.Message != "" {
 		fmt.Fprintf(a.stdout, "claude detail: %s\n", report.ClaudeConfig.Message)
+	}
+	if report.ClaudeCodeConfig.Status != "" && report.ClaudeCodeConfig.Status != doctor.StatusSkipped {
+		fmt.Fprintf(a.stdout, "claude-code config: %s [%s]\n", report.ClaudeCodeConfig.Path, report.ClaudeCodeConfig.Status)
+		if report.ClaudeCodeConfig.Message != "" {
+			fmt.Fprintf(a.stdout, "claude-code detail: %s\n", report.ClaudeCodeConfig.Message)
+		}
 	}
 
 	if len(report.ManifestErrors) > 0 {
@@ -576,7 +593,9 @@ func (a cliApp) cmdStatus(args []string) error {
 	fs := flag.NewFlagSet("status", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	var configPath string
+	var claudeCodeConfigPath string
 	fs.StringVar(&configPath, "config-path", "", "Override Claude Desktop config path")
+	fs.StringVar(&claudeCodeConfigPath, "claude-code-config-path", "", "Override Claude Code config path")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			printStatusHelp(a.stdout)
@@ -589,7 +608,8 @@ func (a cliApp) cmdStatus(args []string) error {
 	}
 
 	report, err := doctor.Run(a.store, doctor.Options{
-		ClaudeConfigPath: configPath,
+		ClaudeConfigPath:     configPath,
+		ClaudeCodeConfigPath: claudeCodeConfigPath,
 	})
 	if err != nil {
 		return err
@@ -605,6 +625,9 @@ func (a cliApp) cmdStatus(args []string) error {
 		report.Summary.Skipped,
 	)
 	fmt.Fprintf(a.stdout, "claude-config: %s\n", report.ClaudeConfig.Status)
+	if report.ClaudeCodeConfig.Status != "" && report.ClaudeCodeConfig.Status != doctor.StatusSkipped {
+		fmt.Fprintf(a.stdout, "claude-code-config: %s\n", report.ClaudeCodeConfig.Status)
+	}
 	if len(report.ManifestErrors) > 0 {
 		fmt.Fprintf(a.stdout, "manifest-errors: %d\n", len(report.ManifestErrors))
 	}
@@ -750,11 +773,11 @@ func parseEnvPairs(pairs []string) (map[string]string, error) {
 	return env, nil
 }
 
-func filterSyncableClaudeManifests(manifests []registry.Manifest) ([]registry.Manifest, []string) {
+func filterSyncableManifests(manifests []registry.Manifest, target string) ([]registry.Manifest, []string) {
 	out := make([]registry.Manifest, 0, len(manifests))
 	var skipped []string
 	for _, manifest := range manifests {
-		if !manifest.Enabled || !hasClaudeTarget(manifest.Clients) {
+		if !manifest.Enabled || !hasClientTarget(manifest.Clients, target) {
 			out = append(out, manifest)
 			continue
 		}
@@ -768,9 +791,28 @@ func filterSyncableClaudeManifests(manifests []registry.Manifest) ([]registry.Ma
 	return out, skipped
 }
 
-func hasClaudeTarget(clients []string) bool {
+func hasClientTarget(clients []string, target string) bool {
 	for _, client := range clients {
-		if strings.EqualFold(strings.TrimSpace(client), claude.Target) {
+		if strings.EqualFold(strings.TrimSpace(client), target) {
+			return true
+		}
+	}
+	return false
+}
+
+func syncTargetsForClients(clients []string) []string {
+	targets := make([]string, 0, len(supportedSyncTargets))
+	for _, target := range supportedSyncTargets {
+		if hasClientTarget(clients, target) {
+			targets = append(targets, target)
+		}
+	}
+	return targets
+}
+
+func isSupportedSyncTarget(target string) bool {
+	for _, supported := range supportedSyncTargets {
+		if target == supported {
 			return true
 		}
 	}
@@ -917,6 +959,32 @@ func formatNameList(names []string) string {
 	return strings.Join(names, ",")
 }
 
+func printSyncSummary(stdout, stderr io.Writer, target, configPath string, dryRun bool, added, updated, removed, unchanged, skipped []string) {
+	mode := "applied"
+	if dryRun {
+		mode = "dry-run"
+	}
+
+	fmt.Fprintf(stdout, "sync target: %s\n", target)
+	fmt.Fprintf(stdout, "config path: %s\n", configPath)
+	fmt.Fprintf(stdout, "mode: %s\n", mode)
+	fmt.Fprintf(stdout, "added: %s\n", formatNameList(added))
+	fmt.Fprintf(stdout, "updated: %s\n", formatNameList(updated))
+	fmt.Fprintf(stdout, "removed: %s\n", formatNameList(removed))
+	if len(skipped) > 0 {
+		fmt.Fprintf(stdout, "skipped: %s\n", formatNameList(skipped))
+		for _, name := range skipped {
+			fmt.Fprintf(stderr, "warning: skipped %s because command path is not an executable file\n", name)
+		}
+	}
+	if len(unchanged) > 0 {
+		fmt.Fprintf(stdout, "unchanged: %s\n", formatNameList(unchanged))
+	}
+	if len(added)+len(updated)+len(removed) == 0 {
+		fmt.Fprintln(stdout, "no changes")
+	}
+}
+
 func isHelpToken(value string) bool {
 	return value == "--help" || value == "-h"
 }
@@ -984,11 +1052,11 @@ func printInstallHelp(out io.Writer) {
 	fmt.Fprintln(out, "  --description <text>       Server description")
 	fmt.Fprintln(out, "  --disabled                 Add server in disabled state")
 	fmt.Fprintln(out, "  --skip-install             Skip package installation")
-	fmt.Fprintln(out, "  --no-sync                  Skip automatic claude-desktop sync")
-	fmt.Fprintln(out, "  --config-path <path>       Override Claude config path for sync")
+	fmt.Fprintln(out, "  --no-sync                  Skip automatic sync after install")
+	fmt.Fprintln(out, "  --config-path <path>       Override target config path for sync (single target only)")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Description:")
-	fmt.Fprintln(out, "  Install a local MCP package, register it in Madari, and sync it to Claude Desktop.")
+	fmt.Fprintln(out, "  Install a local MCP package, register it in Madari, and sync it to configured clients.")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Examples:")
 	fmt.Fprintln(out, "  madari install stewreads-mcp")
@@ -1027,33 +1095,36 @@ func printEnableDisableHelp(command string, out io.Writer) {
 
 func printSyncHelp(out io.Writer) {
 	fmt.Fprintln(out, "Usage:")
-	fmt.Fprintln(out, "  madari sync claude-desktop [--dry-run] [--config-path <path>]")
+	fmt.Fprintln(out, "  madari sync <client> [--dry-run] [--config-path <path>]")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Options:")
 	fmt.Fprintln(out, "  --dry-run                  Preview changes without writing files")
-	fmt.Fprintln(out, "  --config-path <path>       Override Claude config path")
+	fmt.Fprintln(out, "  --config-path <path>       Override target client config path")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Description:")
-	fmt.Fprintln(out, "  Sync enabled claude-desktop servers from Madari registry into Claude config.")
+	fmt.Fprintln(out, "  Sync enabled servers from Madari registry into a target client config.")
+	fmt.Fprintln(out, "  Supported clients: claude-desktop, claude-code.")
 }
 
 func printDoctorHelp(out io.Writer) {
 	fmt.Fprintln(out, "Usage:")
-	fmt.Fprintln(out, "  madari doctor [--config-path <path>]")
+	fmt.Fprintln(out, "  madari doctor [--config-path <path>] [--claude-code-config-path <path>]")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Options:")
-	fmt.Fprintln(out, "  --config-path <path>       Override Claude config path for diagnostics")
+	fmt.Fprintln(out, "  --config-path <path>                Override Claude Desktop config path for diagnostics")
+	fmt.Fprintln(out, "  --claude-code-config-path <path>    Override Claude Code config path for diagnostics")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Description:")
-	fmt.Fprintln(out, "  Validate server manifests, command paths, required env keys, and Claude config health.")
+	fmt.Fprintln(out, "  Validate server manifests, command paths, required env keys, and client config health.")
 }
 
 func printStatusHelp(out io.Writer) {
 	fmt.Fprintln(out, "Usage:")
-	fmt.Fprintln(out, "  madari status [--config-path <path>]")
+	fmt.Fprintln(out, "  madari status [--config-path <path>] [--claude-code-config-path <path>]")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Options:")
-	fmt.Fprintln(out, "  --config-path <path>       Override Claude config path for status checks")
+	fmt.Fprintln(out, "  --config-path <path>                Override Claude Desktop config path for status checks")
+	fmt.Fprintln(out, "  --claude-code-config-path <path>    Override Claude Code config path for status checks")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Description:")
 	fmt.Fprintln(out, "  Show a concise readiness summary. Use `madari doctor` for full details.")
@@ -1109,6 +1180,7 @@ func printHelp(out io.Writer) {
 	fmt.Fprintln(out, "  madari list")
 	fmt.Fprintln(out, "  madari disable stewreads")
 	fmt.Fprintln(out, "  madari sync claude-desktop --dry-run")
+	fmt.Fprintln(out, "  madari sync claude-code --dry-run")
 	fmt.Fprintln(out, "  madari export --file madari-snapshot.json")
 	fmt.Fprintln(out, "  madari import --file madari-snapshot.json")
 	fmt.Fprintln(out, "  madari import --file madari-snapshot.json --apply")

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -328,7 +328,7 @@ func TestRunHelpSubcommandOutput(t *testing.T) {
 	}{
 		{name: "help install", args: []string{"help", "install"}, contains: "madari install <package>"},
 		{name: "help add", args: []string{"help", "add"}, contains: "madari add <name>"},
-		{name: "help sync", args: []string{"help", "sync"}, contains: "madari sync claude-desktop"},
+		{name: "help sync", args: []string{"help", "sync"}, contains: "madari sync <client>"},
 		{name: "help list", args: []string{"help", "list"}, contains: "madari list"},
 		{name: "help doctor", args: []string{"help", "doctor"}, contains: "madari doctor"},
 		{name: "help status", args: []string{"help", "status"}, contains: "madari status"},
@@ -374,7 +374,7 @@ func TestRunWithStoreSubcommandHelpFlags(t *testing.T) {
 	if result := runCmd(store, "install", "--help"); result.code != 0 || !strings.Contains(result.stdout, "madari install <package>") {
 		t.Fatalf("expected install --help to print command help, got code=%d stdout=%s stderr=%s", result.code, result.stdout, result.stderr)
 	}
-	if result := runCmd(store, "sync", "--help"); result.code != 0 || !strings.Contains(result.stdout, "madari sync claude-desktop") {
+	if result := runCmd(store, "sync", "--help"); result.code != 0 || !strings.Contains(result.stdout, "madari sync <client>") {
 		t.Fatalf("expected sync --help to print command help, got code=%d stdout=%s stderr=%s", result.code, result.stdout, result.stderr)
 	}
 	if result := runCmd(store, "list", "--help"); result.code != 0 || !strings.Contains(result.stdout, "madari list") {
@@ -647,6 +647,39 @@ func TestRunWithStoreInstallAutoSyncByDefault(t *testing.T) {
 	}
 }
 
+func TestRunWithStoreInstallAutoSyncClaudeCode(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	configPath := filepath.Join(t.TempDir(), ".mcp.json")
+	if err := os.WriteFile(configPath, []byte(`{"mcpServers":{"weather":{"command":"uv"}}}`), 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	result := runCmd(
+		store,
+		"install", "stewreads-mcp",
+		"--skip-install",
+		"--command", commandPath,
+		"--client", "claude-code",
+		"--config-path", configPath,
+	)
+	if result.code != 0 {
+		t.Fatalf("install auto-sync failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "sync target: claude-code") {
+		t.Fatalf("expected claude-code sync output, got: %s", result.stdout)
+	}
+
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config after install sync: %v", err)
+	}
+	if !strings.Contains(string(after), "\"stewreads\"") {
+		t.Fatalf("expected synced config to include stewreads server, got: %s", string(after))
+	}
+}
+
 func TestRunWithStoreSyncDryRun(t *testing.T) {
 	store := newTestStore(t)
 	commandPath := mustCurrentExecutable(t)
@@ -714,6 +747,43 @@ func TestRunWithStoreSyncApply(t *testing.T) {
 	}
 	if !strings.Contains(result.stdout, "mode: applied") {
 		t.Fatalf("expected applied mode output, got: %s", result.stdout)
+	}
+
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config after sync: %v", err)
+	}
+	if !strings.Contains(string(after), "\"stewreads\"") {
+		t.Fatalf("expected synced config to include stewreads server, got: %s", string(after))
+	}
+	if !strings.Contains(string(after), "\"weather\"") {
+		t.Fatalf("expected synced config to preserve existing weather server, got: %s", string(after))
+	}
+}
+
+func TestRunWithStoreSyncClaudeCodeApply(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	addResult := runCmd(store, "add", "stewreads", "--command", commandPath, "--client", "claude-code")
+	if addResult.code != 0 {
+		t.Fatalf("setup add failed: %s", addResult.stderr)
+	}
+
+	configPath := filepath.Join(t.TempDir(), ".mcp.json")
+	if err := os.WriteFile(configPath, []byte(`{"mcpServers":{"weather":{"command":"uv"}}}`), 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	result := runCmd(store, "sync", "claude-code", "--config-path", configPath)
+	if result.code != 0 {
+		t.Fatalf("sync apply failed with stderr: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "mode: applied") {
+		t.Fatalf("expected applied mode output, got: %s", result.stdout)
+	}
+	if !strings.Contains(result.stdout, "sync target: claude-code") {
+		t.Fatalf("expected claude-code target output, got: %s", result.stdout)
 	}
 
 	after, err := os.ReadFile(configPath)
@@ -942,6 +1012,40 @@ func TestRunWithStoreDoctorReturnsErrorForInvalidConfig(t *testing.T) {
 	}
 }
 
+func TestRunWithStoreDoctorReturnsErrorForInvalidClaudeCodeConfig(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	if result := runCmd(store, "add", "stewreads", "--command", commandPath, "--client", "claude-code"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+
+	desktopConfigPath := filepath.Join(t.TempDir(), "claude_desktop_config.json")
+	if err := os.WriteFile(desktopConfigPath, []byte(`{"mcpServers":{}}`), 0o644); err != nil {
+		t.Fatalf("write desktop config fixture: %v", err)
+	}
+	claudeCodeConfigPath := filepath.Join(t.TempDir(), ".mcp.json")
+	if err := os.WriteFile(claudeCodeConfigPath, []byte("{broken"), 0o644); err != nil {
+		t.Fatalf("write invalid Claude Code config fixture: %v", err)
+	}
+
+	result := runCmd(
+		store,
+		"doctor",
+		"--config-path", desktopConfigPath,
+		"--claude-code-config-path", claudeCodeConfigPath,
+	)
+	if result.code == 0 {
+		t.Fatalf("doctor expected failure for invalid Claude Code config")
+	}
+	if !strings.Contains(result.stderr, "doctor found") {
+		t.Fatalf("expected doctor error summary in stderr, got: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "claude-code config:") {
+		t.Fatalf("expected doctor output to include claude-code config details, got: %s", result.stdout)
+	}
+}
+
 func TestRunWithStoreStatusHealthy(t *testing.T) {
 	store := newTestStore(t)
 	commandPath := mustCurrentExecutable(t)
@@ -986,6 +1090,37 @@ func TestRunWithStoreStatusReturnsErrorForInvalidConfig(t *testing.T) {
 	}
 	if !strings.Contains(result.stderr, "status found") {
 		t.Fatalf("expected status error summary in stderr, got: %s", result.stderr)
+	}
+}
+
+func TestRunWithStoreStatusShowsClaudeCodeConfigWhenTargetPresent(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	if result := runCmd(store, "add", "stewreads", "--command", commandPath, "--client", "claude-code"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+
+	desktopConfigPath := filepath.Join(t.TempDir(), "claude_desktop_config.json")
+	if err := os.WriteFile(desktopConfigPath, []byte(`{"mcpServers":{}}`), 0o644); err != nil {
+		t.Fatalf("write desktop config fixture: %v", err)
+	}
+	claudeCodeConfigPath := filepath.Join(t.TempDir(), ".mcp.json")
+	if err := os.WriteFile(claudeCodeConfigPath, []byte(`{"mcpServers":{}}`), 0o644); err != nil {
+		t.Fatalf("write Claude Code config fixture: %v", err)
+	}
+
+	result := runCmd(
+		store,
+		"status",
+		"--config-path", desktopConfigPath,
+		"--claude-code-config-path", claudeCodeConfigPath,
+	)
+	if result.code != 0 {
+		t.Fatalf("status expected success, got code=%d stderr=%s stdout=%s", result.code, result.stderr, result.stdout)
+	}
+	if !strings.Contains(result.stdout, "claude-code-config: ready") {
+		t.Fatalf("expected status output to include claude-code-config readiness, got: %s", result.stdout)
 	}
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,7 +15,7 @@
 
 2. Client Adapters
 - Translate registry entries into client-specific config.
-- Current adapter: Claude Desktop.
+- Current adapters: Claude Desktop and Claude Code.
 - Adapters own read/merge/write behavior for their client format.
 
 3. Sync Engine

--- a/docs/manifest-spec.md
+++ b/docs/manifest-spec.md
@@ -15,6 +15,11 @@ Each managed server is stored as a TOML document.
 - `clients` (array of strings, required): client IDs.
 - `description` (string, optional): friendly description.
 
+Supported client IDs:
+
+- `claude-desktop`
+- `claude-code`
+
 ### `[env]`
 
 Key/value static environment variables.

--- a/internal/clients/claudecode/sync.go
+++ b/internal/clients/claudecode/sync.go
@@ -1,0 +1,454 @@
+package claudecode
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+const (
+	Target = "claude-code"
+)
+
+var ErrConflict = errors.New("sync conflict with unmanaged server")
+
+// SyncOptions configures sync behavior.
+type SyncOptions struct {
+	ConfigPath string
+	StatePath  string
+	DryRun     bool
+}
+
+// SyncResult captures the computed or applied mutation plan.
+type SyncResult struct {
+	ConfigPath string
+	DryRun     bool
+	Added      []string
+	Updated    []string
+	Removed    []string
+	Unchanged  []string
+}
+
+// HasChanges reports whether sync produces any mutation.
+func (r SyncResult) HasChanges() bool {
+	return len(r.Added)+len(r.Updated)+len(r.Removed) > 0
+}
+
+// Sync synchronizes enabled Claude Code-targeted manifests into the Claude Code config file.
+func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
+	configPath, err := resolveConfigPath(opts.ConfigPath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	statePath, err := resolveStatePath(opts.StatePath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	root, existingServers, configExists, err := loadClaudeCodeConfig(configPath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	managedNames, err := loadManagedState(statePath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	desiredServers := desiredServersForTarget(manifests)
+	result, err := buildPlan(existingServers, managedNames, desiredServers)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	result.ConfigPath = configPath
+	result.DryRun = opts.DryRun
+
+	if opts.DryRun {
+		return result, nil
+	}
+
+	mutated := copyServers(existingServers)
+	for _, name := range result.Removed {
+		delete(mutated, name)
+	}
+	for name, server := range desiredServers {
+		mutated[name] = server
+	}
+
+	updatedRoot := make(map[string]json.RawMessage, len(root)+1)
+	for key, value := range root {
+		updatedRoot[key] = value
+	}
+	serversPayload, err := json.Marshal(mutated)
+	if err != nil {
+		return SyncResult{}, fmt.Errorf("marshal mcpServers: %w", err)
+	}
+	updatedRoot["mcpServers"] = serversPayload
+
+	payload, err := json.MarshalIndent(updatedRoot, "", "  ")
+	if err != nil {
+		return SyncResult{}, fmt.Errorf("marshal Claude Code config: %w", err)
+	}
+	payload = append(payload, '\n')
+
+	if configExists {
+		if _, err := backupFile(configPath); err != nil {
+			return SyncResult{}, fmt.Errorf("backup Claude Code config: %w", err)
+		}
+	}
+	if err := writeFileAtomically(configPath, payload, 0o644); err != nil {
+		return SyncResult{}, fmt.Errorf("write Claude Code config: %w", err)
+	}
+
+	if err := saveManagedState(statePath, mapKeys(desiredServers)); err != nil {
+		return SyncResult{}, fmt.Errorf("write managed sync state: %w", err)
+	}
+
+	return result, nil
+}
+
+func DefaultProjectConfigPath() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("resolve current working directory: %w", err)
+	}
+	return filepath.Join(cwd, ".mcp.json"), nil
+}
+
+func DefaultStatePath() (string, error) {
+	root, err := registry.DefaultRootDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, "state", Target+"-managed.json"), nil
+}
+
+func resolveConfigPath(configPath string) (string, error) {
+	if strings.TrimSpace(configPath) != "" {
+		resolved, err := expandHome(configPath)
+		if err != nil {
+			return "", err
+		}
+		return filepath.Clean(resolved), nil
+	}
+	return DefaultProjectConfigPath()
+}
+
+func resolveStatePath(statePath string) (string, error) {
+	if strings.TrimSpace(statePath) != "" {
+		resolved, err := expandHome(statePath)
+		if err != nil {
+			return "", err
+		}
+		return filepath.Clean(resolved), nil
+	}
+	return DefaultStatePath()
+}
+
+func desiredServersForTarget(manifests []registry.Manifest) map[string]serverConfig {
+	servers := map[string]serverConfig{}
+	for _, manifest := range manifests {
+		if !manifest.Enabled {
+			continue
+		}
+		if !hasTargetClient(manifest.Clients) {
+			continue
+		}
+
+		entry := serverConfig{Command: manifest.Command}
+		if len(manifest.Args) > 0 {
+			entry.Args = append([]string(nil), manifest.Args...)
+		}
+		if len(manifest.Env) > 0 {
+			entry.Env = map[string]string{}
+			for key, value := range manifest.Env {
+				entry.Env[key] = value
+			}
+		}
+		servers[manifest.Name] = entry
+	}
+	return servers
+}
+
+func hasTargetClient(clients []string) bool {
+	for _, client := range clients {
+		if strings.EqualFold(strings.TrimSpace(client), Target) {
+			return true
+		}
+	}
+	return false
+}
+
+func buildPlan(existing map[string]serverConfig, managed []string, desired map[string]serverConfig) (SyncResult, error) {
+	managedSet := map[string]struct{}{}
+	for _, name := range managed {
+		managedSet[name] = struct{}{}
+	}
+
+	result := SyncResult{}
+	for name := range managedSet {
+		if _, stillDesired := desired[name]; stillDesired {
+			continue
+		}
+		if _, exists := existing[name]; exists {
+			result.Removed = append(result.Removed, name)
+		}
+	}
+
+	var conflicts []string
+	for name, desiredServer := range desired {
+		existingServer, exists := existing[name]
+		_, managedByMadari := managedSet[name]
+
+		if !exists {
+			result.Added = append(result.Added, name)
+			continue
+		}
+		if !managedByMadari {
+			if equalServer(existingServer, desiredServer) {
+				result.Unchanged = append(result.Unchanged, name)
+				continue
+			}
+			conflicts = append(conflicts, name)
+			continue
+		}
+
+		if equalServer(existingServer, desiredServer) {
+			result.Unchanged = append(result.Unchanged, name)
+		} else {
+			result.Updated = append(result.Updated, name)
+		}
+	}
+
+	sort.Strings(result.Added)
+	sort.Strings(result.Updated)
+	sort.Strings(result.Removed)
+	sort.Strings(result.Unchanged)
+
+	if len(conflicts) > 0 {
+		sort.Strings(conflicts)
+		return SyncResult{}, fmt.Errorf("%w: unmanaged entries already exist with different values: %s", ErrConflict, strings.Join(conflicts, ", "))
+	}
+	return result, nil
+}
+
+func equalServer(a, b serverConfig) bool {
+	if a.Command != b.Command {
+		return false
+	}
+	if len(a.Args) != len(b.Args) {
+		return false
+	}
+	for i := range a.Args {
+		if a.Args[i] != b.Args[i] {
+			return false
+		}
+	}
+	if len(a.Env) != len(b.Env) {
+		return false
+	}
+	for key, value := range a.Env {
+		if b.Env[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func loadClaudeCodeConfig(path string) (map[string]json.RawMessage, map[string]serverConfig, bool, error) {
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]json.RawMessage{}, map[string]serverConfig{}, false, nil
+		}
+		return nil, nil, false, fmt.Errorf("read Claude Code config %q: %w", path, err)
+	}
+
+	root := map[string]json.RawMessage{}
+	if err := json.Unmarshal(payload, &root); err != nil {
+		return nil, nil, true, fmt.Errorf("parse Claude Code config JSON: %w", err)
+	}
+
+	servers := map[string]serverConfig{}
+	if raw, exists := root["mcpServers"]; exists {
+		if err := json.Unmarshal(raw, &servers); err != nil {
+			return nil, nil, true, fmt.Errorf("parse mcpServers: %w", err)
+		}
+	}
+	if servers == nil {
+		servers = map[string]serverConfig{}
+	}
+
+	return root, servers, true, nil
+}
+
+func copyServers(in map[string]serverConfig) map[string]serverConfig {
+	out := make(map[string]serverConfig, len(in))
+	for name, server := range in {
+		clone := serverConfig{Command: server.Command}
+		if len(server.Args) > 0 {
+			clone.Args = append([]string(nil), server.Args...)
+		}
+		if len(server.Env) > 0 {
+			clone.Env = map[string]string{}
+			for key, value := range server.Env {
+				clone.Env[key] = value
+			}
+		}
+		out[name] = clone
+	}
+	return out
+}
+
+func loadManagedState(path string) ([]string, error) {
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return []string{}, nil
+		}
+		return nil, fmt.Errorf("read managed state %q: %w", path, err)
+	}
+
+	state := managedState{}
+	if err := json.Unmarshal(payload, &state); err != nil {
+		return nil, fmt.Errorf("parse managed state JSON: %w", err)
+	}
+
+	seen := map[string]struct{}{}
+	unique := make([]string, 0, len(state.ManagedServers))
+	for _, name := range state.ManagedServers {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if _, exists := seen[name]; exists {
+			continue
+		}
+		seen[name] = struct{}{}
+		unique = append(unique, name)
+	}
+	sort.Strings(unique)
+	return unique, nil
+}
+
+func saveManagedState(path string, names []string) error {
+	sorted := append([]string(nil), names...)
+	sort.Strings(sorted)
+	state := managedState{ManagedServers: sorted}
+
+	payload, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal managed state JSON: %w", err)
+	}
+	payload = append(payload, '\n')
+
+	return writeFileAtomically(path, payload, 0o644)
+}
+
+func mapKeys[K comparable, V any](m map[K]V) []K {
+	keys := make([]K, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func backupFile(path string) (string, error) {
+	source, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer source.Close()
+
+	backupPath := fmt.Sprintf("%s.bak.%s", path, time.Now().Format("20060102-150405"))
+	if err := os.MkdirAll(filepath.Dir(backupPath), 0o755); err != nil {
+		return "", fmt.Errorf("ensure backup directory: %w", err)
+	}
+
+	target, err := os.Create(backupPath)
+	if err != nil {
+		return "", err
+	}
+	if _, err := io.Copy(target, source); err != nil {
+		_ = target.Close()
+		return "", err
+	}
+	if err := target.Close(); err != nil {
+		return "", err
+	}
+	return backupPath, nil
+}
+
+func writeFileAtomically(path string, payload []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("ensure directory %q: %w", dir, err)
+	}
+
+	tmp, err := os.CreateTemp(dir, ".madari-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() {
+		_ = os.Remove(tmpPath)
+	}
+	defer cleanup()
+
+	if _, err := tmp.Write(payload); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	return nil
+}
+
+type managedState struct {
+	ManagedServers []string `json:"managed_servers"`
+}
+
+type serverConfig struct {
+	Command string            `json:"command"`
+	Args    []string          `json:"args,omitempty"`
+	Env     map[string]string `json:"env,omitempty"`
+}
+
+func expandHome(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "~" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve user home: %w", err)
+		}
+		return home, nil
+	}
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve user home: %w", err)
+		}
+		return filepath.Join(home, path[2:]), nil
+	}
+	return path, nil
+}

--- a/internal/clients/claudecode/sync_test.go
+++ b/internal/clients/claudecode/sync_test.go
@@ -1,0 +1,231 @@
+package claudecode
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+func TestSyncDryRunDoesNotMutateFiles(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".mcp.json")
+	statePath := filepath.Join(tmp, "state", "claude-code-managed.json")
+
+	original := []byte(`{
+  "mcpServers": {
+    "weather": {
+      "command": "uv",
+      "args": ["run", "weather.py"]
+    }
+  },
+  "preferences": {
+    "sidebarMode": "chat"
+  }
+}
+`)
+	if err := os.WriteFile(configPath, original, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	manifests := []registry.Manifest{newStewreadsManifest()}
+	result, err := Sync(manifests, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+		DryRun:     true,
+	})
+	if err != nil {
+		t.Fatalf("sync dry-run failed: %v", err)
+	}
+
+	if len(result.Added) != 1 || result.Added[0] != "stewreads" {
+		t.Fatalf("expected stewreads to be planned as added, got: %+v", result)
+	}
+
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config after dry-run: %v", err)
+	}
+	if string(after) != string(original) {
+		t.Fatalf("expected dry-run to keep config unchanged")
+	}
+	if _, err := os.Stat(statePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected no state file write on dry-run, got err=%v", err)
+	}
+}
+
+func TestSyncApplyAddUpdateRemoveLifecycle(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".mcp.json")
+	statePath := filepath.Join(tmp, "state", "claude-code-managed.json")
+
+	baseConfig := []byte(`{
+  "mcpServers": {
+    "weather": {
+      "command": "uv",
+      "args": ["run", "weather.py"]
+    }
+  },
+  "preferences": {
+    "sidebarMode": "chat"
+  }
+}
+`)
+	if err := os.WriteFile(configPath, baseConfig, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	manifest := newStewreadsManifest()
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("initial sync failed: %v", err)
+	}
+	if len(result.Added) != 1 || result.Added[0] != "stewreads" {
+		t.Fatalf("expected add result, got: %+v", result)
+	}
+
+	servers := readServers(t, configPath)
+	if _, ok := servers["weather"]; !ok {
+		t.Fatalf("expected existing weather server to be preserved")
+	}
+	if got := servers["stewreads"].Command; got != "stewreads-mcp" {
+		t.Fatalf("expected stewreads command to be synced, got: %q", got)
+	}
+
+	managedNames := readManagedNames(t, statePath)
+	if len(managedNames) != 1 || managedNames[0] != "stewreads" {
+		t.Fatalf("expected managed state to track stewreads, got: %#v", managedNames)
+	}
+
+	result, err = Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("unchanged sync failed: %v", err)
+	}
+	if len(result.Unchanged) != 1 || result.Unchanged[0] != "stewreads" {
+		t.Fatalf("expected unchanged result, got: %+v", result)
+	}
+
+	manifest.Args = []string{"--stdio"}
+	result, err = Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("update sync failed: %v", err)
+	}
+	if len(result.Updated) != 1 || result.Updated[0] != "stewreads" {
+		t.Fatalf("expected update result, got: %+v", result)
+	}
+	servers = readServers(t, configPath)
+	if len(servers["stewreads"].Args) != 1 || servers["stewreads"].Args[0] != "--stdio" {
+		t.Fatalf("expected synced args update, got: %#v", servers["stewreads"].Args)
+	}
+
+	manifest.Enabled = false
+	result, err = Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("remove sync failed: %v", err)
+	}
+	if len(result.Removed) != 1 || result.Removed[0] != "stewreads" {
+		t.Fatalf("expected remove result, got: %+v", result)
+	}
+	servers = readServers(t, configPath)
+	if _, ok := servers["stewreads"]; ok {
+		t.Fatalf("expected stewreads to be removed from Claude config")
+	}
+	if _, ok := servers["weather"]; !ok {
+		t.Fatalf("expected weather to remain after removal")
+	}
+
+	managedNames = readManagedNames(t, statePath)
+	if len(managedNames) != 0 {
+		t.Fatalf("expected managed state to be empty after removal, got: %#v", managedNames)
+	}
+}
+
+func TestSyncRejectsUnmanagedNameCollision(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".mcp.json")
+	statePath := filepath.Join(tmp, "state", "claude-code-managed.json")
+
+	config := []byte(`{
+  "mcpServers": {
+    "stewreads": {
+      "command": "manual-custom-command"
+    }
+  }
+}
+`)
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	_, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+		DryRun:     true,
+	})
+	if err == nil {
+		t.Fatalf("expected sync conflict")
+	}
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected ErrConflict, got: %v", err)
+	}
+}
+
+func readServers(t *testing.T, configPath string) map[string]serverConfig {
+	t.Helper()
+	payload, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	root := map[string]json.RawMessage{}
+	if err := json.Unmarshal(payload, &root); err != nil {
+		t.Fatalf("parse root config: %v", err)
+	}
+	servers := map[string]serverConfig{}
+	if err := json.Unmarshal(root["mcpServers"], &servers); err != nil {
+		t.Fatalf("parse mcpServers: %v", err)
+	}
+	return servers
+}
+
+func readManagedNames(t *testing.T, statePath string) []string {
+	t.Helper()
+	payload, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read managed state: %v", err)
+	}
+	state := managedState{}
+	if err := json.Unmarshal(payload, &state); err != nil {
+		t.Fatalf("parse managed state: %v", err)
+	}
+	sorted := append([]string(nil), state.ManagedServers...)
+	slices.Sort(sorted)
+	return sorted
+}
+
+func newStewreadsManifest() registry.Manifest {
+	return registry.Manifest{
+		Name:    "stewreads",
+		Command: "stewreads-mcp",
+		Enabled: true,
+		Clients: []string{Target},
+		Env: map[string]string{
+			"STEWREADS_CONFIG_PATH": "~/.config/stewreads/config.toml",
+		},
+	}
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/ankitvg/madari/internal/clients/claude"
+	"github.com/ankitvg/madari/internal/clients/claudecode"
 	"github.com/ankitvg/madari/internal/registry"
 )
 
@@ -66,16 +67,18 @@ type Summary struct {
 }
 
 type Report struct {
-	ServersDir     string
-	Servers        []ServerReport
-	ManifestErrors []ManifestError
-	ClaudeConfig   ClaudeConfigReport
-	Summary        Summary
+	ServersDir       string
+	Servers          []ServerReport
+	ManifestErrors   []ManifestError
+	ClaudeConfig     ClaudeConfigReport
+	ClaudeCodeConfig ClaudeConfigReport
+	Summary          Summary
 }
 
 type Options struct {
-	ClaudeConfigPath string
-	EnvLookup        func(string) string
+	ClaudeConfigPath     string
+	ClaudeCodeConfigPath string
+	EnvLookup            func(string) string
 }
 
 func Run(store *registry.Store, opts Options) (Report, error) {
@@ -110,6 +113,16 @@ func Run(store *registry.Store, opts Options) (Report, error) {
 		return report.Servers[i].Name < report.Servers[j].Name
 	})
 
+	if hasTargetInManifests(manifests, claudecode.Target) {
+		claudeCodePath, err := resolveClaudeCodePath(opts.ClaudeCodeConfigPath)
+		if err != nil {
+			return Report{}, err
+		}
+		report.ClaudeCodeConfig = inspectClaudeConfig(claudeCodePath)
+	} else {
+		report.ClaudeCodeConfig = ClaudeConfigReport{Status: StatusSkipped}
+	}
+
 	report.Summary = summarize(report)
 	return report, nil
 }
@@ -135,6 +148,11 @@ func summarize(report Report) Summary {
 	} else if report.ClaudeConfig.Status == StatusWarning {
 		summary.Warning++
 	}
+	if report.ClaudeCodeConfig.Status == StatusError {
+		summary.Error++
+	} else if report.ClaudeCodeConfig.Status == StatusWarning {
+		summary.Warning++
+	}
 	return summary
 }
 
@@ -148,7 +166,7 @@ func inspectServer(manifest registry.Manifest, envLookup func(string) string) Se
 		Issues:  []Issue{},
 	}
 
-	if !manifest.Enabled || !hasClaudeTarget(manifest.Clients) {
+	if !manifest.Enabled || !hasSyncTarget(manifest.Clients) {
 		return report
 	}
 
@@ -183,6 +201,17 @@ func resolveClaudePath(path string) (string, error) {
 		return filepath.Clean(resolved), nil
 	}
 	return claude.DefaultDesktopConfigPath()
+}
+
+func resolveClaudeCodePath(path string) (string, error) {
+	if strings.TrimSpace(path) != "" {
+		resolved, err := expandHome(path)
+		if err != nil {
+			return "", err
+		}
+		return filepath.Clean(resolved), nil
+	}
+	return claudecode.DefaultProjectConfigPath()
 }
 
 func inspectClaudeConfig(path string) ClaudeConfigReport {
@@ -275,9 +304,22 @@ func loadManifests(serversDir string) ([]registry.Manifest, []ManifestError, err
 	return manifests, manifestErrors, nil
 }
 
-func hasClaudeTarget(clients []string) bool {
+func hasSyncTarget(clients []string) bool {
+	return hasTargetClient(clients, claude.Target) || hasTargetClient(clients, claudecode.Target)
+}
+
+func hasTargetClient(clients []string, target string) bool {
 	for _, client := range clients {
-		if strings.EqualFold(strings.TrimSpace(client), claude.Target) {
+		if strings.EqualFold(strings.TrimSpace(client), target) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasTargetInManifests(manifests []registry.Manifest, target string) bool {
+	for _, manifest := range manifests {
+		if hasTargetClient(manifest.Clients, target) {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary
- add a new `claude-code` client adapter that syncs managed servers into project `.mcp.json`
- extend `sync` command to support both `claude-desktop` and `claude-code` targets
- update install auto-sync to run for all configured supported clients
- extend doctor/status diagnostics with optional Claude Code config checks
- update docs and add regression tests for the new client path

## Testing
- `go test ./...`
- manual validation with `@modelcontextprotocol/server-memory` and `@modelcontextprotocol/server-github` via `madari` + `claude mcp get`
