### PR TITLE
sync: never adopt pre-existing unmanaged entries

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,6 +43,8 @@
 
 - Never overwrite unknown config blocks.
 - Keep managed entries isolated via per-target managed state tracking files.
+- Never adopt pre-existing entries Madari did not create, even when their
+  values match a manifest; ownership is only taken for entries sync introduces.
 - Remove managed entries from client config only when no recorded source owns them.
 - Always backup before write.
 - Fail closed on parse errors.

--- a/internal/clients/claude-desktop/sync.go
+++ b/internal/clients/claude-desktop/sync.go
@@ -91,7 +91,7 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 		return SyncResult{}, fmt.Errorf("write Claude config: %w", err)
 	}
 
-	nextState := syncshared.NextManagedState(managedState, syncshared.MapKeys(desiredServers))
+	nextState := syncshared.NextManagedState(managedState, syncshared.MapKeys(desiredServers), result.Added)
 	if err := syncshared.SaveManagedState(statePath, nextState); err != nil {
 		return SyncResult{}, fmt.Errorf("write managed sync state: %w", err)
 	}

--- a/internal/clients/claude-desktop/sync_test.go
+++ b/internal/clients/claude-desktop/sync_test.go
@@ -321,6 +321,59 @@ func TestSyncApplyCreatesBackup(t *testing.T) {
 	}
 }
 
+func TestSyncDoesNotAdoptEqualUnmanagedEntry(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "claude_desktop_config.json")
+	statePath := filepath.Join(tmp, "state", "claude-desktop-managed.json")
+
+	config := []byte(`{
+  "mcpServers": {
+    "stewreads": {
+      "command": "stewreads-mcp",
+      "env": {
+        "STEWREADS_CONFIG_PATH": "~/.config/stewreads/config.toml"
+      }
+    }
+  }
+}
+`)
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	manifest := newStewreadsManifest()
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync apply failed: %v", err)
+	}
+	if len(result.Unchanged) != 1 || result.Unchanged[0] != "stewreads" {
+		t.Fatalf("expected equal unmanaged entry to be unchanged, got: %+v", result)
+	}
+
+	if managedNames := readManagedNames(t, statePath); len(managedNames) != 0 {
+		t.Fatalf("expected no adoption of unmanaged entry, got managed: %#v", managedNames)
+	}
+
+	manifest.Enabled = false
+	result, err = Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync after disable failed: %v", err)
+	}
+	if len(result.Removed) != 0 {
+		t.Fatalf("expected no removal of never-owned entry, got: %#v", result.Removed)
+	}
+	servers := readServers(t, configPath)
+	if _, ok := servers["stewreads"]; !ok {
+		t.Fatalf("expected hand-managed stewreads entry to survive disable")
+	}
+}
+
 func TestSyncMigratesV1ManagedStateToV2(t *testing.T) {
 	tmp := t.TempDir()
 	configPath := filepath.Join(tmp, "claude_desktop_config.json")

--- a/internal/clients/claudecode/sync.go
+++ b/internal/clients/claudecode/sync.go
@@ -89,7 +89,7 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 		return SyncResult{}, fmt.Errorf("write Claude Code config: %w", err)
 	}
 
-	nextState := syncshared.NextManagedState(managedState, syncshared.MapKeys(desiredServers))
+	nextState := syncshared.NextManagedState(managedState, syncshared.MapKeys(desiredServers), result.Added)
 	if err := syncshared.SaveManagedState(statePath, nextState); err != nil {
 		return SyncResult{}, fmt.Errorf("write managed sync state: %w", err)
 	}

--- a/internal/clients/claudecode/sync_test.go
+++ b/internal/clients/claudecode/sync_test.go
@@ -321,6 +321,59 @@ func TestSyncApplyCreatesBackup(t *testing.T) {
 	}
 }
 
