### PR TITLE
build: inject version into madari CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           fi
           # Build binary into a staging directory
           mkdir -p staging
-          go build -v -o "staging/madari${EXT}" ./cmd/madari
+          go build -v -ldflags "-X main.version=${GITHUB_REF_NAME}" -o "staging/madari${EXT}" ./cmd/madari
           # Copy license, notice, and readme
           cp LICENSE NOTICE README.md staging/
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BINARY=madari
 .PHONY: build run test
 
 build:
-	go build -o bin/$(BINARY) ./cmd/madari
+	go build $(if $(VERSION),-ldflags "-X main.version=$(VERSION)") -o bin/$(BINARY) ./cmd/madari
 
 run:
 	go run ./cmd/madari

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -19,7 +19,7 @@ import (
 	"github.com/ankitvg/madari/internal/registry"
 )
 
-const version = "0.0.0-dev"
+var version = "0.0.0-dev"
 
 var syncAdapters = map[string]clients.ClientAdapter{
 	claudedesktop.Target: claudedesktop.Adapter{},

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -1202,6 +1202,32 @@ func TestRunHelpMentionsConfigDefaults(t *testing.T) {
 	}
 }
 
+func TestRunVersionCommandsUseDefaultBuildVersion(t *testing.T) {
+	tests := [][]string{
+		{"version"},
+		{"--version"},
+		{"-v"},
+	}
+
+	for _, args := range tests {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			code := run(args, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("expected version command to succeed, got code=%d stderr=%s", code, stderr.String())
+			}
+			if got := strings.TrimSpace(stdout.String()); got != "0.0.0-dev" {
+				t.Fatalf("expected default build version, got %q", got)
+			}
+			if stderr.Len() != 0 {
+				t.Fatalf("expected empty stderr, got: %s", stderr.String())
+			}
+		})
+	}
+}
+
 func TestDeriveServerName(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Summary
- make the madari CLI version string overrideable at build time
- add optional VERSION support to local builds via Makefile
- inject the Git tag into release builds and add CLI coverage for default version output

## Verification
- go test ./cmd/madari
- make build && ./bin/madari --version
- make build VERSION=v0.1.3 && ./bin/madari --version