### PR TITLE
docs: align README with current CLI help surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ go install github.com/ankitvg/madari/cmd/madari@latest
 - `madari status [--client-config target=path ...]`
 - `madari export [--file <path>]`
 - `madari import --file <path> [--apply]`
+- `madari help [command]`
+- `madari version`
 
 Notes:
 
@@ -78,6 +80,8 @@ madari export --file madari-snapshot.json
 madari import --file madari-snapshot.json
 madari import --file madari-snapshot.json --apply
 madari doctor
+madari help install
+madari version
 ```
 
 ## Development


### PR DESCRIPTION
## What
Aligns README command docs with the current CLI help surface (commit was sitting unpushed on local main).

## Why
Keeps README in sync with help text per AGENTS.md working rule 2, ahead of the v0.1.3 release.

## Tests
- `go test ./...` (docs-only change; suite green locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)