### PR TITLE
cli: polish top-level help and bad-input guidance

### DIFF
--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -42,18 +42,41 @@ func run(args []string, stdout, stderr io.Writer) int {
 	}
 
 	switch args[0] {
-	case "version", "--version", "-v":
-		fmt.Fprintln(stdout, version)
-		return 0
+	case "version":
+		if len(args) == 1 {
+			fmt.Fprintln(stdout, version)
+			return 0
+		}
+		if len(args) == 2 && isHelpToken(args[1]) {
+			printVersionHelp(stdout)
+			return 0
+		}
+		fmt.Fprintln(stderr, "error: usage: madari version")
+		return 1
+	case "--version", "-v":
+		if len(args) == 1 {
+			fmt.Fprintln(stdout, version)
+			return 0
+		}
+		fmt.Fprintf(stderr, "error: usage: madari %s\n", args[0])
+		return 1
 	case "--help", "-h":
-		printHelp(stdout)
-		return 0
+		if len(args) == 1 {
+			printHelp(stdout)
+			return 0
+		}
+		fmt.Fprintln(stderr, "error: usage: madari help [command]")
+		return 1
 	case "help":
 		if len(args) == 1 {
 			printHelp(stdout)
 			return 0
 		}
 		if len(args) == 2 {
+			if isHelpToken(args[1]) {
+				printHelpHelp(stdout)
+				return 0
+			}
 			if !printCommandHelp(args[1], stdout) {
 				fmt.Fprintf(stderr, "error: unknown command: %s\n", args[1])
 				return 1
@@ -1100,10 +1123,39 @@ func printCommandHelp(command string, out io.Writer) bool {
 		printExportHelp(out)
 	case "import":
 		printImportHelp(out)
+	case "help":
+		printHelpHelp(out)
+	case "version":
+		printVersionHelp(out)
 	default:
 		return false
 	}
 	return true
+}
+
+func printHelpHelp(out io.Writer) {
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  madari help [command]")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Description:")
+	fmt.Fprintln(out, "  Show general help or command-specific help for any top-level command.")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Examples:")
+	fmt.Fprintln(out, "  madari help")
+	fmt.Fprintln(out, "  madari help install")
+	fmt.Fprintln(out, "  madari help version")
+}
+
+func printVersionHelp(out io.Writer) {
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  madari version")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Description:")
+	fmt.Fprintln(out, "  Show the Madari CLI version.")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Aliases:")
+	fmt.Fprintln(out, "  madari --version")
+	fmt.Fprintln(out, "  madari -v")
 }
 
 func printAddHelp(out io.Writer) {

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -148,7 +148,7 @@ func (a cliApp) dispatch(args []string) error {
 
 func (a cliApp) cmdInstall(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("usage: madari install <package> [options]")
+		return commandUsageError("install", "madari install <package> [options]")
 	}
 	if len(args) == 1 && isHelpToken(args[0]) {
 		printInstallHelp(a.stdout)
@@ -194,10 +194,10 @@ func (a cliApp) cmdInstall(args []string) error {
 			printInstallHelp(a.stdout)
 			return nil
 		}
-		return err
+		return commandInputError("install", err.Error())
 	}
 	if fs.NArg() != 0 {
-		return fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " "))
+		return commandUnexpectedArgsError("install", fs.Args())
 	}
 
 	manager = strings.TrimSpace(strings.ToLower(manager))
@@ -205,10 +205,10 @@ func (a cliApp) cmdInstall(args []string) error {
 		manager = "uv"
 	}
 	if !isSupportedInstallManager(manager) {
-		return fmt.Errorf("unsupported package manager %q (supported: uv, npm)", manager)
+		return commandInputError("install", fmt.Sprintf("unsupported package manager %q (supported: uv, npm)", manager))
 	}
 	if manager == "npm" && strings.TrimSpace(command) == "" {
-		return fmt.Errorf("--command is required when --manager npm because npm package names may differ from executable names")
+		return commandInputError("install", "--command is required when --manager npm because npm package names may differ from executable names")
 	}
 
 	name = strings.TrimSpace(name)
