### PR TITLE
docs: scope doctor description to implemented checks

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,7 +37,9 @@
 5. Doctor Engine
 - Verifies command/binary resolution.
 - Validates required env values are present.
-- Validates client config parseability and managed entry consistency.
+- Validates client config parseability.
+- Drift detection between manifests and materialized client entries is
+  planned, not yet implemented.
 
 ## Safety Model
 


### PR DESCRIPTION
## What
Trims the Doctor Engine description in `docs/architecture.md`: it claimed doctor validates "managed entry consistency", but doctor only checks manifests, command/env readiness, and client config parseability today. Notes drift detection as planned, not implemented.

## Why
Review finding (P2): premature documentation — drift detection between manifests and materialized client entries is scheduled for v0.1.5 in the Rings release plan.

## Tests
- Docs-only change; `go test ./...` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)