### PR TITLE
clients: version managed-state file with per-entry sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ go install github.com/ankitvg/madari/cmd/madari@latest
 - `madari status [--client-config target=path ...]`
 - `madari export [--file <path>]`
 - `madari import --file <path> [--apply]`
+- `madari help [command]`
+- `madari version`
 
 Notes:
 
@@ -78,6 +80,8 @@ madari export --file madari-snapshot.json
 madari import --file madari-snapshot.json
 madari import --file madari-snapshot.json --apply
 madari doctor
+madari help install
+madari version
 ```
 
 ## Development

--- a/internal/clients/adapter.go
+++ b/internal/clients/adapter.go
@@ -46,7 +46,8 @@ type ClientAdapter interface {
 type SyncOptions struct {
 	// ConfigPath overrides adapter default config path when non-empty.
 	ConfigPath string
-	// StatePath stores names currently managed by Madari for this target.
+	// StatePath stores entries currently managed by Madari for this target,
+	// each mapped to the sources that own it (e.g. "standalone").
 	StatePath string
 	// DryRun computes a plan without writing config or managed state.
 	DryRun bool

--- a/internal/clients/claude-desktop/sync.go
+++ b/internal/clients/claude-desktop/sync.go
@@ -41,13 +41,13 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 	if err != nil {
 		return SyncResult{}, err
 	}
-	managedNames, err := syncshared.LoadManagedState(statePath)
+	managedState, err := syncshared.LoadManagedState(statePath)
 	if err != nil {
 		return SyncResult{}, err
 	}
 
 	desiredServers := desiredServersForTarget(manifests)
-	result, err := buildPlan(existingServers, managedNames, desiredServers)
+	result, err := buildPlan(existingServers, syncshared.MapKeys(managedState), desiredServers)
 	if err != nil {
 		return SyncResult{}, err
 	}
@@ -91,7 +91,8 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 		return SyncResult{}, fmt.Errorf("write Claude config: %w", err)
 	}
 
-	if err := syncshared.SaveManagedState(statePath, syncshared.MapKeys(desiredServers)); err != nil {
+	nextState := syncshared.NextManagedState(managedState, syncshared.MapKeys(desiredServers))
+	if err := syncshared.SaveManagedState(statePath, nextState); err != nil {
 		return SyncResult{}, fmt.Errorf("write managed sync state: %w", err)
 	}
 

--- a/internal/clients/claude-desktop/sync_test.go
+++ b/internal/clients/claude-desktop/sync_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/ankitvg/madari/internal/clients"
+	"github.com/ankitvg/madari/internal/clients/syncshared"
 	"github.com/ankitvg/madari/internal/registry"
 )
 
@@ -320,6 +321,69 @@ func TestSyncApplyCreatesBackup(t *testing.T) {
 	}
 }
 
+func TestSyncMigratesV1ManagedStateToV2(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "claude_desktop_config.json")
+	statePath := filepath.Join(tmp, "state", "claude-desktop-managed.json")
+
+	baseConfig := []byte(`{
+  "mcpServers": {
+    "legacy": {
+      "command": "legacy-mcp"
+    }
+  }
+}
+`)
+	if err := os.WriteFile(configPath, baseConfig, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
+		t.Fatalf("create state dir: %v", err)
+	}
+	v1State := []byte(`{"managed_servers":["legacy"]}` + "\n")
+	if err := os.WriteFile(statePath, v1State, 0o644); err != nil {
+		t.Fatalf("write v1 state fixture: %v", err)
+	}
+
+	result, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync apply failed: %v", err)
+	}
+	if len(result.Removed) != 1 || result.Removed[0] != "legacy" {
+		t.Fatalf("expected v1-managed legacy entry to be removed, got: %+v", result)
+	}
+	if len(result.Added) != 1 || result.Added[0] != "stewreads" {
+		t.Fatalf("expected stewreads add, got: %+v", result)
+	}
+
+	servers := readServers(t, configPath)
+	if _, ok := servers["legacy"]; ok {
+		t.Fatalf("expected legacy entry to be removed from config")
+	}
+
+	payload, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read managed state: %v", err)
+	}
+	var file struct {
+		Version        int                 `json:"version"`
+		ManagedServers map[string][]string `json:"managed_servers"`
+	}
+	if err := json.Unmarshal(payload, &file); err != nil {
+		t.Fatalf("parse managed state: %v", err)
+	}
+	if file.Version != 2 {
+		t.Fatalf("expected managed state rewritten as version 2, got %d", file.Version)
+	}
+	expected := map[string][]string{"stewreads": {"standalone"}}
+	if !reflect.DeepEqual(file.ManagedServers, expected) {
+		t.Fatalf("expected managed state %#v, got %#v", expected, file.ManagedServers)
+	}
+}
+
 func readRoot(t *testing.T, configPath string) map[string]json.RawMessage {
 	t.Helper()
 	payload, err := os.ReadFile(configPath)
@@ -345,17 +409,16 @@ func readServers(t *testing.T, configPath string) map[string]serverConfig {
 
 func readManagedNames(t *testing.T, statePath string) []string {
 	t.Helper()
-	payload, err := os.ReadFile(statePath)
+	state, err := syncshared.LoadManagedState(statePath)
 	if err != nil {
-		t.Fatalf("read managed state: %v", err)
+		t.Fatalf("load managed state: %v", err)
 	}
-	state := managedStateFile{}
-	if err := json.Unmarshal(payload, &state); err != nil {
-		t.Fatalf("parse managed state: %v", err)
+	names := make([]string, 0, len(state))
+	for name := range state {
+		names = append(names, name)
 	}
-	sorted := append([]string(nil), state.ManagedServers...)
-	slices.Sort(sorted)
-	return sorted
+	slices.Sort(names)
+	return names
 }
 
 func assertJSONEqual(t *testing.T, want, got []byte) {
@@ -371,10 +434,6 @@ func assertJSONEqual(t *testing.T, want, got []byte) {
 	if !reflect.DeepEqual(wantJSON, gotJSON) {
 		t.Fatalf("JSON mismatch: want=%s got=%s", string(want), string(got))
 	}
-}
-
-type managedStateFile struct {
-	ManagedServers []string `json:"managed_servers"`
 }
 
 func newStewreadsManifest() registry.Manifest {

--- a/internal/clients/claudecode/sync.go
+++ b/internal/clients/claudecode/sync.go
@@ -39,13 +39,13 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 	if err != nil {
 		return SyncResult{}, err
 	}
-	managedNames, err := syncshared.LoadManagedState(statePath)
+	managedState, err := syncshared.LoadManagedState(statePath)
 	if err != nil {
 		return SyncResult{}, err
 	}
 
 	desiredServers := desiredServersForTarget(manifests)
-	result, err := buildPlan(existingServers, managedNames, desiredServers)
+	result, err := buildPlan(existingServers, syncshared.MapKeys(managedState), desiredServers)
 	if err != nil {
 		return SyncResult{}, err
 	}
@@ -89,7 +89,8 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 		return SyncResult{}, fmt.Errorf("write Claude Code config: %w", err)
 	}
 
-	if err := syncshared.SaveManagedState(statePath, syncshared.MapKeys(desiredServers)); err != nil {
+	nextState := syncshared.NextManagedState(managedState, syncshared.MapKeys(desiredServers))
+	if err := syncshared.SaveManagedState(statePath, nextState); err != nil {
 		return SyncResult{}, fmt.Errorf("write managed sync state: %w", err)
 	}
 

--- a/internal/clients/claudecode/sync_test.go
+++ b/internal/clients/claudecode/sync_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/ankitvg/madari/internal/clients"
+	"github.com/ankitvg/madari/internal/clients/syncshared"
 	"github.com/ankitvg/madari/internal/registry"
 )
 
@@ -320,6 +321,69 @@ func TestSyncApplyCreatesBackup(t *testing.T) {
 	}
 }
 
+func TestSyncMigratesV1ManagedStateToV2(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".mcp.json")
+	statePath := filepath.Join(tmp, "state", "claude-code-managed.json")
+
+	baseConfig := []byte(`{
+  "mcpServers": {
+    "legacy": {
+      "command": "legacy-mcp"
+    }
+  }
+}
+`)
+	if err := os.WriteFile(configPath, baseConfig, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
+		t.Fatalf("create state dir: %v", err)
+	}
+	v1State := []byte(`{"managed_servers":["legacy"]}` + "\n")
+	if err := os.WriteFile(statePath, v1State, 0o644); err != nil {
+		t.Fatalf("write v1 state fixture: %v", err)
+	}
+
+	result, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync apply failed: %v", err)
+	}
+	if len(result.Removed) != 1 || result.Removed[0] != "legacy" {
+		t.Fatalf("expected v1-managed legacy entry to be removed, got: %+v", result)
+	}
+	if len(result.Added) != 1 || result.Added[0] != "stewreads" {
+		t.Fatalf("expected stewreads add, got: %+v", result)
+	}
+
+	servers := readServers(t, configPath)
+	if _, ok := servers["legacy"]; ok {
+		t.Fatalf("expected legacy entry to be removed from config")
+	}
+
+	payload, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read managed state: %v", err)
+	}
+	var file struct {
+		Version        int                 `json:"version"`
+		ManagedServers map[string][]string `json:"managed_servers"`
+	}
+	if err := json.Unmarshal(payload, &file); err != nil {
+		t.Fatalf("parse managed state: %v", err)
+	}
+	if file.Version != 2 {
+		t.Fatalf("expected managed state rewritten as version 2, got %d", file.Version)
+	}
+	expected := map[string][]string{"stewreads": {"standalone"}}
+	if !reflect.DeepEqual(file.ManagedServers, expected) {
+		t.Fatalf("expected managed state %#v, got %#v", expected, file.ManagedServers)
+	}
+}
+
 func readRoot(t *testing.T, configPath string) map[string]json.RawMessage {
 	t.Helper()
 	payload, err := os.ReadFile(configPath)
@@ -345,17 +409,16 @@ func readServers(t *testing.T, configPath string) map[string]serverConfig {
 
 func readManagedNames(t *testing.T, statePath string) []string {
 	t.Helper()
-	payload, err := os.ReadFile(statePath)
+	state, err := syncshared.LoadManagedState(statePath)
 	if err != nil {
-		t.Fatalf("read managed state: %v", err)
+		t.Fatalf("load managed state: %v", err)
 	}
-	state := managedStateFile{}
-	if err := json.Unmarshal(payload, &state); err != nil {
-		t.Fatalf("parse managed state: %v", err)
+	names := make([]string, 0, len(state))
+	for name := range state {
+		names = append(names, name)
 	}
-	sorted := append([]string(nil), state.ManagedServers...)
-	slices.Sort(sorted)
-	return sorted
+	slices.Sort(names)
+	return names
 }
 
 func assertJSONEqual(t *testing.T, want, got []byte) {
@@ -371,10 +434,6 @@ func assertJSONEqual(t *testing.T, want, got []byte) {
 	if !reflect.DeepEqual(wantJSON, gotJSON) {
 		t.Fatalf("JSON mismatch: want=%s got=%s", string(want), string(got))
 	}
-}
-
-type managedStateFile struct {
-	ManagedServers []string `json:"managed_servers"`
 }
 
 func newStewreadsManifest() registry.Manifest {

--- a/internal/clients/syncshared/syncshared.go
+++ b/internal/clients/syncshared/syncshared.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -101,43 +102,66 @@ func BuildPlan[T any](
 	)
 }
 
-// LoadManagedState reads and normalizes managed server names.
-func LoadManagedState(path string) ([]string, error) {
+// SourceStandalone marks an entry as owned by a direct (non-ring) sync.
+const SourceStandalone = "standalone"
+
+// managedStateVersion is the only version the writer emits.
+const managedStateVersion = 2
+
+// LoadManagedState reads managed server state, mapping each server name to
+// the sources that own it. Version 1 files (a bare name list) are read
+// transparently with every name owned by SourceStandalone; unknown versions
+// fail closed.
+func LoadManagedState(path string) (map[string][]string, error) {
 	payload, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return []string{}, nil
+			return map[string][]string{}, nil
 		}
 		return nil, fmt.Errorf("read managed state %q: %w", path, err)
 	}
 
-	state := managedState{}
-	if err := json.Unmarshal(payload, &state); err != nil {
+	probe := struct {
+		Version        int             `json:"version"`
+		ManagedServers json.RawMessage `json:"managed_servers"`
+	}{}
+	if err := json.Unmarshal(payload, &probe); err != nil {
 		return nil, fmt.Errorf("parse managed state JSON: %w", err)
 	}
 
-	seen := map[string]struct{}{}
-	unique := make([]string, 0, len(state.ManagedServers))
-	for _, name := range state.ManagedServers {
-		name = strings.TrimSpace(name)
-		if name == "" {
-			continue
+	switch probe.Version {
+	case 0:
+		var names []string
+		if len(probe.ManagedServers) > 0 {
+			if err := json.Unmarshal(probe.ManagedServers, &names); err != nil {
+				return nil, fmt.Errorf("parse managed state v1 names: %w", err)
+			}
 		}
-		if _, exists := seen[name]; exists {
-			continue
+		servers := make(map[string][]string, len(names))
+		for _, name := range names {
+			servers[name] = []string{SourceStandalone}
 		}
-		seen[name] = struct{}{}
-		unique = append(unique, name)
+		return normalizeManagedState(servers), nil
+	case managedStateVersion:
+		servers := map[string][]string{}
+		if len(probe.ManagedServers) > 0 {
+			if err := json.Unmarshal(probe.ManagedServers, &servers); err != nil {
+				return nil, fmt.Errorf("parse managed state v2 entries: %w", err)
+			}
+		}
+		return normalizeManagedState(servers), nil
+	default:
+		return nil, fmt.Errorf("unsupported managed state version %d in %q", probe.Version, path)
 	}
-	sort.Strings(unique)
-	return unique, nil
 }
 
-// SaveManagedState writes managed server names in sorted order.
-func SaveManagedState(path string, names []string) error {
-	sorted := append([]string(nil), names...)
-	sort.Strings(sorted)
-	state := managedState{ManagedServers: sorted}
+// SaveManagedState writes managed server state in the current (v2) format
+// with deterministic ordering.
+func SaveManagedState(path string, servers map[string][]string) error {
+	state := managedStateFile{
+		Version:        managedStateVersion,
+		ManagedServers: normalizeManagedState(servers),
+	}
 
 	payload, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
@@ -146,6 +170,52 @@ func SaveManagedState(path string, names []string) error {
 	payload = append(payload, '\n')
 
 	return WriteFileAtomically(path, payload, 0o644)
+}
+
+// NextManagedState computes post-sync managed state: every desired name is
+// owned at least by SourceStandalone, preserving any other sources already
+// recorded for it.
+func NextManagedState(previous map[string][]string, desiredNames []string) map[string][]string {
+	next := make(map[string][]string, len(desiredNames))
+	for _, name := range desiredNames {
+		sources := append([]string(nil), previous[name]...)
+		if !slices.Contains(sources, SourceStandalone) {
+			sources = append(sources, SourceStandalone)
+		}
+		next[name] = sources
+	}
+	return next
+}
+
+// normalizeManagedState trims and deduplicates names and sources, dropping
+// entries that end up without a name or any sources.
+func normalizeManagedState(servers map[string][]string) map[string][]string {
+	normalized := make(map[string][]string, len(servers))
+	for name, sources := range servers {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		seen := map[string]struct{}{}
+		unique := make([]string, 0, len(sources))
+		for _, source := range sources {
+			source = strings.TrimSpace(source)
+			if source == "" {
+				continue
+			}
+			if _, exists := seen[source]; exists {
+				continue
+			}
+			seen[source] = struct{}{}
+			unique = append(unique, source)
+		}
+		if len(unique) == 0 {
+			continue
+		}
+		sort.Strings(unique)
+		normalized[name] = unique
+	}
+	return normalized
 }
 
 func MapKeys[K comparable, V any](m map[K]V) []K {
@@ -239,6 +309,7 @@ func ExpandHome(path string) (string, error) {
 	return path, nil
 }
 
-type managedState struct {
-	ManagedServers []string `json:"managed_servers"`
+type managedStateFile struct {
+	Version        int                 `json:"version"`
+	ManagedServers map[string][]string `json:"managed_servers"`
 }

--- a/internal/clients/syncshared/syncshared_test.go
+++ b/internal/clients/syncshared/syncshared_test.go
@@ -5,43 +5,98 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
 func TestLoadManagedStateMissingFileReturnsEmpty(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "missing-managed.json")
 
-	names, err := LoadManagedState(path)
+	state, err := LoadManagedState(path)
 	if err != nil {
 		t.Fatalf("load managed state: %v", err)
 	}
-	if len(names) != 0 {
-		t.Fatalf("expected empty managed list for missing file, got: %#v", names)
+	if len(state) != 0 {
+		t.Fatalf("expected empty managed state for missing file, got: %#v", state)
 	}
 }
 
-func TestLoadManagedStateNormalizesAndDeduplicates(t *testing.T) {
+func TestLoadManagedStateReadsV1AsStandaloneSources(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "managed.json")
 	payload := []byte(`{"managed_servers":[" stewreads ","", "alpha","stewreads","beta","alpha"]}`)
 	if err := os.WriteFile(path, payload, 0o644); err != nil {
 		t.Fatalf("write fixture: %v", err)
 	}
 
-	names, err := LoadManagedState(path)
+	state, err := LoadManagedState(path)
 	if err != nil {
 		t.Fatalf("load managed state: %v", err)
 	}
 
-	expected := []string{"alpha", "beta", "stewreads"}
-	if !reflect.DeepEqual(names, expected) {
-		t.Fatalf("expected normalized names %#v, got %#v", expected, names)
+	expected := map[string][]string{
+		"alpha":     {SourceStandalone},
+		"beta":      {SourceStandalone},
+		"stewreads": {SourceStandalone},
+	}
+	if !reflect.DeepEqual(state, expected) {
+		t.Fatalf("expected migrated v1 state %#v, got %#v", expected, state)
 	}
 }
 
-func TestSaveManagedStateWritesSortedNames(t *testing.T) {
+func TestLoadManagedStateReadsV2Sources(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "managed.json")
+	payload := []byte(`{
+  "version": 2,
+  "managed_servers": {
+    " stewreads ": ["ring:research", " standalone ", "standalone", ""],
+    "alpha": ["standalone"],
+    "empty": ["", "  "],
+    "": ["standalone"]
+  }
+}`)
+	if err := os.WriteFile(path, payload, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	state, err := LoadManagedState(path)
+	if err != nil {
+		t.Fatalf("load managed state: %v", err)
+	}
+
+	expected := map[string][]string{
+		"alpha":     {SourceStandalone},
+		"stewreads": {"ring:research", SourceStandalone},
+	}
+	if !reflect.DeepEqual(state, expected) {
+		t.Fatalf("expected normalized v2 state %#v, got %#v", expected, state)
+	}
+}
+
+func TestLoadManagedStateRejectsUnknownVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "managed.json")
+	payload := []byte(`{"version": 3, "managed_servers": {}}`)
+	if err := os.WriteFile(path, payload, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	_, err := LoadManagedState(path)
+	if err == nil {
+		t.Fatalf("expected error for unsupported managed state version")
+	}
+	if !strings.Contains(err.Error(), "unsupported managed state version 3") {
+		t.Fatalf("expected unsupported-version error, got: %v", err)
+	}
+}
+
+func TestSaveManagedStateWritesDeterministicV2(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "managed.json")
 
-	if err := SaveManagedState(path, []string{"zeta", "alpha", "beta"}); err != nil {
+	state := map[string][]string{
+		"zeta":  {SourceStandalone},
+		"alpha": {"ring:research", SourceStandalone, "ring:research"},
+		"beta":  {SourceStandalone},
+	}
+	if err := SaveManagedState(path, state); err != nil {
 		t.Fatalf("save managed state: %v", err)
 	}
 
@@ -50,31 +105,77 @@ func TestSaveManagedStateWritesSortedNames(t *testing.T) {
 		t.Fatalf("read managed state: %v", err)
 	}
 
-	var state managedState
-	if err := json.Unmarshal(payload, &state); err != nil {
-		t.Fatalf("parse managed state: %v", err)
+	expected := `{
+  "version": 2,
+  "managed_servers": {
+    "alpha": [
+      "ring:research",
+      "standalone"
+    ],
+    "beta": [
+      "standalone"
+    ],
+    "zeta": [
+      "standalone"
+    ]
+  }
+}
+`
+	if string(payload) != expected {
+		t.Fatalf("expected deterministic v2 payload:\n%s\ngot:\n%s", expected, string(payload))
 	}
 
-	expected := []string{"alpha", "beta", "zeta"}
-	if !reflect.DeepEqual(state.ManagedServers, expected) {
-		t.Fatalf("expected sorted names %#v, got %#v", expected, state.ManagedServers)
+	var file managedStateFile
+	if err := json.Unmarshal(payload, &file); err != nil {
+		t.Fatalf("parse managed state: %v", err)
+	}
+	if file.Version != managedStateVersion {
+		t.Fatalf("expected version %d, got %d", managedStateVersion, file.Version)
 	}
 }
 
 func TestSaveThenLoadManagedStateRoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "managed.json")
 
-	if err := SaveManagedState(path, []string{"beta", "alpha", "beta", "alpha", "gamma"}); err != nil {
+	state := map[string][]string{
+		"beta":  {SourceStandalone, SourceStandalone},
+		"alpha": {"ring:research", SourceStandalone},
+		"gamma": {SourceStandalone},
+	}
+	if err := SaveManagedState(path, state); err != nil {
 		t.Fatalf("save managed state: %v", err)
 	}
 
-	names, err := LoadManagedState(path)
+	loaded, err := LoadManagedState(path)
 	if err != nil {
 		t.Fatalf("load managed state: %v", err)
 	}
 
-	expected := []string{"alpha", "beta", "gamma"}
-	if !reflect.DeepEqual(names, expected) {
-		t.Fatalf("expected round-trip normalized names %#v, got %#v", expected, names)
+	expected := map[string][]string{
+		"alpha": {"ring:research", SourceStandalone},
+		"beta":  {SourceStandalone},
+		"gamma": {SourceStandalone},
+	}
+	if !reflect.DeepEqual(loaded, expected) {
+		t.Fatalf("expected round-trip state %#v, got %#v", expected, loaded)
+	}
+}
+
+func TestNextManagedStatePreservesExistingSources(t *testing.T) {
+	previous := map[string][]string{
+		"alpha": {"ring:research"},
+		"beta":  {SourceStandalone},
+		"gone":  {SourceStandalone},
+	}
+
+	next := NextManagedState(previous, []string{"alpha", "beta", "new"})
+
+	expected := map[string][]string{
+		"alpha": {"ring:research", SourceStandalone},
+		"beta":  {SourceStandalone},
+		"new":   {SourceStandalone},
+	}
+	if !reflect.DeepEqual(next, expected) {
+		t.Fatalf("expected next state %#v, got %#v", expected, next)
 	}
 }


### PR DESCRIPTION
## What
- Managed-state files gain an explicit `version` field (v2) and map each server name to a list of owning sources (`["standalone"]` today, `ring:<name>` later).
- `syncshared.LoadManagedState` reads v1 files (bare name lists) transparently as standalone-owned; unknown versions fail closed.
- `syncshared.SaveManagedState` emits deterministic v2 only (sorted keys, sorted+deduped sources, atomic write).
- Both adapters preserve any non-standalone sources already recorded for still-desired entries via `syncshared.NextManagedState`.
- Zero sync behavior change; existing adapter tests pass unchanged.

## Why
Groundwork for v0.1.3 (Rings release plan): reference-counted ownership needs per-entry sources, and making `sources` a list now avoids a second schema migration when rings land. Registry parser strictness philosophy is mirrored: schema evolution is explicit and versioned.

## Tests
- `go test ./...`
- `go vet ./...`
- New: v1→standalone migration, v2 round-trip, unknown-version rejection, deterministic writer output (`internal/clients/syncshared`), and adapter-level v1→v2 migration tests for both claude-code and claude-desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)