### PR TITLE
add madari clients command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ go install github.com/ankitvg/madari/cmd/madari@latest
 - `madari enable <name>`
 - `madari disable <name>`
 - `madari sync <client> [--dry-run] [--config-path <path>]`
+- `madari clients`
 - `madari doctor [--client-config target=path ...]`
 - `madari status [--client-config target=path ...]`
 - `madari export [--file <path>]`

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -106,6 +106,8 @@ func (a cliApp) dispatch(args []string) error {
 		return a.cmdSetEnabled(args[1:], true)
 	case "disable":
 		return a.cmdSetEnabled(args[1:], false)
+	case "clients":
+		return a.cmdClients(args[1:])
 	case "doctor":
 		return a.cmdDoctor(args[1:])
 	case "status":
@@ -490,6 +492,75 @@ func (a cliApp) cmdSync(args []string) error {
 		return err
 	}
 	printSyncSummary(a.stdout, a.stderr, target, result.ConfigPath, result.DryRun, result.Added, result.Updated, result.Removed, result.Unchanged, skipped)
+	return nil
+}
+
+func (a cliApp) cmdClients(args []string) error {
+	if len(args) == 1 && isHelpToken(args[0]) {
+		printClientsHelp(a.stdout)
+		return nil
+	}
+
+	fs := flag.NewFlagSet("clients", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printClientsHelp(a.stdout)
+			return nil
+		}
+		return err
+	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " "))
+	}
+
+	type clientRow struct {
+		target string
+		path   string
+		cr     doctor.ClientConfigReport
+	}
+
+	adapters := sortedAdapters()
+	rows := make([]clientRow, 0, len(adapters))
+	for _, adapter := range adapters {
+		path, err := adapter.DefaultConfigPath()
+		if err != nil {
+			rows = append(rows, clientRow{
+				target: adapter.Target(),
+				cr: doctor.ClientConfigReport{
+					Target:  adapter.Target(),
+					Status:  doctor.StatusError,
+					Message: fmt.Sprintf("resolve default config path: %v", err),
+				},
+			})
+			continue
+		}
+		cr := doctor.InspectConfigPath(path)
+		cr.Target = adapter.Target()
+		rows = append(rows, clientRow{target: adapter.Target(), path: path, cr: cr})
+	}
+
+	statusRank := map[doctor.Status]int{
+		doctor.StatusError:   0,
+		doctor.StatusReady:   1,
+		doctor.StatusWarning: 2,
+		doctor.StatusSkipped: 3,
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		ri, rj := statusRank[rows[i].cr.Status], statusRank[rows[j].cr.Status]
+		if ri != rj {
+			return ri < rj
+		}
+		return rows[i].target < rows[j].target
+	})
+
+	fmt.Fprintln(a.stdout, "CLIENT\tSTATUS\tCONFIG")
+	for _, r := range rows {
+		fmt.Fprintf(a.stdout, "%s\t[%s]\t%s\n", r.target, r.cr.Status, r.path)
+		if r.cr.Message != "" && r.cr.Status != doctor.StatusReady {
+			fmt.Fprintf(a.stdout, "\t\t%s\n", r.cr.Message)
+		}
+	}
 	return nil
 }
 
