### PR TITLE
make doctor adapter-driven, drop hardcoded client coupling

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ go install github.com/ankitvg/madari/cmd/madari@latest
 - `madari enable <name>`
 - `madari disable <name>`
 - `madari sync <client> [--dry-run] [--config-path <path>]`
-- `madari doctor [--config-path <path>] [--claude-code-config-path <path>]`
-- `madari status [--config-path <path>] [--claude-code-config-path <path>]`
+- `madari doctor [--client-config target=path ...]`
+- `madari status [--client-config target=path ...]`
 - `madari export [--file <path>]`
 - `madari import --file <path> [--apply]`
 

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -501,10 +501,8 @@ func (a cliApp) cmdDoctor(args []string) error {
 
 	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	var configPath string
-	var claudeCodeConfigPath string
-	fs.StringVar(&configPath, "config-path", "", "Override Claude Desktop config path")
-	fs.StringVar(&claudeCodeConfigPath, "claude-code-config-path", "", "Override Claude Code config path")
+	var clientConfigs stringList
+	fs.Var(&clientConfigs, "client-config", "Override config path for a client: target=path (repeatable)")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			printDoctorHelp(a.stdout)
@@ -516,23 +514,28 @@ func (a cliApp) cmdDoctor(args []string) error {
 		return fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " "))
 	}
 
+	configPathOverrides, err := parseClientConfigOverrides(clientConfigs)
+	if err != nil {
+		return err
+	}
+
+	adapters := sortedAdapters()
 	report, err := doctor.Run(a.store, doctor.Options{
-		ClaudeConfigPath:     configPath,
-		ClaudeCodeConfigPath: claudeCodeConfigPath,
+		Adapters:            adapters,
+		ConfigPathOverrides: configPathOverrides,
 	})
 	if err != nil {
 		return err
 	}
 
 	fmt.Fprintf(a.stdout, "servers directory: %s\n", report.ServersDir)
