### PR TITLE
Wire Claude Desktop through ClientAdapter

### DIFF
--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -12,7 +12,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/ankitvg/madari/internal/clients/claude"
+	"github.com/ankitvg/madari/internal/clients"
+	claudedesktop "github.com/ankitvg/madari/internal/clients/claude-desktop"
 	"github.com/ankitvg/madari/internal/clients/claudecode"
 	"github.com/ankitvg/madari/internal/doctor"
 	"github.com/ankitvg/madari/internal/registry"
@@ -21,7 +22,7 @@ import (
 const version = "0.0.0-dev"
 
 var supportedSyncTargets = []string{
-	claude.Target,
+	claudedesktop.Target,
 	claudecode.Target,
 }
 
@@ -185,7 +186,7 @@ func (a cliApp) cmdInstall(args []string) error {
 	}
 
 	if len(clients) == 0 {
-		clients = append(clients, claude.Target)
+		clients = append(clients, claudedesktop.Target)
 	}
 
 	if !skipInstall {
@@ -471,8 +472,8 @@ func (a cliApp) cmdSync(args []string) error {
 
 	statePath := filepath.Join(filepath.Dir(a.store.ServersDir()), "state", target+"-managed.json")
 	switch target {
-	case claude.Target:
-		result, err := claude.Sync(syncable, claude.SyncOptions{
+	case claudedesktop.Target:
+		result, err := claudedesktop.Adapter{}.Sync(syncable, clients.SyncOptions{
 			ConfigPath: configPath,
 			StatePath:  statePath,
 			DryRun:     dryRun,

--- a/internal/clients/claude-desktop/adapter.go
+++ b/internal/clients/claude-desktop/adapter.go
@@ -1,0 +1,23 @@
+package claudedesktop
+
+import (
+	"github.com/ankitvg/madari/internal/clients"
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+// Adapter implements clients.ClientAdapter for Claude Desktop.
+type Adapter struct{}
+
+var _ clients.ClientAdapter = Adapter{}
+
+func (Adapter) Target() string {
+	return Target
+}
+
+func (Adapter) DefaultConfigPath() (string, error) {
+	return DefaultDesktopConfigPath()
+}
+
+func (Adapter) Sync(manifests []registry.Manifest, opts clients.SyncOptions) (clients.SyncResult, error) {
+	return Sync(manifests, opts)
+}

--- a/internal/clients/claude-desktop/sync.go
+++ b/internal/clients/claude-desktop/sync.go
@@ -1,4 +1,4 @@
-package claude
+package claudedesktop
 
 import (
 	"encoding/json"
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ankitvg/madari/internal/clients"
 	"github.com/ankitvg/madari/internal/registry"
 )
 
@@ -19,29 +20,13 @@ const (
 	Target = "claude-desktop"
 )
 
-var ErrConflict = errors.New("sync conflict with unmanaged server")
+var ErrConflict = clients.ErrConflict
 
 // SyncOptions configures sync behavior.
-type SyncOptions struct {
-	ConfigPath string
-	StatePath  string
-	DryRun     bool
-}
+type SyncOptions = clients.SyncOptions
 
 // SyncResult captures the computed or applied mutation plan.
-type SyncResult struct {
-	ConfigPath string
-	DryRun     bool
-	Added      []string
-	Updated    []string
-	Removed    []string
-	Unchanged  []string
-}
-
-// HasChanges reports whether sync produces any mutation.
-func (r SyncResult) HasChanges() bool {
-	return len(r.Added)+len(r.Updated)+len(r.Removed) > 0
-}
+type SyncResult = clients.SyncResult
 
 // Sync synchronizes enabled Claude-targeted manifests into the Claude Desktop config file.
 func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {

--- a/internal/clients/claude-desktop/sync_test.go
+++ b/internal/clients/claude-desktop/sync_test.go
@@ -1,4 +1,4 @@
-package claude
+package claudedesktop
 
 import (
 	"encoding/json"
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/ankitvg/madari/internal/clients"
 	"github.com/ankitvg/madari/internal/registry"
 )
 
@@ -183,6 +184,9 @@ func TestSyncRejectsUnmanagedNameCollision(t *testing.T) {
 	}
 	if !errors.Is(err, ErrConflict) {
 		t.Fatalf("expected ErrConflict, got: %v", err)
+	}
+	if !errors.Is(err, clients.ErrConflict) {
+		t.Fatalf("expected clients.ErrConflict compatibility, got: %v", err)
 	}
 }
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/ankitvg/madari/internal/clients/claude"
+	claudedesktop "github.com/ankitvg/madari/internal/clients/claude-desktop"
 	"github.com/ankitvg/madari/internal/clients/claudecode"
 	"github.com/ankitvg/madari/internal/registry"
 )
@@ -200,7 +200,7 @@ func resolveClaudePath(path string) (string, error) {
 		}
 		return filepath.Clean(resolved), nil
 	}
-	return claude.DefaultDesktopConfigPath()
+	return claudedesktop.DefaultDesktopConfigPath()
 }
 
 func resolveClaudeCodePath(path string) (string, error) {
@@ -305,7 +305,7 @@ func loadManifests(serversDir string) ([]registry.Manifest, []ManifestError, err
 }
 
 func hasSyncTarget(clients []string) bool {
-	return hasTargetClient(clients, claude.Target) || hasTargetClient(clients, claudecode.Target)
+	return hasTargetClient(clients, claudedesktop.Target) || hasTargetClient(clients, claudecode.Target)
 }
 
 func hasTargetClient(clients []string, target string) bool {


### PR DESCRIPTION
## Summary
- wire `madari sync claude-desktop` through the new `ClientAdapter` path
- add `internal/clients/claude-desktop/adapter.go` implementing `clients.ClientAdapter`
- move Claude Desktop client package directory to `internal/clients/claude-desktop`
- rename package identifier to `claudedesktop` for Go naming clarity
- align Claude Desktop sync types/sentinel to shared `clients` contract (`SyncOptions`, `SyncResult`, `ErrConflict`)

## Scope
- only Claude Desktop is wired through adapter in this PR
- Claude Code remains on the existing direct sync path

## Validation
- `go test ./...`