@@ -1028,6 +1099,8 @@ func printCommandHelp(command string, out io.Writer) bool {
 		printEnableDisableHelp("disable", out)
 	case "sync":
 		printSyncHelp(out)
+	case "clients":
+		printClientsHelp(out)
 	case "doctor":
 		printDoctorHelp(out)
 	case "status":
@@ -1129,6 +1202,15 @@ func printSyncHelp(out io.Writer) {
 	fmt.Fprintf(out, "  Supported clients: %s.\n", strings.Join(supportedSyncTargets(), ", "))
 }
 
+func printClientsHelp(out io.Writer) {
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  madari clients")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Description:")
+	fmt.Fprintln(out, "  List all supported MCP clients with their config path and readiness status.")
+	fmt.Fprintln(out, "  Output is sorted by status: error first, then ready, then warn.")
+}
+
 func printDoctorHelp(out io.Writer) {
 	fmt.Fprintln(out, "Usage:")
 	fmt.Fprintln(out, "  madari doctor [--client-config target=path ...]")
@@ -1191,6 +1273,7 @@ func printHelp(out io.Writer) {
 	fmt.Fprintln(out, "  enable    Enable a server")
 	fmt.Fprintln(out, "  disable   Disable a server")
 	fmt.Fprintln(out, "  sync      Sync server manifests to a client config")
+	fmt.Fprintln(out, "  clients   List supported clients and config readiness")
 	fmt.Fprintln(out, "  doctor    Run diagnostics on local MCP setup")
 	fmt.Fprintln(out, "  status    Show concise readiness summary")
 	fmt.Fprintln(out, "  export    Export registry snapshot")

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -300,6 +300,7 @@ func TestRunWithStoreCommandUsageValidation(t *testing.T) {
 		{name: "sync missing target", args: []string{"sync"}, expected: "usage: madari sync <client>"},
 		{name: "sync unsupported target", args: []string{"sync", "cursor"}, expected: "unsupported sync target"},
 		{name: "sync extra positionals", args: []string{"sync", "claude-desktop", "extra"}, expected: "unexpected positional arguments"},
+		{name: "clients extra positionals", args: []string{"clients", "extra"}, expected: "unexpected positional arguments"},
 		{name: "doctor extra positionals", args: []string{"doctor", "extra"}, expected: "unexpected positional arguments"},
 		{name: "status extra positionals", args: []string{"status", "extra"}, expected: "unexpected positional arguments"},
 		{name: "export extra positionals", args: []string{"export", "extra"}, expected: "unexpected positional arguments"},
@@ -326,6 +327,7 @@ func TestRunHelpSubcommandOutput(t *testing.T) {
 		args     []string
 		contains string
 	}{
+		{name: "help clients", args: []string{"help", "clients"}, contains: "madari clients"},
 		{name: "help install", args: []string{"help", "install"}, contains: "madari install <package>"},
 		{name: "help add", args: []string{"help", "add"}, contains: "madari add <name>"},
 		{name: "help sync", args: []string{"help", "sync"}, contains: "madari sync <client>"},
@@ -388,6 +390,9 @@ func TestRunWithStoreSubcommandHelpFlags(t *testing.T) {
 	}
 	if result := runCmd(store, "disable", "--help"); result.code != 0 || !strings.Contains(result.stdout, "madari disable <name>") {
 		t.Fatalf("expected disable --help to print command help, got code=%d stdout=%s stderr=%s", result.code, result.stdout, result.stderr)
+	}
+	if result := runCmd(store, "clients", "--help"); result.code != 0 || !strings.Contains(result.stdout, "madari clients") {
+		t.Fatalf("expected clients --help to print command help, got code=%d stdout=%s stderr=%s", result.code, result.stdout, result.stderr)
 	}
 	if result := runCmd(store, "doctor", "--help"); result.code != 0 || !strings.Contains(result.stdout, "madari doctor") {
 		t.Fatalf("expected doctor --help to print command help, got code=%d stdout=%s stderr=%s", result.code, result.stdout, result.stderr)
@@ -965,6 +970,63 @@ func TestRunWithStoreImportDryRunAndApply(t *testing.T) {
 	}
 	if _, err := store.Get("beta"); err != nil {
 		t.Fatalf("expected beta after apply: %v", err)
+	}
+}
+
+func TestRunWithStoreClientsListsAllAdapters(t *testing.T) {
+	store := newTestStore(t)
+
+	result := runCmd(store, "clients")
+	if result.code != 0 {
+		t.Fatalf("clients expected success, got code=%d stderr=%s stdout=%s", result.code, result.stderr, result.stdout)
+	}
+	if !strings.Contains(result.stdout, "claude-desktop") {
+		t.Fatalf("expected claude-desktop in clients output, got: %s", result.stdout)
+	}
+	if !strings.Contains(result.stdout, "claude-code") {
+		t.Fatalf("expected claude-code in clients output, got: %s", result.stdout)
+	}
+}
+
+func TestRunWithStoreClientsShowsHeaderAndStatus(t *testing.T) {
+	store := newTestStore(t)
+
+	result := runCmd(store, "clients")
+	if result.code != 0 {
+		t.Fatalf("clients expected success, got code=%d stderr=%s", result.code, result.stderr)
+	}
+	lines := strings.Split(strings.TrimSpace(result.stdout), "\n")
+	if len(lines) < 3 {
+		// header + at least 2 adapter rows
+		t.Fatalf("expected header + adapter rows, got: %s", result.stdout)
+	}
+	if !strings.HasPrefix(lines[0], "CLIENT") {
+		t.Fatalf("expected header row first, got: %s", lines[0])
+	}
+	// Every non-header row must carry a bracketed status token.
+	for _, line := range lines[1:] {
+		if line == "" {
+			continue
+		}
+		// Detail lines (indented) are allowed to not have a status token.
+		if strings.HasPrefix(line, "\t") {
+			continue
+		}
+		if !strings.Contains(line, "[ready]") && !strings.Contains(line, "[warn]") && !strings.Contains(line, "[error]") {
+			t.Fatalf("expected status token in client row, got: %s", line)
+		}
+	}
+}
+
+func TestRunWithStoreClientsRejectsPositionals(t *testing.T) {
+	store := newTestStore(t)
+
+	result := runCmd(store, "clients", "extra")
+	if result.code == 0 {
+		t.Fatalf("expected clients to fail with positional argument")
+	}
+	if !strings.Contains(result.stderr, "unexpected positional arguments") {
+		t.Fatalf("expected positional argument error, got: %s", result.stderr)
 	}
 }
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -201,6 +201,10 @@ func resolveAdapterConfigPath(adapter clients.ClientAdapter, overrides map[strin
 	return adapter.DefaultConfigPath()
 }
 
+func InspectConfigPath(path string) ClientConfigReport {
+	return inspectClientConfig(path)
+}
+
 func inspectClientConfig(path string) ClientConfigReport {
 	report := ClientConfigReport{Path: path}
 	payload, err := os.ReadFile(path)


### PR DESCRIPTION
## Summary

Adds `madari clients` command listing all registered MCP clients with their default config path and readiness status. Closes #8.

- Output sorted error → ready → warn so the most important information surfaces first
- A path-resolution failure for one adapter shows as an error row rather than aborting the whole command
- Exposes `doctor.InspectConfigPath` to avoid duplicating config inspection logic


## More Details
- Lists all registered MCP clients with their default config path and readiness status (error/ready/warn), sorted so errors surface first. 
- Output mirrors the per-adapter inspection already done in doctor, via a new exported doctor.InspectConfigPath helper. 
- Clients are always shown regardless of manifest contents — this is a global view of supported clients, not a per-server diagnostic. 
- A path-resolution failure for one adapter is shown as an error row rather than aborting the whole command.


## Example output

```
CLIENT          STATUS   CONFIG
claude-desktop  [ready]  /Users/you/.../claude_desktop_config.json
claude-code     [warn]   /Users/you/project/.mcp.json
                         config file not found
```

## Test plan

- [ ] `go build ./...` and `go test ./...` pass
- [ ] `madari clients` lists all adapters with status and config path
- [ ] Header row appears first; every client row has a bracketed status token
- [ ] `madari clients extra` returns "unexpected positional arguments"
- [ ] `madari clients --help` prints usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)