-	fmt.Fprintf(a.stdout, "claude config: %s [%s]\n", report.ClaudeConfig.Path, report.ClaudeConfig.Status)
-	if report.ClaudeConfig.Message != "" {
-		fmt.Fprintf(a.stdout, "claude detail: %s\n", report.ClaudeConfig.Message)
-	}
-	if report.ClaudeCodeConfig.Status != "" && report.ClaudeCodeConfig.Status != doctor.StatusSkipped {
-		fmt.Fprintf(a.stdout, "claude-code config: %s [%s]\n", report.ClaudeCodeConfig.Path, report.ClaudeCodeConfig.Status)
-		if report.ClaudeCodeConfig.Message != "" {
-			fmt.Fprintf(a.stdout, "claude-code detail: %s\n", report.ClaudeCodeConfig.Message)
+	for _, cc := range report.ClientConfigs {
+		if cc.Status == doctor.StatusSkipped {
+			continue
+		}
+		fmt.Fprintf(a.stdout, "%s config: %s [%s]\n", cc.Target, cc.Path, cc.Status)
+		if cc.Message != "" {
+			fmt.Fprintf(a.stdout, "%s detail: %s\n", cc.Target, cc.Message)
 		}
 	}
 
@@ -587,10 +590,8 @@ func (a cliApp) cmdStatus(args []string) error {
 
 	fs := flag.NewFlagSet("status", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	var configPath string
-	var claudeCodeConfigPath string
-	fs.StringVar(&configPath, "config-path", "", "Override Claude Desktop config path")
-	fs.StringVar(&claudeCodeConfigPath, "claude-code-config-path", "", "Override Claude Code config path")
+	var clientConfigs stringList
+	fs.Var(&clientConfigs, "client-config", "Override config path for a client: target=path (repeatable)")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			printStatusHelp(a.stdout)
@@ -602,9 +603,15 @@ func (a cliApp) cmdStatus(args []string) error {
 		return fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " "))
 	}
 
+	configPathOverrides, err := parseClientConfigOverrides(clientConfigs)
+	if err != nil {
+		return err
+	}
+
+	adapters := sortedAdapters()
 	report, err := doctor.Run(a.store, doctor.Options{
-		ClaudeConfigPath:     configPath,
-		ClaudeCodeConfigPath: claudeCodeConfigPath,
+		Adapters:            adapters,
+		ConfigPathOverrides: configPathOverrides,
 	})
 	if err != nil {
 		return err
@@ -619,9 +626,10 @@ func (a cliApp) cmdStatus(args []string) error {
 		report.Summary.Error,
 		report.Summary.Skipped,
 	)
-	fmt.Fprintf(a.stdout, "claude-config: %s\n", report.ClaudeConfig.Status)
-	if report.ClaudeCodeConfig.Status != "" && report.ClaudeCodeConfig.Status != doctor.StatusSkipped {
-		fmt.Fprintf(a.stdout, "claude-code-config: %s\n", report.ClaudeCodeConfig.Status)
+	for _, cc := range report.ClientConfigs {
+		if cc.Status != doctor.StatusSkipped {
+			fmt.Fprintf(a.stdout, "%s-config: %s\n", cc.Target, cc.Status)
+		}
 	}
 	if len(report.ManifestErrors) > 0 {
 		fmt.Fprintf(a.stdout, "manifest-errors: %d\n", len(report.ManifestErrors))
@@ -751,6 +759,34 @@ func (s *stringList) String() string {
 func (s *stringList) Set(value string) error {
 	*s = append(*s, value)
 	return nil
+}
+
+func sortedAdapters() []clients.ClientAdapter {
+	targets := supportedSyncTargets()
+	adapters := make([]clients.ClientAdapter, 0, len(targets))
+	for _, t := range targets {
+		adapters = append(adapters, syncAdapters[t])
+	}
+	return adapters
+}
+
+func parseClientConfigOverrides(pairs []string) (map[string]string, error) {
+	overrides := map[string]string{}
+	for _, pair := range pairs {
+		target, path, ok := strings.Cut(pair, "=")
+		target = strings.TrimSpace(target)
+		if !ok || target == "" {
+			return nil, fmt.Errorf("invalid client config override %q, expected target=path", pair)
+		}
+		if _, known := syncAdapters[target]; !known {
+			return nil, fmt.Errorf("unknown client config target %q (supported: %s)", target, strings.Join(supportedSyncTargets(), ", "))
+		}
+		if _, exists := overrides[target]; exists {
+			return nil, fmt.Errorf("duplicate client config override for target %q", target)
+		}
+		overrides[target] = path
+	}
+	return overrides, nil
 }
 
 func parseEnvPairs(pairs []string) (map[string]string, error) {
@@ -1095,23 +1131,26 @@ func printSyncHelp(out io.Writer) {
 
 func printDoctorHelp(out io.Writer) {
 	fmt.Fprintln(out, "Usage:")
-	fmt.Fprintln(out, "  madari doctor [--config-path <path>] [--claude-code-config-path <path>]")
+	fmt.Fprintln(out, "  madari doctor [--client-config target=path ...]")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Options:")
-	fmt.Fprintln(out, "  --config-path <path>                Override Claude Desktop config path for diagnostics")
-	fmt.Fprintln(out, "  --claude-code-config-path <path>    Override Claude Code config path for diagnostics")
+	fmt.Fprintln(out, "  --client-config target=path    Override config path for a client (repeatable)")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Description:")
 	fmt.Fprintln(out, "  Validate server manifests, command paths, required env keys, and client config health.")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Examples:")
+	fmt.Fprintln(out, "  madari doctor")
+	fmt.Fprintln(out, "  madari doctor --client-config claude-desktop=/tmp/test.json")
+	fmt.Fprintln(out, "  madari doctor --client-config claude-desktop=/p1 --client-config claude-code=/p2")
 }
 
 func printStatusHelp(out io.Writer) {
 	fmt.Fprintln(out, "Usage:")
-	fmt.Fprintln(out, "  madari status [--config-path <path>] [--claude-code-config-path <path>]")
+	fmt.Fprintln(out, "  madari status [--client-config target=path ...]")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Options:")
-	fmt.Fprintln(out, "  --config-path <path>                Override Claude Desktop config path for status checks")
-	fmt.Fprintln(out, "  --claude-code-config-path <path>    Override Claude Code config path for status checks")
+	fmt.Fprintln(out, "  --client-config target=path    Override config path for a client (repeatable)")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Description:")
 	fmt.Fprintln(out, "  Show a concise readiness summary. Use `madari doctor` for full details.")

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -981,7 +981,7 @@ func TestRunWithStoreDoctorHealthy(t *testing.T) {
 		t.Fatalf("write config fixture: %v", err)
 	}
 
-	result := runCmd(store, "doctor", "--config-path", configPath)
+	result := runCmd(store, "doctor", "--client-config", "claude-desktop="+configPath)
 	if result.code != 0 {
 		t.Fatalf("doctor expected success, got code=%d stderr=%s stdout=%s", result.code, result.stderr, result.stdout)
 	}
@@ -1003,7 +1003,7 @@ func TestRunWithStoreDoctorReturnsErrorForInvalidConfig(t *testing.T) {
 		t.Fatalf("write invalid config fixture: %v", err)
 	}
 
-	result := runCmd(store, "doctor", "--config-path", configPath)
+	result := runCmd(store, "doctor", "--client-config", "claude-desktop="+configPath)
 	if result.code == 0 {
 		t.Fatalf("doctor expected failure for invalid config")
 	}
@@ -1020,10 +1020,6 @@ func TestRunWithStoreDoctorReturnsErrorForInvalidClaudeCodeConfig(t *testing.T) 
 		t.Fatalf("setup add failed: %s", result.stderr)
 	}
 
-	desktopConfigPath := filepath.Join(t.TempDir(), "claude_desktop_config.json")
-	if err := os.WriteFile(desktopConfigPath, []byte(`{"mcpServers":{}}`), 0o644); err != nil {
-		t.Fatalf("write desktop config fixture: %v", err)
-	}
 	claudeCodeConfigPath := filepath.Join(t.TempDir(), ".mcp.json")
 	if err := os.WriteFile(claudeCodeConfigPath, []byte("{broken"), 0o644); err != nil {
 		t.Fatalf("write invalid Claude Code config fixture: %v", err)
@@ -1032,8 +1028,7 @@ func TestRunWithStoreDoctorReturnsErrorForInvalidClaudeCodeConfig(t *testing.T) 
 	result := runCmd(
 		store,
 		"doctor",
-		"--config-path", desktopConfigPath,
-		"--claude-code-config-path", claudeCodeConfigPath,
+		"--client-config", "claude-code="+claudeCodeConfigPath,
 	)
 	if result.code == 0 {
 		t.Fatalf("doctor expected failure for invalid Claude Code config")
@@ -1059,7 +1054,7 @@ func TestRunWithStoreStatusHealthy(t *testing.T) {
 		t.Fatalf("write config fixture: %v", err)
 	}
 
-	result := runCmd(store, "status", "--config-path", configPath)
+	result := runCmd(store, "status", "--client-config", "claude-desktop="+configPath)
 	if result.code != 0 {
 		t.Fatalf("status expected success, got code=%d stderr=%s stdout=%s", result.code, result.stderr, result.stdout)
 	}
@@ -1084,7 +1079,7 @@ func TestRunWithStoreStatusReturnsErrorForInvalidConfig(t *testing.T) {
 		t.Fatalf("write invalid config fixture: %v", err)
 	}
 
-	result := runCmd(store, "status", "--config-path", configPath)
+	result := runCmd(store, "status", "--client-config", "claude-desktop="+configPath)
 	if result.code == 0 {
 		t.Fatalf("status expected failure for invalid config")
 	}
@@ -1101,10 +1096,6 @@ func TestRunWithStoreStatusShowsClaudeCodeConfigWhenTargetPresent(t *testing.T) 
 		t.Fatalf("setup add failed: %s", result.stderr)
 	}
 
-	desktopConfigPath := filepath.Join(t.TempDir(), "claude_desktop_config.json")
-	if err := os.WriteFile(desktopConfigPath, []byte(`{"mcpServers":{}}`), 0o644); err != nil {
-		t.Fatalf("write desktop config fixture: %v", err)
-	}
 	claudeCodeConfigPath := filepath.Join(t.TempDir(), ".mcp.json")
 	if err := os.WriteFile(claudeCodeConfigPath, []byte(`{"mcpServers":{}}`), 0o644); err != nil {
 		t.Fatalf("write Claude Code config fixture: %v", err)
@@ -1113,8 +1104,7 @@ func TestRunWithStoreStatusShowsClaudeCodeConfigWhenTargetPresent(t *testing.T) 
 	result := runCmd(
 		store,
 		"status",
-		"--config-path", desktopConfigPath,
-		"--claude-code-config-path", claudeCodeConfigPath,
+		"--client-config", "claude-code="+claudeCodeConfigPath,
 	)
 	if result.code != 0 {
 		t.Fatalf("status expected success, got code=%d stderr=%s stdout=%s", result.code, result.stderr, result.stdout)

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -10,8 +10,7 @@ import (
 	"sort"
 	"strings"
 
-	claudedesktop "github.com/ankitvg/madari/internal/clients/claude-desktop"
-	"github.com/ankitvg/madari/internal/clients/claudecode"
+	"github.com/ankitvg/madari/internal/clients"
 	"github.com/ankitvg/madari/internal/registry"
 )
 
@@ -51,7 +50,8 @@ type ManifestError struct {
 	Message string
 }
 
-type ClaudeConfigReport struct {
+type ClientConfigReport struct {
+	Target  string
 	Path    string
 	Exists  bool
 	Status  Status
@@ -67,18 +67,17 @@ type Summary struct {
 }
 
 type Report struct {
-	ServersDir       string
-	Servers          []ServerReport
-	ManifestErrors   []ManifestError
-	ClaudeConfig     ClaudeConfigReport
-	ClaudeCodeConfig ClaudeConfigReport
-	Summary          Summary
+	ServersDir     string
+	Servers        []ServerReport
+	ManifestErrors []ManifestError
+	ClientConfigs  []ClientConfigReport
+	Summary        Summary
 }
 
 type Options struct {
-	ClaudeConfigPath     string
-	ClaudeCodeConfigPath string
-	EnvLookup            func(string) string
+	Adapters            []clients.ClientAdapter
+	ConfigPathOverrides map[string]string // keyed by Target(), e.g. {"claude-desktop": "/custom/path"}
+	EnvLookup           func(string) string
 }
 
 func Run(store *registry.Store, opts Options) (Report, error) {
@@ -91,13 +90,7 @@ func Run(store *registry.Store, opts Options) (Report, error) {
 		envLookup = os.Getenv
 	}
 
-	claudePath, err := resolveClaudePath(opts.ClaudeConfigPath)
-	if err != nil {
-		return Report{}, err
-	}
-
 	report := Report{ServersDir: store.ServersDir()}
-	report.ClaudeConfig = inspectClaudeConfig(claudePath)
 
 	manifests, manifestErrors, err := loadManifests(store.ServersDir())
 	if err != nil {
@@ -107,20 +100,28 @@ func Run(store *registry.Store, opts Options) (Report, error) {
 
 	report.Servers = make([]ServerReport, 0, len(manifests))
 	for _, manifest := range manifests {
-		report.Servers = append(report.Servers, inspectServer(manifest, envLookup))
+		report.Servers = append(report.Servers, inspectServer(manifest, envLookup, opts.Adapters))
 	}
 	sort.Slice(report.Servers, func(i, j int) bool {
 		return report.Servers[i].Name < report.Servers[j].Name
 	})
 
-	if hasTargetInManifests(manifests, claudecode.Target) {
-		claudeCodePath, err := resolveClaudeCodePath(opts.ClaudeCodeConfigPath)
+	report.ClientConfigs = make([]ClientConfigReport, 0, len(opts.Adapters))
+	for _, adapter := range opts.Adapters {
+		if !hasTargetInManifests(manifests, adapter.Target()) {
+			report.ClientConfigs = append(report.ClientConfigs, ClientConfigReport{
+				Target: adapter.Target(),
+				Status: StatusSkipped,
+			})
+			continue
+		}
+		configPath, err := resolveAdapterConfigPath(adapter, opts.ConfigPathOverrides)
 		if err != nil {
 			return Report{}, err
 		}
-		report.ClaudeCodeConfig = inspectClaudeConfig(claudeCodePath)
-	} else {
-		report.ClaudeCodeConfig = ClaudeConfigReport{Status: StatusSkipped}
+		cr := inspectClientConfig(configPath)
+		cr.Target = adapter.Target()
+		report.ClientConfigs = append(report.ClientConfigs, cr)
 	}
 
 	report.Summary = summarize(report)
@@ -143,20 +144,17 @@ func summarize(report Report) Summary {
 	}
 
 	summary.Error += len(report.ManifestErrors)
-	if report.ClaudeConfig.Status == StatusError {
-		summary.Error++
-	} else if report.ClaudeConfig.Status == StatusWarning {
-		summary.Warning++
-	}
-	if report.ClaudeCodeConfig.Status == StatusError {
-		summary.Error++
-	} else if report.ClaudeCodeConfig.Status == StatusWarning {
-		summary.Warning++
+	for _, cc := range report.ClientConfigs {
+		if cc.Status == StatusError {
+			summary.Error++
+		} else if cc.Status == StatusWarning {
+			summary.Warning++
+		}
 	}
 	return summary
 }
 
-func inspectServer(manifest registry.Manifest, envLookup func(string) string) ServerReport {
+func inspectServer(manifest registry.Manifest, envLookup func(string) string, adapters []clients.ClientAdapter) ServerReport {
 	report := ServerReport{
 		Name:    manifest.Name,
 		Enabled: manifest.Enabled,
@@ -166,7 +164,7 @@ func inspectServer(manifest registry.Manifest, envLookup func(string) string) Se
 		Issues:  []Issue{},
 	}
 
-	if !manifest.Enabled || !hasSyncTarget(manifest.Clients) {
+	if !manifest.Enabled || !hasSyncTarget(manifest.Clients, adapters) {
 		return report
 	}
 
@@ -192,30 +190,19 @@ func inspectServer(manifest registry.Manifest, envLookup func(string) string) Se
 	return report
 }
 
-func resolveClaudePath(path string) (string, error) {
-	if strings.TrimSpace(path) != "" {
-		resolved, err := expandHome(path)
+func resolveAdapterConfigPath(adapter clients.ClientAdapter, overrides map[string]string) (string, error) {
+	if override := overrides[adapter.Target()]; strings.TrimSpace(override) != "" {
+		resolved, err := expandHome(override)
 		if err != nil {
 			return "", err
 		}
 		return filepath.Clean(resolved), nil
 	}
-	return claudedesktop.DefaultDesktopConfigPath()
+	return adapter.DefaultConfigPath()
 }
 
-func resolveClaudeCodePath(path string) (string, error) {
-	if strings.TrimSpace(path) != "" {
-		resolved, err := expandHome(path)
-		if err != nil {
-			return "", err
-		}
-		return filepath.Clean(resolved), nil
-	}
-	return claudecode.DefaultProjectConfigPath()
-}
-
-func inspectClaudeConfig(path string) ClaudeConfigReport {
-	report := ClaudeConfigReport{Path: path}
+func inspectClientConfig(path string) ClientConfigReport {
+	report := ClientConfigReport{Path: path}
 	payload, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -304,8 +291,13 @@ func loadManifests(serversDir string) ([]registry.Manifest, []ManifestError, err
 	return manifests, manifestErrors, nil
 }
 
-func hasSyncTarget(clients []string) bool {
-	return hasTargetClient(clients, claudedesktop.Target) || hasTargetClient(clients, claudecode.Target)
+func hasSyncTarget(clientIDs []string, adapters []clients.ClientAdapter) bool {
+	for _, adapter := range adapters {
+		if hasTargetClient(clientIDs, adapter.Target()) {
+			return true
+		}
+	}
+	return false
 }
 
 func hasTargetClient(clients []string, target string) bool {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -6,8 +6,30 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/ankitvg/madari/internal/clients"
 	"github.com/ankitvg/madari/internal/registry"
 )
+
+// testAdapter is a minimal ClientAdapter for use in doctor tests.
+type testAdapter struct {
+	target     string
+	configPath string
+}
+
+func (a testAdapter) Target() string                    { return a.target }
+func (a testAdapter) DefaultConfigPath() (string, error) { return a.configPath, nil }
+func (a testAdapter) Sync(_ []registry.Manifest, _ clients.SyncOptions) (clients.SyncResult, error) {
+	return clients.SyncResult{}, nil
+}
+
+func findClientConfig(report Report, target string) (ClientConfigReport, bool) {
+	for _, cc := range report.ClientConfigs {
+		if cc.Target == target {
+			return cc, true
+		}
+	}
+	return ClientConfigReport{}, false
+}
 
 func TestRunHealthyServer(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -31,7 +53,8 @@ func TestRunHealthyServer(t *testing.T) {
 		t.Fatalf("write config fixture: %v", err)
 	}
 
-	report, err := Run(store, Options{ClaudeConfigPath: configPath})
+	adapter := testAdapter{target: "claude-desktop", configPath: configPath}
+	report, err := Run(store, Options{Adapters: []clients.ClientAdapter{adapter}})
 	if err != nil {
 		t.Fatalf("doctor run failed: %v", err)
 	}
@@ -42,8 +65,12 @@ func TestRunHealthyServer(t *testing.T) {
 	if len(report.Servers) != 1 || report.Servers[0].Status != StatusReady {
 		t.Fatalf("unexpected server report: %+v", report.Servers)
 	}
-	if report.ClaudeConfig.Status != StatusReady {
-		t.Fatalf("expected ready claude config status, got: %+v", report.ClaudeConfig)
+	cc, ok := findClientConfig(report, "claude-desktop")
+	if !ok {
+		t.Fatalf("expected claude-desktop client config report, got: %+v", report.ClientConfigs)
+	}
+	if cc.Status != StatusReady {
+		t.Fatalf("expected ready claude-desktop config status, got: %+v", cc)
 	}
 }
 
@@ -72,8 +99,9 @@ func TestRunMissingRequiredEnvWarns(t *testing.T) {
 		t.Fatalf("write config fixture: %v", err)
 	}
 
+	adapter := testAdapter{target: "claude-desktop", configPath: configPath}
 	report, err := Run(store, Options{
-		ClaudeConfigPath: configPath,
+		Adapters: []clients.ClientAdapter{adapter},
 		EnvLookup: func(string) string {
 			return ""
 		},
@@ -101,13 +129,19 @@ func TestRunCapturesManifestAndConfigErrors(t *testing.T) {
 	if err := os.WriteFile(badManifestPath, []byte("name = \"broken\"\nunknown = 1\n"), 0o644); err != nil {
 		t.Fatalf("write bad manifest: %v", err)
 	}
+	// A valid manifest targeting the adapter is required so the config inspection runs.
+	validManifestPath := filepath.Join(store.ServersDir(), "ok.toml")
+	if err := os.WriteFile(validManifestPath, []byte("name = \"ok\"\ncommand = \"/nonexistent\"\nenabled = true\nclients = [\"claude-desktop\"]\n"), 0o644); err != nil {
+		t.Fatalf("write valid manifest: %v", err)
+	}
 
 	configPath := filepath.Join(tmp, "claude_desktop_config.json")
 	if err := os.WriteFile(configPath, []byte("{invalid-json"), 0o644); err != nil {
 		t.Fatalf("write invalid config: %v", err)
 	}
 
-	report, err := Run(store, Options{ClaudeConfigPath: configPath})
+	adapter := testAdapter{target: "claude-desktop", configPath: configPath}
+	report, err := Run(store, Options{Adapters: []clients.ClientAdapter{adapter}})
 	if err != nil {
 		t.Fatalf("doctor run failed: %v", err)
 	}
@@ -115,8 +149,12 @@ func TestRunCapturesManifestAndConfigErrors(t *testing.T) {
 	if len(report.ManifestErrors) != 1 {
 		t.Fatalf("expected one manifest error, got: %+v", report.ManifestErrors)
 	}
-	if report.ClaudeConfig.Status != StatusError {
-		t.Fatalf("expected config error status, got: %+v", report.ClaudeConfig)
+	cc, ok := findClientConfig(report, "claude-desktop")
+	if !ok {
+		t.Fatalf("expected claude-desktop client config report, got: %+v", report.ClientConfigs)
+	}
+	if cc.Status != StatusError {
+		t.Fatalf("expected config error status, got: %+v", cc)
 	}
 	if report.Summary.Error < 2 {
 		t.Fatalf("expected at least two errors (manifest + config), got: %+v", report.Summary)


### PR DESCRIPTION
## Summary

- Replaces hardcoded `claude-desktop`/`claude-code` imports in `doctor.go` with a `[]clients.ClientAdapter` slice — doctor now knows nothing about specific clients
- `Options` takes `Adapters` and `ConfigPathOverrides` (keyed by adapter target); the old per-client fields and duplicate resolve functions are gone
- Client config inspection is skipped for adapters whose target appears in no loaded manifest, so users only see diagnostics relevant to clients they're actually using
- Replaces `--config-path` / `--claude-code-config-path` flags on `doctor`/`status` with a repeatable `--client-config target=path` flag; unknown targets are rejected with a clear error

## More details
- Replace hardcoded claude-desktop/claude-code imports in doctor.go with a []clients.ClientAdapter slice. Options now takes Adapters and ConfigPathOverrides (keyed by adapter target); the old per-client fields and resolve functions are gone. Client config inspection is skipped for adapters whose target appears in no loaded manifest, avoiding noise for clients the user isn't actually using.
- The --config-path / --claude-code-config-path flags on doctor/status are replaced by a repeatable --client-config target=path flag; unknown targets are rejected with a clear error. Adding a new adapter to syncAdapters in run.go now automatically appears in doctor output with no changes to doctor.go.

## Impact

Adding a new adapter to `syncAdapters` in `run.go` now automatically appears in `madari doctor` output with zero changes to `doctor.go`.

## Test plan

- [ ] `go build ./...` and `go test ./...` pass
- [ ] `madari doctor` shows per-adapter config lines only for clients used in manifests
- [ ] `madari doctor --client-config claude-desktop=/tmp/test.json` overrides path correctly
- [ ] `madari doctor --client-config claude-destkop=/tmp/x` returns a clear unknown-target error
- [ ] `madari status` output shows `<target>-config: <status>` for active adapters

🤖 Generated with [Claude Code](https://claude.com/claude-code)