@@ -216,7 +216,7 @@ func (a cliApp) cmdInstall(args []string) error {
 		name = deriveServerName(packageName)
 	}
 	if name == "" {
-		return fmt.Errorf("unable to derive server name from package %q, pass --name", packageName)
+		return commandInputError("install", fmt.Sprintf("unable to derive server name from package %q, pass --name", packageName))
 	}
 
 	if len(clients) == 0 {
@@ -470,7 +470,7 @@ func (a cliApp) cmdSetEnabled(args []string, enabled bool) error {
 
 func (a cliApp) cmdSync(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("usage: madari sync <client> [--dry-run] [--config-path <path>]")
+		return commandUsageError("sync", "madari sync <client> [--dry-run] [--config-path <path>]")
 	}
 	if isHelpToken(args[0]) {
 		printSyncHelp(a.stdout)
@@ -489,14 +489,14 @@ func (a cliApp) cmdSync(args []string) error {
 			printSyncHelp(a.stdout)
 			return nil
 		}
-		return err
+		return commandInputError("sync", err.Error())
 	}
 	if fs.NArg() != 0 {
-		return fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " "))
+		return commandUnexpectedArgsError("sync", fs.Args())
 	}
 	adapter, ok := syncAdapters[target]
 	if !ok {
-		return fmt.Errorf("unsupported sync target %q (supported: %s)", target, strings.Join(supportedSyncTargets(), ", "))
+		return commandInputError("sync", fmt.Sprintf("unsupported sync target %q (supported: %s)", target, strings.Join(supportedSyncTargets(), ", ")))
 	}
 
 	manifests, err := a.store.List()
@@ -602,15 +602,15 @@ func (a cliApp) cmdDoctor(args []string) error {
 			printDoctorHelp(a.stdout)
 			return nil
 		}
-		return err
+		return commandInputError("doctor", err.Error())
 	}
 	if fs.NArg() != 0 {
-		return fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " "))
+		return commandUnexpectedArgsError("doctor", fs.Args())
 	}
 
 	configPathOverrides, err := parseClientConfigOverrides(clientConfigs)
 	if err != nil {
-		return err
+		return commandInputError("doctor", err.Error())
 	}
 
 	adapters := sortedAdapters()
@@ -691,15 +691,15 @@ func (a cliApp) cmdStatus(args []string) error {
 			printStatusHelp(a.stdout)
 			return nil
 		}
-		return err
+		return commandInputError("status", err.Error())
 	}
 	if fs.NArg() != 0 {
-		return fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " "))
+		return commandUnexpectedArgsError("status", fs.Args())
 	}
 
 	configPathOverrides, err := parseClientConfigOverrides(clientConfigs)
 	if err != nil {
-		return err
+		return commandInputError("status", err.Error())
 	}
 
 	adapters := sortedAdapters()
@@ -751,10 +751,10 @@ func (a cliApp) cmdExport(args []string) error {
 			printExportHelp(a.stdout)
 			return nil
 		}
-		return err
+		return commandInputError("export", err.Error())
 	}
 	if fs.NArg() != 0 {
-		return fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " "))
+		return commandUnexpectedArgsError("export", fs.Args())
 	}
 
 	snapshot, err := registry.ExportSnapshot(a.store)
@@ -801,15 +801,15 @@ func (a cliApp) cmdImport(args []string) error {
 			printImportHelp(a.stdout)
 			return nil
 		}
-		return err
+		return commandInputError("import", err.Error())
 	}
 	if fs.NArg() != 0 {
-		return fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " "))
+		return commandUnexpectedArgsError("import", fs.Args())
 	}
 
 	filePath = strings.TrimSpace(filePath)
 	if filePath == "" {
-		return fmt.Errorf("--file is required")
+		return commandInputError("import", "--file is required")
 	}
 
 	payload, err := os.ReadFile(filePath)
