### PR TITLE
sync: remove managed entries only when sources empty; surface sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Notes:
 - `install --manager npm` requires `--command` because npm package names can differ from executable names.
 - `add` resolves `--command` to an absolute executable path and stores that path in the manifest.
 - `sync` skips servers with missing/non-executable command paths and continues syncing others.
+- `list` shows the managed sources owning each synced entry (`standalone` today; `-` when not synced), and `status` summarizes managed entries per client.
 - Supported sync clients: `claude-desktop` and `claude-code`.
 - Default sync config paths:
   - `claude-desktop`: platform-specific Claude Desktop config path.

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ankitvg/madari/internal/clients"
 	claudedesktop "github.com/ankitvg/madari/internal/clients/claude-desktop"
 	"github.com/ankitvg/madari/internal/clients/claudecode"
+	"github.com/ankitvg/madari/internal/clients/syncshared"
 	"github.com/ankitvg/madari/internal/doctor"
 	"github.com/ankitvg/madari/internal/registry"
 )
@@ -388,7 +389,12 @@ func (a cliApp) cmdList(args []string) error {
 		return nil
 	}
 
-	fmt.Fprintln(a.stdout, "NAME\tSTATUS\tCOMMAND\tCLIENTS")
+	managedSources, err := a.managedSourcesByServer()
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(a.stdout, "NAME\tSTATUS\tCOMMAND\tCLIENTS\tSOURCES")
 	for _, manifest := range manifests {
 		status := "disabled"
 		if manifest.Enabled {
@@ -396,9 +402,49 @@ func (a cliApp) cmdList(args []string) error {
 		}
 		clients := append([]string(nil), manifest.Clients...)
 		sort.Strings(clients)
-		fmt.Fprintf(a.stdout, "%s\t%s\t%s\t%s\n", manifest.Name, status, manifest.Command, strings.Join(clients, ","))
+		sources := "-"
+		if list := managedSources[manifest.Name]; len(list) > 0 {
+			sources = strings.Join(list, ",")
+		}
+		fmt.Fprintf(a.stdout, "%s\t%s\t%s\t%s\t%s\n", manifest.Name, status, manifest.Command, strings.Join(clients, ","), sources)
 	}
 	return nil
+}
+
+// managedStatePath locates the per-target managed sync state file.
+func (a cliApp) managedStatePath(target string) string {
+	return filepath.Join(filepath.Dir(a.store.ServersDir()), "state", target+"-managed.json")
+}
+
+// managedSourcesByServer unions managed-state sources per server name across
+// all sync targets.
+func (a cliApp) managedSourcesByServer() (map[string][]string, error) {
+	union := map[string]map[string]struct{}{}
+	for _, adapter := range sortedAdapters() {
+		state, err := syncshared.LoadManagedState(a.managedStatePath(adapter.Target()))
+		if err != nil {
+			return nil, err
+		}
+		for name, sources := range state {
+			if union[name] == nil {
+				union[name] = map[string]struct{}{}
+			}
+			for _, source := range sources {
+				union[name][source] = struct{}{}
+			}
+		}
+	}
+
+	result := make(map[string][]string, len(union))
+	for name, set := range union {
+		sources := make([]string, 0, len(set))
+		for source := range set {
+			sources = append(sources, source)
+		}
+		sort.Strings(sources)
+		result[name] = sources
+	}
+	return result, nil
 }
 
 func (a cliApp) cmdRemove(args []string) error {
@@ -505,7 +551,7 @@ func (a cliApp) cmdSync(args []string) error {
 	}
 	syncable, skipped := filterSyncableManifests(manifests, target)
 
-	statePath := filepath.Join(filepath.Dir(a.store.ServersDir()), "state", target+"-managed.json")
+	statePath := a.managedStatePath(target)
 	result, err := adapter.Sync(syncable, clients.SyncOptions{
 		ConfigPath: configPath,
 		StatePath:  statePath,
@@ -724,6 +770,27 @@ func (a cliApp) cmdStatus(args []string) error {
 		if cc.Status != doctor.StatusSkipped {
 			fmt.Fprintf(a.stdout, "%s-config: %s\n", cc.Target, cc.Status)
 		}
+	}
+	for _, adapter := range adapters {
+		state, err := syncshared.LoadManagedState(a.managedStatePath(adapter.Target()))
+		if err != nil {
+			return err
+		}
+		if len(state) == 0 {
+			continue
+		}
+		sourceSet := map[string]struct{}{}
+		for _, sources := range state {
+			for _, source := range sources {
+				sourceSet[source] = struct{}{}
+			}
+		}
+		sourceList := make([]string, 0, len(sourceSet))
+		for source := range sourceSet {
+			sourceList = append(sourceList, source)
+		}
+		sort.Strings(sourceList)
+		fmt.Fprintf(a.stdout, "%s-managed: entries=%d sources=%s\n", adapter.Target(), len(state), strings.Join(sourceList, ","))
 	}
 	if len(report.ManifestErrors) > 0 {
 		fmt.Fprintf(a.stdout, "manifest-errors: %d\n", len(report.ManifestErrors))
@@ -1221,7 +1288,8 @@ func printListHelp(out io.Writer) {
 	fmt.Fprintln(out, "  madari list")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Description:")
-	fmt.Fprintln(out, "  List configured servers with status, command path, and clients.")
+	fmt.Fprintln(out, "  List configured servers with status, command path, clients, and the")
+	fmt.Fprintln(out, "  managed sources that own each synced entry (\"-\" when not synced).")
 }
 
 func printRemoveHelp(out io.Writer) {
@@ -1290,7 +1358,8 @@ func printStatusHelp(out io.Writer) {
 	fmt.Fprintln(out, "  --client-config target=path    Override config path for a client (repeatable)")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Description:")
-	fmt.Fprintln(out, "  Show a concise readiness summary. Use `madari doctor` for full details.")
+	fmt.Fprintln(out, "  Show a concise readiness summary, including managed sync entries per")
+	fmt.Fprintln(out, "  client with their owning sources. Use `madari doctor` for full details.")
 }
 
 func printExportHelp(out io.Writer) {

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -1236,6 +1236,50 @@ func TestRunWithStoreStatusHealthy(t *testing.T) {
 	}
 }
 
+func TestRunWithStoreListAndStatusShowManagedSources(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	if result := runCmd(store, "add", "stewreads", "--command", commandPath, "--client", "claude-desktop"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+
+	result := runCmd(store, "list")
+	if result.code != 0 {
+		t.Fatalf("list failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "SOURCES") {
+		t.Fatalf("expected SOURCES column header, got: %s", result.stdout)
+	}
+	if !strings.Contains(result.stdout, "stewreads\tenabled\t"+commandPath+"\tclaude-desktop\t-") {
+		t.Fatalf("expected unsynced server to show '-' sources, got: %s", result.stdout)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "claude_desktop_config.json")
+	if err := os.WriteFile(configPath, []byte(`{"mcpServers":{}}`), 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+	if result := runCmd(store, "sync", "claude-desktop", "--config-path", configPath); result.code != 0 {
+		t.Fatalf("sync failed: %s", result.stderr)
+	}
+
+	result = runCmd(store, "list")
+	if result.code != 0 {
+		t.Fatalf("list after sync failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "stewreads\tenabled\t"+commandPath+"\tclaude-desktop\tstandalone") {
+		t.Fatalf("expected synced server to show standalone source, got: %s", result.stdout)
+	}
+
+	result = runCmd(store, "status", "--client-config", "claude-desktop="+configPath)
+	if result.code != 0 {
+		t.Fatalf("status failed: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	if !strings.Contains(result.stdout, "claude-desktop-managed: entries=1 sources=standalone") {
+		t.Fatalf("expected managed summary line, got: %s", result.stdout)
+	}
+}
+
 func TestRunWithStoreStatusReturnsErrorForInvalidConfig(t *testing.T) {
 	store := newTestStore(t)
 	commandPath := mustCurrentExecutable(t)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,7 +24,17 @@
 - Supports `--dry-run` to preview changes.
 - Performs backup + atomic write when applying changes.
 
-4. Doctor Engine
+4. Managed Sync State
+- Path: `<config-root>/state/<target>-managed.json`, one file per sync target.
+- Versioned JSON (current: version 2) mapping each managed server name to the
+  sources that own it (`standalone` today; ring sources later).
+- Version 1 files (bare name lists) are read transparently as
+  standalone-owned; the writer emits version 2 only; unknown versions fail
+  closed.
+- A managed entry that is no longer desired loses its `standalone` source and
+  is removed from client config only when no sources remain to own it.
+
+5. Doctor Engine
 - Verifies command/binary resolution.
 - Validates required env values are present.
 - Validates client config parseability and managed entry consistency.
@@ -33,5 +43,6 @@
 
 - Never overwrite unknown config blocks.
 - Keep managed entries isolated via per-target managed state tracking files.
+- Remove managed entries from client config only when no recorded source owns them.
 - Always backup before write.
 - Fail closed on parse errors.

--- a/internal/clients/claude-desktop/sync.go
+++ b/internal/clients/claude-desktop/sync.go
@@ -47,7 +47,7 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 	}
 
 	desiredServers := desiredServersForTarget(manifests)
-	result, err := buildPlan(existingServers, syncshared.MapKeys(managedState), desiredServers)
+	result, err := buildPlan(existingServers, managedState, desiredServers)
 	if err != nil {
 		return SyncResult{}, err
 	}
@@ -160,7 +160,7 @@ func desiredServersForTarget(manifests []registry.Manifest) map[string]serverCon
 	return servers
 }
 
-func buildPlan(existing map[string]serverConfig, managed []string, desired map[string]serverConfig) (SyncResult, error) {
+func buildPlan(existing map[string]serverConfig, managed map[string][]string, desired map[string]serverConfig) (SyncResult, error) {
 	return syncshared.BuildPlan(existing, managed, desired, equalServer, ErrConflict)
 }
 

--- a/internal/clients/claudecode/sync.go
+++ b/internal/clients/claudecode/sync.go
@@ -45,7 +45,7 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 	}
 
 	desiredServers := desiredServersForTarget(manifests)
-	result, err := buildPlan(existingServers, syncshared.MapKeys(managedState), desiredServers)
+	result, err := buildPlan(existingServers, managedState, desiredServers)
 	if err != nil {
 		return SyncResult{}, err
 	}
@@ -146,7 +146,7 @@ func desiredServersForTarget(manifests []registry.Manifest) map[string]serverCon
 	return servers
 }
 
-func buildPlan(existing map[string]serverConfig, managed []string, desired map[string]serverConfig) (SyncResult, error) {
+func buildPlan(existing map[string]serverConfig, managed map[string][]string, desired map[string]serverConfig) (SyncResult, error) {
 	return syncshared.BuildPlan(existing, managed, desired, equalServer, ErrConflict)
 }
 

--- a/internal/clients/syncshared/syncshared.go
+++ b/internal/clients/syncshared/syncshared.go
@@ -28,9 +28,12 @@ func ResolvePath(override string, defaultResolver func() (string, error)) (strin
 }
 
 // BuildPlan computes sync mutations against existing + managed state.
+//
+// A managed entry that is no longer desired loses its standalone source; it
+// is removed from client config only when no sources remain to own it.
 func BuildPlan[T any](
 	existing map[string]T,
-	managed []string,
+	managed map[string][]string,
 	desired map[string]T,
 	equal func(a, b T) bool,
 	conflictErr error,
@@ -39,14 +42,12 @@ func BuildPlan[T any](
 		return clients.SyncResult{}, fmt.Errorf("equal comparer is required")
 	}
 
-	managedSet := map[string]struct{}{}
-	for _, name := range managed {
-		managedSet[name] = struct{}{}
-	}
-
 	result := clients.SyncResult{}
-	for name := range managedSet {
+	for name, sources := range managed {
 		if _, stillDesired := desired[name]; stillDesired {
+			continue
+		}
+		if len(withoutSource(sources, SourceStandalone)) > 0 {
 			continue
 		}
 		if _, exists := existing[name]; exists {
@@ -57,7 +58,7 @@ func BuildPlan[T any](
 	var conflicts []string
 	for name, desiredServer := range desired {
 		existingServer, exists := existing[name]
-		_, managedByMadari := managedSet[name]
+		_, managedByMadari := managed[name]
 
 		if !exists {
 			result.Added = append(result.Added, name)
@@ -174,7 +175,8 @@ func SaveManagedState(path string, servers map[string][]string) error {
 
 // NextManagedState computes post-sync managed state: every desired name is
 // owned at least by SourceStandalone, preserving any other sources already
-// recorded for it.
+// recorded for it. Names no longer desired lose their standalone source and
+// stay tracked only while other sources still own them.
 func NextManagedState(previous map[string][]string, desiredNames []string) map[string][]string {
 	next := make(map[string][]string, len(desiredNames))
 	for _, name := range desiredNames {
@@ -184,7 +186,31 @@ func NextManagedState(previous map[string][]string, desiredNames []string) map[s
 		}
 		next[name] = sources
 	}
+	desired := make(map[string]struct{}, len(desiredNames))
+	for _, name := range desiredNames {
+		desired[name] = struct{}{}
+	}
+	for name, sources := range previous {
+		if _, stillDesired := desired[name]; stillDesired {
+			continue
+		}
+		if remaining := withoutSource(sources, SourceStandalone); len(remaining) > 0 {
+			next[name] = remaining
+		}
+	}
 	return next
+}
+
+// withoutSource returns sources with every occurrence of source removed.
+func withoutSource(sources []string, source string) []string {
+	remaining := make([]string, 0, len(sources))
+	for _, candidate := range sources {
+		if candidate == source {
+			continue
+		}
+		remaining = append(remaining, candidate)
+	}
+	return remaining
 }
 
 // normalizeManagedState trims and deduplicates names and sources, dropping

--- a/internal/clients/syncshared/syncshared_test.go
+++ b/internal/clients/syncshared/syncshared_test.go
@@ -163,19 +163,72 @@ func TestSaveThenLoadManagedStateRoundTrip(t *testing.T) {
 
 func TestNextManagedStatePreservesExistingSources(t *testing.T) {
 	previous := map[string][]string{
-		"alpha": {"ring:research"},
-		"beta":  {SourceStandalone},
-		"gone":  {SourceStandalone},
+		"alpha":    {"ring:research"},
+		"beta":     {SourceStandalone},
+		"gone":     {SourceStandalone},
+		"ringonly": {"ring:research", SourceStandalone},
 	}
 
 	next := NextManagedState(previous, []string{"alpha", "beta", "new"})
 
 	expected := map[string][]string{
-		"alpha": {"ring:research", SourceStandalone},
-		"beta":  {SourceStandalone},
-		"new":   {SourceStandalone},
+		"alpha":    {"ring:research", SourceStandalone},
+		"beta":     {SourceStandalone},
+		"new":      {SourceStandalone},
+		"ringonly": {"ring:research"},
 	}
 	if !reflect.DeepEqual(next, expected) {
 		t.Fatalf("expected next state %#v, got %#v", expected, next)
+	}
+}
+
+func TestBuildPlanRemovesOnlyWhenSourcesEmpty(t *testing.T) {
+	equal := func(a, b string) bool { return a == b }
+	cases := []struct {
+		name        string
+		existing    map[string]string
+		managed     map[string][]string
+		desired     map[string]string
+		wantRemoved []string
+	}{
+		{
+			name:        "standalone-only entry no longer desired is removed",
+			existing:    map[string]string{"alpha": "cmd"},
+			managed:     map[string][]string{"alpha": {SourceStandalone}},
+			desired:     map[string]string{},
+			wantRemoved: []string{"alpha"},
+		},
+		{
+			name:     "entry with leftover ring source is kept",
+			existing: map[string]string{"alpha": "cmd"},
+			managed:  map[string][]string{"alpha": {"ring:research", SourceStandalone}},
+			desired:  map[string]string{},
+		},
+		{
+			name:    "undesired entry already absent from config is ignored",
+			managed: map[string][]string{"alpha": {SourceStandalone}},
+			desired: map[string]string{},
+		},
+		{
+			name:     "still-desired entry is never removed",
+			existing: map[string]string{"alpha": "cmd"},
+			managed:  map[string][]string{"alpha": {SourceStandalone}},
+			desired:  map[string]string{"alpha": "cmd"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := BuildPlan(tc.existing, tc.managed, tc.desired, equal, nil)
+			if err != nil {
+				t.Fatalf("build plan: %v", err)
+			}
+			if len(tc.wantRemoved) == 0 && len(result.Removed) != 0 {
+				t.Fatalf("expected no removals, got %#v", result.Removed)
+			}
+			if len(tc.wantRemoved) > 0 && !reflect.DeepEqual(result.Removed, tc.wantRemoved) {
+				t.Fatalf("expected removed %#v, got %#v", tc.wantRemoved, result.Removed)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What
- `syncshared.BuildPlan` now strips the `standalone` source from managed entries that are no longer desired and marks them removed only when no sources remain to own them. `NextManagedState` keeps leftover-source entries tracked in managed state.
- `madari list` gains a `SOURCES` column showing the managed sources owning each synced entry (union across sync targets, `-` when not synced).
- `madari status` reports per-target managed summaries, e.g. `claude-code-managed: entries=1 sources=standalone`.
- Help text for `list`/`status`, README notes, and `docs/architecture.md` (new Managed Sync State section + safety model line) updated per AGENTS.md working rule 2.

## Why
Second half of the v0.1.3 groundwork (Rings release plan): the "sources empty → remove" rule is what reference-counted ring attach/detach will rely on. Behaviorally identical today since `standalone` is the only source — existing adapter sync tests pass unchanged.

## Tests
- `go test ./...`
- `go vet ./...`
- New: table-driven removal-rule cases (standalone-only removed, leftover ring source kept, absent-from-config ignored, still-desired never removed), `NextManagedState` leftover-source coverage, and a CLI test asserting the `SOURCES` column and the status managed line before/after a real sync.
- Manual smoke: seeded a v1 state file + stale config entry; dry-run and apply plans identical to pre-change behavior, state rewritten as v2, `list`/`status` show `standalone`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)