### PR TITLE
Wire Claude Code through ClientAdapter and unify sync dispatch

### DIFF
--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -21,9 +21,18 @@ import (
 
 const version = "0.0.0-dev"
 
-var supportedSyncTargets = []string{
-	claudedesktop.Target,
-	claudecode.Target,
+var syncAdapters = map[string]clients.ClientAdapter{
+	claudedesktop.Target: claudedesktop.Adapter{},
+	claudecode.Target:    claudecode.Adapter{},
+}
+
+func supportedSyncTargets() []string {
+	targets := make([]string, 0, len(syncAdapters))
+	for target := range syncAdapters {
+		targets = append(targets, target)
+	}
+	sort.Strings(targets)
+	return targets
 }
 
 func run(args []string, stdout, stderr io.Writer) int {
@@ -460,8 +469,9 @@ func (a cliApp) cmdSync(args []string) error {
 	if fs.NArg() != 0 {
 		return fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " "))
 	}
-	if !isSupportedSyncTarget(target) {
-		return fmt.Errorf("unsupported sync target %q (supported: %s)", target, strings.Join(supportedSyncTargets, ", "))
+	adapter, ok := syncAdapters[target]
+	if !ok {
+		return fmt.Errorf("unsupported sync target %q (supported: %s)", target, strings.Join(supportedSyncTargets(), ", "))
 	}
 
 	manifests, err := a.store.List()
@@ -471,32 +481,16 @@ func (a cliApp) cmdSync(args []string) error {
 	syncable, skipped := filterSyncableManifests(manifests, target)
 
 	statePath := filepath.Join(filepath.Dir(a.store.ServersDir()), "state", target+"-managed.json")
-	switch target {
-	case claudedesktop.Target:
-		result, err := claudedesktop.Adapter{}.Sync(syncable, clients.SyncOptions{
-			ConfigPath: configPath,
-			StatePath:  statePath,
-			DryRun:     dryRun,
-		})
-		if err != nil {
-			return err
-		}
-		printSyncSummary(a.stdout, a.stderr, target, result.ConfigPath, result.DryRun, result.Added, result.Updated, result.Removed, result.Unchanged, skipped)
-		return nil
-	case claudecode.Target:
-		result, err := claudecode.Sync(syncable, claudecode.SyncOptions{
-			ConfigPath: configPath,
-			StatePath:  statePath,
-			DryRun:     dryRun,
-		})
-		if err != nil {
-			return err
-		}
-		printSyncSummary(a.stdout, a.stderr, target, result.ConfigPath, result.DryRun, result.Added, result.Updated, result.Removed, result.Unchanged, skipped)
-		return nil
-	default:
-		return fmt.Errorf("unsupported sync target %q (supported: %s)", target, strings.Join(supportedSyncTargets, ", "))
+	result, err := adapter.Sync(syncable, clients.SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+		DryRun:     dryRun,
+	})
+	if err != nil {
+		return err
 	}
+	printSyncSummary(a.stdout, a.stderr, target, result.ConfigPath, result.DryRun, result.Added, result.Updated, result.Removed, result.Unchanged, skipped)
+	return nil
 }
 
 func (a cliApp) cmdDoctor(args []string) error {
@@ -802,22 +796,14 @@ func hasClientTarget(clients []string, target string) bool {
 }
 
 func syncTargetsForClients(clients []string) []string {
-	targets := make([]string, 0, len(supportedSyncTargets))
-	for _, target := range supportedSyncTargets {
+	supported := supportedSyncTargets()
+	targets := make([]string, 0, len(supported))
+	for _, target := range supported {
 		if hasClientTarget(clients, target) {
 			targets = append(targets, target)
 		}
 	}
 	return targets
-}
-
-func isSupportedSyncTarget(target string) bool {
-	for _, supported := range supportedSyncTargets {
-		if target == supported {
-			return true
-		}
-	}
-	return false
 }
 
 func resolveCommandPath(command string) (string, error) {
@@ -1104,7 +1090,7 @@ func printSyncHelp(out io.Writer) {
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Description:")
 	fmt.Fprintln(out, "  Sync enabled servers from Madari registry into a target client config.")
-	fmt.Fprintln(out, "  Supported clients: claude-desktop, claude-code.")
+	fmt.Fprintf(out, "  Supported clients: %s.\n", strings.Join(supportedSyncTargets(), ", "))
 }
 
 func printDoctorHelp(out io.Writer) {

--- a/internal/clients/claudecode/adapter.go
+++ b/internal/clients/claudecode/adapter.go
@@ -1,0 +1,23 @@
+package claudecode
+
+import (
+	"github.com/ankitvg/madari/internal/clients"
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+// Adapter implements clients.ClientAdapter for Claude Code.
+type Adapter struct{}
+
+var _ clients.ClientAdapter = Adapter{}
+
+func (Adapter) Target() string {
+	return Target
+}
+
+func (Adapter) DefaultConfigPath() (string, error) {
+	return DefaultProjectConfigPath()
+}
+
+func (Adapter) Sync(manifests []registry.Manifest, opts clients.SyncOptions) (clients.SyncResult, error) {
+	return Sync(manifests, opts)
+}

--- a/internal/clients/claudecode/sync.go
+++ b/internal/clients/claudecode/sync.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ankitvg/madari/internal/clients"
 	"github.com/ankitvg/madari/internal/registry"
 )
 
@@ -18,29 +19,13 @@ const (
 	Target = "claude-code"
 )
 
-var ErrConflict = errors.New("sync conflict with unmanaged server")
+var ErrConflict = clients.ErrConflict
 
 // SyncOptions configures sync behavior.
-type SyncOptions struct {
-	ConfigPath string
-	StatePath  string
-	DryRun     bool
-}
+type SyncOptions = clients.SyncOptions
 
 // SyncResult captures the computed or applied mutation plan.
-type SyncResult struct {
-	ConfigPath string
-	DryRun     bool
-	Added      []string
-	Updated    []string
-	Removed    []string
-	Unchanged  []string
-}
-
-// HasChanges reports whether sync produces any mutation.
-func (r SyncResult) HasChanges() bool {
-	return len(r.Added)+len(r.Updated)+len(r.Removed) > 0
-}
+type SyncResult = clients.SyncResult
 
 // Sync synchronizes enabled Claude Code-targeted manifests into the Claude Code config file.
 func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {

--- a/internal/clients/claudecode/sync_test.go
+++ b/internal/clients/claudecode/sync_test.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/ankitvg/madari/internal/clients"
 	"github.com/ankitvg/madari/internal/registry"
 )
 
@@ -183,6 +184,9 @@ func TestSyncRejectsUnmanagedNameCollision(t *testing.T) {
 	}
 	if !errors.Is(err, ErrConflict) {
 		t.Fatalf("expected ErrConflict, got: %v", err)
+	}
+	if !errors.Is(err, clients.ErrConflict) {
+		t.Fatalf("expected clients.ErrConflict compatibility, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `internal/clients/claudecode/adapter.go` implementing `clients.ClientAdapter`
- migrate Claude Code sync contract to shared client types (`clients.SyncOptions`, `clients.SyncResult`)
- use canonical conflict sentinel (`clients.ErrConflict`) for Claude Code sync
- assert `errors.Is(err, clients.ErrConflict)` in Claude Code sync tests
- unify `cmd sync` dispatch to use adapter map for all supported clients (desktop + code)
- remove stale per-client switch path and derive supported sync targets from `syncAdapters`

## Scope
- completes migration of currently supported clients to adapter-based sync dispatch
- does not introduce new clients

## Validation
- `go test ./...`