@@ -1095,6 +1095,18 @@ func printSyncSummary(stdout, stderr io.Writer, target, configPath string, dryRu
 
 func isHelpToken(value string) bool {
 	return value == "--help" || value == "-h"
+}
+
+func commandUsageError(command, usage string) error {
+	return fmt.Errorf("usage: %s (run `madari help %s` for details)", usage, command)
+}
+
+func commandInputError(command, message string) error {
+	return fmt.Errorf("%s (run `madari help %s` for details)", message, command)
+}
+
+func commandUnexpectedArgsError(command string, args []string) error {
+	return commandInputError(command, fmt.Sprintf("unexpected positional arguments: %s", strings.Join(args, " ")))
 }
 
 func printCommandHelp(command string, out io.Writer) bool {

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -330,6 +330,7 @@ func TestRunHelpSubcommandOutput(t *testing.T) {
 		contains string
 	}{
 		{name: "help clients", args: []string{"help", "clients"}, contains: "madari clients"},
+		{name: "help help", args: []string{"help", "help"}, contains: "madari help [command]"},
 		{name: "help install", args: []string{"help", "install"}, contains: "madari install <package>"},
 		{name: "help add", args: []string{"help", "add"}, contains: "madari add <name>"},
 		{name: "help sync", args: []string{"help", "sync"}, contains: "madari sync <client>"},
@@ -338,6 +339,7 @@ func TestRunHelpSubcommandOutput(t *testing.T) {
 		{name: "help status", args: []string{"help", "status"}, contains: "madari status"},
 		{name: "help export", args: []string{"help", "export"}, contains: "madari export"},
 		{name: "help import", args: []string{"help", "import"}, contains: "madari import"},
+		{name: "help version", args: []string{"help", "version"}, contains: "madari version"},
 	}
 
 	for _, tt := range tests {
@@ -365,6 +367,71 @@ func TestRunHelpSubcommandUnknownCommand(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "unknown command") {
 		t.Fatalf("expected unknown command error, got: %s", stderr.String())
+	}
+}
+
+func TestRunTopLevelHelpAndVersionArgumentValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		wantCode    int
+		stdoutMatch string
+		stderrMatch string
+	}{
+		{
+			name:        "help help flag",
+			args:        []string{"help", "--help"},
+			wantCode:    0,
+			stdoutMatch: "madari help [command]",
+		},
+		{
+			name:        "version help flag",
+			args:        []string{"version", "--help"},
+			wantCode:    0,
+			stdoutMatch: "madari version",
+		},
+		{
+			name:        "version extra arg",
+			args:        []string{"version", "extra"},
+			wantCode:    1,
+			stderrMatch: "usage: madari version",
+		},
+		{
+			name:        "short version extra arg",
+			args:        []string{"-v", "extra"},
+			wantCode:    1,
+			stderrMatch: "usage: madari -v",
+		},
+		{
+			name:        "long version extra arg",
+			args:        []string{"--version", "extra"},
+			wantCode:    1,
+			stderrMatch: "usage: madari --version",
+		},
+		{
+			name:        "top level help extra arg",
+			args:        []string{"--help", "extra"},
+			wantCode:    1,
+			stderrMatch: "usage: madari help [command]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			code := run(tt.args, &stdout, &stderr)
+			if code != tt.wantCode {
+				t.Fatalf("expected code %d, got %d stdout=%s stderr=%s", tt.wantCode, code, stdout.String(), stderr.String())
+			}
+			if tt.stdoutMatch != "" && !strings.Contains(stdout.String(), tt.stdoutMatch) {
+				t.Fatalf("expected stdout to contain %q, got: %s", tt.stdoutMatch, stdout.String())
+			}
+			if tt.stderrMatch != "" && !strings.Contains(stderr.String(), tt.stderrMatch) {
+				t.Fatalf("expected stderr to contain %q, got: %s", tt.stderrMatch, stderr.String())
+			}
+		})
 	}
 }
 

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -288,26 +288,27 @@ func TestRunWithStoreCommandUsageValidation(t *testing.T) {
 	store := newTestStore(t)
 
 	tests := []struct {
-		name     string
-		args     []string
-		expected string
+		name        string
+		args        []string
+		expected    string
+		helpCommand string
 	}{
-		{name: "install missing package", args: []string{"install"}, expected: "usage: madari install <package>"},
+		{name: "install missing package", args: []string{"install"}, expected: "usage: madari install <package>", helpCommand: "install"},
 		{name: "list with arg", args: []string{"list", "oops"}, expected: "usage: madari list"},
 		{name: "remove missing name", args: []string{"remove"}, expected: "usage: madari remove <name>"},
 		{name: "enable missing name", args: []string{"enable"}, expected: "usage: madari enable <name>"},
 		{name: "disable missing name", args: []string{"disable"}, expected: "usage: madari disable <name>"},
-		{name: "sync missing target", args: []string{"sync"}, expected: "usage: madari sync <client>"},
-		{name: "sync unsupported target", args: []string{"sync", "cursor"}, expected: "unsupported sync target"},
-		{name: "sync extra positionals", args: []string{"sync", "claude-desktop", "extra"}, expected: "unexpected positional arguments"},
+		{name: "sync missing target", args: []string{"sync"}, expected: "usage: madari sync <client>", helpCommand: "sync"},
+		{name: "sync unsupported target", args: []string{"sync", "cursor"}, expected: "unsupported sync target", helpCommand: "sync"},
+		{name: "sync extra positionals", args: []string{"sync", "claude-desktop", "extra"}, expected: "unexpected positional arguments", helpCommand: "sync"},
 		{name: "clients extra positionals", args: []string{"clients", "extra"}, expected: "unexpected positional arguments"},
-		{name: "doctor unknown client-config target", args: []string{"doctor", "--client-config", "cursor=/tmp/x"}, expected: "unknown client config target"},
-		{name: "status unknown client-config target", args: []string{"status", "--client-config", "cursor=/tmp/x"}, expected: "unknown client config target"},
-		{name: "doctor extra positionals", args: []string{"doctor", "extra"}, expected: "unexpected positional arguments"},
-		{name: "status extra positionals", args: []string{"status", "extra"}, expected: "unexpected positional arguments"},
-		{name: "export extra positionals", args: []string{"export", "extra"}, expected: "unexpected positional arguments"},
-		{name: "import missing file", args: []string{"import"}, expected: "--file is required"},
-		{name: "import extra positionals", args: []string{"import", "--file", "snapshot.json", "extra"}, expected: "unexpected positional arguments"},
+		{name: "doctor unknown client-config target", args: []string{"doctor", "--client-config", "cursor=/tmp/x"}, expected: "unknown client config target", helpCommand: "doctor"},
+		{name: "status unknown client-config target", args: []string{"status", "--client-config", "cursor=/tmp/x"}, expected: "unknown client config target", helpCommand: "status"},
+		{name: "doctor extra positionals", args: []string{"doctor", "extra"}, expected: "unexpected positional arguments", helpCommand: "doctor"},
+		{name: "status extra positionals", args: []string{"status", "extra"}, expected: "unexpected positional arguments", helpCommand: "status"},
+		{name: "export extra positionals", args: []string{"export", "extra"}, expected: "unexpected positional arguments", helpCommand: "export"},
+		{name: "import missing file", args: []string{"import"}, expected: "--file is required", helpCommand: "import"},
+		{name: "import extra positionals", args: []string{"import", "--file", "snapshot.json", "extra"}, expected: "unexpected positional arguments", helpCommand: "import"},
 	}
 
 	for _, tt := range tests {
@@ -318,6 +319,41 @@ func TestRunWithStoreCommandUsageValidation(t *testing.T) {
 			}
 			if !strings.Contains(result.stderr, tt.expected) {
 				t.Fatalf("expected stderr to contain %q, got: %s", tt.expected, result.stderr)
+			}
+			if tt.helpCommand != "" && !strings.Contains(result.stderr, "madari help "+tt.helpCommand) {
+				t.Fatalf("expected stderr to mention command help for %q, got: %s", tt.helpCommand, result.stderr)
+			}
+		})
+	}
+}
+
+func TestRunWithStoreCommandFlagParsingShowsHelpHint(t *testing.T) {
+	store := newTestStore(t)
+
+	tests := []struct {
+		name        string
+		args        []string
+		helpCommand string
+	}{
+		{name: "install unknown flag", args: []string{"install", "stewreads-mcp", "--bogus"}, helpCommand: "install"},
+		{name: "sync unknown flag", args: []string{"sync", "claude-desktop", "--bogus"}, helpCommand: "sync"},
+		{name: "doctor unknown flag", args: []string{"doctor", "--bogus"}, helpCommand: "doctor"},
+		{name: "status unknown flag", args: []string{"status", "--bogus"}, helpCommand: "status"},
+		{name: "export unknown flag", args: []string{"export", "--bogus"}, helpCommand: "export"},
+		{name: "import unknown flag", args: []string{"import", "--bogus"}, helpCommand: "import"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := runCmd(store, tt.args...)
+			if result.code == 0 {
+				t.Fatalf("expected command to fail")
+			}
+			if !strings.Contains(result.stderr, "flag provided but not defined") {
+				t.Fatalf("expected unknown flag error, got: %s", result.stderr)
+			}
+			if !strings.Contains(result.stderr, "madari help "+tt.helpCommand) {
+				t.Fatalf("expected help hint for %q, got: %s", tt.helpCommand, result.stderr)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- make top-level help and version behavior more consistent
- add dedicated help output for madari - local MCP manager

Commands:
  install   Install and register a server
  add       Add a server manifest
  list      List configured servers
  remove    Remove a server manifest
  enable    Enable a server
  disable   Disable a server
  sync      Sync server manifests to a client config
  clients   List supported clients and config readiness
  doctor    Run diagnostics on local MCP setup
  status    Show concise readiness summary
  export    Export registry snapshot
  import    Import registry snapshot
  help      Show help
  version   Show version

Run `madari help <command>` for command-specific help.

Examples:
  madari install stewreads-mcp
  madari add stewreads --command stewreads-mcp --client claude-desktop
  madari list
  madari disable stewreads
  madari sync claude-desktop --dry-run
  madari sync claude-code --dry-run
  madari export --file madari-snapshot.json
  madari import --file madari-snapshot.json
  madari import --file madari-snapshot.json --apply

Default config directory: /Users/ankitgupta/Library/Application Support/madari
Default servers directory: /Users/ankitgupta/Library/Application Support/madari/servers
Override config directory with: MADARI_CONFIG_DIR and 0.0.0-dev
- return command-specific help hints for bad input across install, sync, doctor, status, export, and import

## Verification
- go test ./cmd/madari
- /tmp/madari-next help version
- /tmp/madari-next version extra
- /tmp/madari-badinput import
- /tmp/madari-badinput doctor --bogus