+func TestSyncDoesNotAdoptEqualUnmanagedEntry(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".mcp.json")
+	statePath := filepath.Join(tmp, "state", "claude-code-managed.json")
+
+	config := []byte(`{
+  "mcpServers": {
+    "stewreads": {
+      "command": "stewreads-mcp",
+      "env": {
+        "STEWREADS_CONFIG_PATH": "~/.config/stewreads/config.toml"
+      }
+    }
+  }
+}
+`)
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	manifest := newStewreadsManifest()
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync apply failed: %v", err)
+	}
+	if len(result.Unchanged) != 1 || result.Unchanged[0] != "stewreads" {
+		t.Fatalf("expected equal unmanaged entry to be unchanged, got: %+v", result)
+	}
+
+	if managedNames := readManagedNames(t, statePath); len(managedNames) != 0 {
+		t.Fatalf("expected no adoption of unmanaged entry, got managed: %#v", managedNames)
+	}
+
+	manifest.Enabled = false
+	result, err = Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync after disable failed: %v", err)
+	}
+	if len(result.Removed) != 0 {
+		t.Fatalf("expected no removal of never-owned entry, got: %#v", result.Removed)
+	}
+	servers := readServers(t, configPath)
+	if _, ok := servers["stewreads"]; !ok {
+		t.Fatalf("expected hand-managed stewreads entry to survive disable")
+	}
+}
+
 func TestSyncMigratesV1ManagedStateToV2(t *testing.T) {
 	tmp := t.TempDir()
 	configPath := filepath.Join(tmp, ".mcp.json")

--- a/internal/clients/syncshared/syncshared.go
+++ b/internal/clients/syncshared/syncshared.go
@@ -173,22 +173,33 @@ func SaveManagedState(path string, servers map[string][]string) error {
 	return WriteFileAtomically(path, payload, 0o644)
 }
 
-// NextManagedState computes post-sync managed state: every desired name is
-// owned at least by SourceStandalone, preserving any other sources already
-// recorded for it. Names no longer desired lose their standalone source and
-// stay tracked only while other sources still own them.
-func NextManagedState(previous map[string][]string, desiredNames []string) map[string][]string {
+// NextManagedState computes post-sync managed state. A desired name is owned
+// only when Madari already owned it or introduced it in this sync (addedNames);
+// pre-existing unmanaged entries that happen to match desired values are never
+// adopted. Owned names carry SourceStandalone plus any other sources already
+// recorded. Names no longer desired lose their standalone source and stay
+// tracked only while other sources still own them.
+func NextManagedState(previous map[string][]string, desiredNames, addedNames []string) map[string][]string {
+	added := make(map[string]struct{}, len(addedNames))
+	for _, name := range addedNames {
+		added[name] = struct{}{}
+	}
+
 	next := make(map[string][]string, len(desiredNames))
+	desired := make(map[string]struct{}, len(desiredNames))
 	for _, name := range desiredNames {
-		sources := append([]string(nil), previous[name]...)
+		desired[name] = struct{}{}
+		sources, owned := previous[name]
+		if !owned {
+			if _, introduced := added[name]; !introduced {
+				continue
+			}
+		}
+		sources = append([]string(nil), sources...)
 		if !slices.Contains(sources, SourceStandalone) {
 			sources = append(sources, SourceStandalone)
 		}
 		next[name] = sources
-	}
-	desired := make(map[string]struct{}, len(desiredNames))
-	for _, name := range desiredNames {
-		desired[name] = struct{}{}
 	}
 	for name, sources := range previous {
 		if _, stillDesired := desired[name]; stillDesired {

--- a/internal/clients/syncshared/syncshared_test.go
+++ b/internal/clients/syncshared/syncshared_test.go
@@ -169,7 +169,7 @@ func TestNextManagedStatePreservesExistingSources(t *testing.T) {
 		"ringonly": {"ring:research", SourceStandalone},
 	}
 
-	next := NextManagedState(previous, []string{"alpha", "beta", "new"})
+	next := NextManagedState(previous, []string{"alpha", "beta", "new"}, []string{"new"})
 
 	expected := map[string][]string{
 		"alpha":    {"ring:research", SourceStandalone},
@@ -179,6 +179,23 @@ func TestNextManagedStatePreservesExistingSources(t *testing.T) {
 	}
 	if !reflect.DeepEqual(next, expected) {
 		t.Fatalf("expected next state %#v, got %#v", expected, next)
+	}
+}
+
+func TestNextManagedStateDoesNotAdoptUnownedEntries(t *testing.T) {
+	previous := map[string][]string{
+		"owned": {SourceStandalone},
+	}
+
+	// "handmade" is desired and already present in client config (so it is
+	// not in addedNames); ownership must not be taken for it.
+	next := NextManagedState(previous, []string{"owned", "handmade"}, nil)
+
+	expected := map[string][]string{
+		"owned": {SourceStandalone},
+	}
+	if !reflect.DeepEqual(next, expected) {
+		t.Fatalf("expected no adoption of unowned entries, got %#v", next)
 	}
 }
 


### PR DESCRIPTION
## What
- `syncshared.NextManagedState` now takes the plan's `Added` names and records ownership only for entries Madari already owned or introduced in this sync. Pre-existing unmanaged entries whose values happen to match a manifest stay unmanaged (still reported `unchanged` in the plan) and are never removed by a later `disable`/`remove` + sync.
- Both adapters pass `result.Added` through; architecture safety model documents the no-adoption guarantee.

## Why
Review finding (P1): apply persisted every desired name into managed state, silently adopting hand-managed entries — a later disable would delete config Madari never created. This conflicts with the Rings-plan decision "no adoption of hand-edited entries" and the existing "do not clobber unmanaged client entries" safety rule, and needed resolving before rings attach/detach builds on ownership.

## Tests
- `go test ./...`
- `go vet ./...`
- New: `NextManagedState` no-adoption unit case, plus adapter-level tests for claude-code and claude-desktop asserting an equal unmanaged entry is not recorded in managed state and survives manifest disable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)