### PR TITLE
v0.1.5: secret-env placement policy, drift detection, ADR-002

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ go install github.com/ankitvg/madari/cmd/madari@latest
 - `madari remove <name>`
 - `madari enable <name>`
 - `madari disable <name>`
-- `madari sync <client> [--dry-run] [--config-path <path>] [--json]`
+- `madari sync <client> [--dry-run] [--config-path <path>] [--json] [--scope project|user]`
 - `madari clients`
 - `madari doctor [--client-config target=path ...] [--json]`
 - `madari status [--client-config target=path ...] [--json]`
@@ -41,6 +41,7 @@ Notes:
 - `install --manager npm` requires `--command` because npm package names can differ from executable names.
 - `add` resolves `--command` to an absolute executable path and stores that path in the manifest.
 - `sync` skips servers with missing/non-executable command paths and continues syncing others.
+- Manifests can mark secret env keys (`[secret_env]`, or `--secret-env` on `add`/`install`); sync refuses to write their static values into the repo-scoped Claude Code `.mcp.json` — refused entries are reported with guidance (and scrubbed if previously materialized) while other servers sync normally. Use `madari sync claude-code --scope user` to materialize them into the user-scoped `~/.claude.json` instead.
 - `list` shows the managed sources owning each synced entry (`standalone` today; `-` when not synced), and `status` summarizes managed entries per client.
 - `list`, `status`, `doctor`, and `sync --dry-run` accept `--json` for machine-readable output with a versioned schema; schemas and exit codes are documented in `docs/cli-reference.md`.
 - Supported sync clients: `claude-desktop` and `claude-code`.

--- a/cmd/madari/json_output.go
+++ b/cmd/madari/json_output.go
@@ -104,6 +104,7 @@ type syncJSON struct {
 	Removed       []string `json:"removed"`
 	Unchanged     []string `json:"unchanged"`
 	Skipped       []string `json:"skipped"`
+	Refused       []string `json:"refused"`
 }
 
 // writeJSON emits one indented JSON document followed by a newline; --json

--- a/cmd/madari/json_output.go
+++ b/cmd/madari/json_output.go
@@ -34,6 +34,7 @@ type statusJSON struct {
 	ClientConfigs  []statusConfigJSON `json:"client_configs"`
 	Managed        []managedJSON      `json:"managed"`
 	ManifestErrors int                `json:"manifest_errors"`
+	Drift          []driftJSON        `json:"drift"`
 }
 
 type summaryJSON struct {
@@ -62,7 +63,19 @@ type doctorJSON struct {
 	Servers        []doctorServerJSON  `json:"servers"`
 	ManifestErrors []manifestErrorJSON `json:"manifest_errors"`
 	ClientConfigs  []doctorConfigJSON  `json:"client_configs"`
+	Drift          []driftJSON         `json:"drift"`
 	Summary        summaryJSON         `json:"summary"`
+}
+
+type driftJSON struct {
+	Target     string   `json:"target"`
+	Scope      string   `json:"scope"`
+	ConfigPath string   `json:"config_path"`
+	Status     string   `json:"status"`
+	Stale      []string `json:"stale"`
+	Missing    []string `json:"missing"`
+	Orphaned   []string `json:"orphaned"`
+	Issue      string   `json:"issue"`
 }
 
 type doctorServerJSON struct {
@@ -135,4 +148,25 @@ func summaryToJSON(s doctor.Summary) summaryJSON {
 		Error:   s.Error,
 		Skipped: s.Skipped,
 	}
+}
+
+func driftToJSON(reports []doctor.DriftReport) []driftJSON {
+	out := make([]driftJSON, 0, len(reports))
+	for _, dr := range reports {
+		scope := dr.Scope
+		if scope == "" {
+			scope = "default"
+		}
+		out = append(out, driftJSON{
+			Target:     dr.Target,
+			Scope:      scope,
+			ConfigPath: dr.ConfigPath,
+			Status:     string(dr.Status),
+			Stale:      nonNilStrings(dr.Stale),
+			Missing:    nonNilStrings(dr.Missing),
+			Orphaned:   nonNilStrings(dr.Orphaned),
+			Issue:      dr.Issue,
+		})
+	}
+	return out
 }

--- a/cmd/madari/json_output.go
+++ b/cmd/madari/json_output.go
@@ -52,6 +52,7 @@ type statusConfigJSON struct {
 
 type managedJSON struct {
 	Target  string   `json:"target"`
+	Scope   string   `json:"scope"`
 	Entries int      `json:"entries"`
 	Sources []string `json:"sources"`
 }

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -451,14 +451,32 @@ func (a cliApp) managedUserStatePath(target string) string {
 	return filepath.Join(filepath.Dir(a.store.ServersDir()), "state", target+"-user-managed.json")
 }
 
-// managedStatePaths lists every managed-state file for a target; claude-code
-// has one per scope.
-func (a cliApp) managedStatePaths(target string) []string {
-	paths := []string{a.managedStatePath(target)}
-	if target == claudecode.Target {
-		paths = append(paths, a.managedUserStatePath(target))
+// managedStateRef names one managed-state file: a sync target plus the scope
+// the state belongs to ("" = the target's default scope).
+type managedStateRef struct {
+	target string
+	scope  string
+	path   string
+}
+
+// managedStateRefs lists every managed-state file across sync targets;
+// claude-code has one per scope.
+func (a cliApp) managedStateRefs() []managedStateRef {
+	refs := []managedStateRef{}
+	for _, adapter := range sortedAdapters() {
+		refs = append(refs, managedStateRef{
+			target: adapter.Target(),
+			path:   a.managedStatePath(adapter.Target()),
+		})
+		if adapter.Target() == claudecode.Target {
+			refs = append(refs, managedStateRef{
+				target: adapter.Target(),
+				scope:  clients.ScopeUser,
+				path:   a.managedUserStatePath(adapter.Target()),
+			})
+		}
 	}
-	return paths
+	return refs
 }
 
 // driftTargets enumerates the managed-state/config pairs doctor and status
@@ -486,19 +504,17 @@ func (a cliApp) driftTargets(adapters []clients.ClientAdapter, configPathOverrid
 // all sync targets and scopes.
 func (a cliApp) managedSourcesByServer() (map[string][]string, error) {
 	union := map[string]map[string]struct{}{}
-	for _, adapter := range sortedAdapters() {
-		for _, path := range a.managedStatePaths(adapter.Target()) {
-			state, err := syncshared.LoadManagedState(path)
-			if err != nil {
-				return nil, err
+	for _, ref := range a.managedStateRefs() {
+		state, err := syncshared.LoadManagedState(ref.path)
+		if err != nil {
+			return nil, err
+		}
+		for name, sources := range state {
+			if union[name] == nil {
+				union[name] = map[string]struct{}{}
 			}
-			for name, sources := range state {
-				if union[name] == nil {
-					union[name] = map[string]struct{}{}
-				}
-				for _, source := range sources {
-					union[name][source] = struct{}{}
-				}
+			for _, source := range sources {
+				union[name][source] = struct{}{}
 			}
 		}
 	}
@@ -948,12 +964,14 @@ func (a cliApp) cmdStatus(args []string) error {
 
 	type managedSummary struct {
 		target  string
+		scope   string
 		entries int
 		sources []string
 	}
-	managed := make([]managedSummary, 0, len(adapters))
-	for _, adapter := range adapters {
-		state, err := syncshared.LoadManagedState(a.managedStatePath(adapter.Target()))
+	refs := a.managedStateRefs()
+	managed := make([]managedSummary, 0, len(refs))
+	for _, ref := range refs {
+		state, err := syncshared.LoadManagedState(ref.path)
 		if err != nil {
 			return err
 		}
@@ -969,7 +987,8 @@ func (a cliApp) cmdStatus(args []string) error {
 		}
 		sort.Strings(sourceList)
 		managed = append(managed, managedSummary{
-			target:  adapter.Target(),
+			target:  ref.target,
+			scope:   ref.scope,
 			entries: len(state),
 			sources: sourceList,
 		})
@@ -992,8 +1011,13 @@ func (a cliApp) cmdStatus(args []string) error {
 			})
 		}
 		for _, m := range managed {
+			scope := m.scope
+			if scope == "" {
+				scope = "default"
+			}
 			payload.Managed = append(payload.Managed, managedJSON{
 				Target:  m.target,
+				Scope:   scope,
 				Entries: m.entries,
 				Sources: nonNilStrings(m.sources),
 			})
@@ -1025,7 +1049,11 @@ func (a cliApp) cmdStatus(args []string) error {
 		if m.entries == 0 {
 			continue
 		}
-		fmt.Fprintf(a.stdout, "%s-managed: entries=%d sources=%s\n", m.target, m.entries, strings.Join(m.sources, ","))
+		label := m.target + "-managed"
+		if m.scope == clients.ScopeUser {
+			label = m.target + "-user-managed"
+		}
+		fmt.Fprintf(a.stdout, "%s: entries=%d sources=%s\n", label, m.entries, strings.Join(m.sources, ","))
 	}
 	for _, dr := range report.Drift {
 		if dr.Status == doctor.StatusReady {

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -176,6 +176,7 @@ func (a cliApp) cmdInstall(args []string) error {
 	var clients stringList
 	var envPairs stringList
 	var requiredEnv stringList
+	var secretEnv stringList
 
 	fs.StringVar(&name, "name", "", "Server name (defaults from package)")
 	fs.StringVar(&command, "command", "", "Server command (defaults to package name)")
@@ -189,6 +190,7 @@ func (a cliApp) cmdInstall(args []string) error {
 	fs.Var(&clients, "client", "Client id (repeatable, default: claude-desktop)")
 	fs.Var(&envPairs, "env", "Environment variable KEY=VALUE (repeatable)")
 	fs.Var(&requiredEnv, "required-env", "Required runtime env key (repeatable)")
+	fs.Var(&secretEnv, "secret-env", "Secret env key barred from repo-scoped configs (repeatable)")
 
 	if err := fs.Parse(args[1:]); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -256,6 +258,7 @@ func (a cliApp) cmdInstall(args []string) error {
 		Description: description,
 		Env:         env,
 		RequiredEnv: registry.RequiredEnv{Keys: append([]string(nil), requiredEnv...)},
+		SecretEnv:   registry.SecretEnv{Keys: append([]string(nil), secretEnv...)},
 	}
 
 	if err := a.store.Add(manifest); err != nil {
@@ -309,6 +312,7 @@ func (a cliApp) cmdAdd(args []string) error {
 	var clients stringList
 	var envPairs stringList
 	var requiredEnv stringList
+	var secretEnv stringList
 
 	fs.StringVar(&command, "command", "", "Server command")
 	fs.StringVar(&description, "description", "", "Server description")
@@ -317,6 +321,7 @@ func (a cliApp) cmdAdd(args []string) error {
 	fs.Var(&clients, "client", "Client id (repeatable)")
 	fs.Var(&envPairs, "env", "Environment variable KEY=VALUE (repeatable)")
 	fs.Var(&requiredEnv, "required-env", "Required environment key (repeatable)")
+	fs.Var(&secretEnv, "secret-env", "Secret env key barred from repo-scoped configs (repeatable)")
 
 	if err := fs.Parse(args[1:]); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -353,6 +358,7 @@ func (a cliApp) cmdAdd(args []string) error {
 		Description: description,
 		Env:         env,
 		RequiredEnv: registry.RequiredEnv{Keys: append([]string(nil), requiredEnv...)},
+		SecretEnv:   registry.SecretEnv{Keys: append([]string(nil), secretEnv...)},
 	}
 
 	if err := a.store.Add(manifest); err != nil {
@@ -438,21 +444,40 @@ func (a cliApp) managedStatePath(target string) string {
 	return filepath.Join(filepath.Dir(a.store.ServersDir()), "state", target+"-managed.json")
 }
 
+// managedUserStatePath locates managed state for a target's user-scoped
+// config; project and user syncs track ownership independently so removals
+// in one scope never orphan entries in the other.
+func (a cliApp) managedUserStatePath(target string) string {
+	return filepath.Join(filepath.Dir(a.store.ServersDir()), "state", target+"-user-managed.json")
+}
+
+// managedStatePaths lists every managed-state file for a target; claude-code
+// has one per scope.
+func (a cliApp) managedStatePaths(target string) []string {
+	paths := []string{a.managedStatePath(target)}
+	if target == claudecode.Target {
+		paths = append(paths, a.managedUserStatePath(target))
+	}
+	return paths
+}
+
 // managedSourcesByServer unions managed-state sources per server name across
-// all sync targets.
+// all sync targets and scopes.
 func (a cliApp) managedSourcesByServer() (map[string][]string, error) {
 	union := map[string]map[string]struct{}{}
 	for _, adapter := range sortedAdapters() {
-		state, err := syncshared.LoadManagedState(a.managedStatePath(adapter.Target()))
-		if err != nil {
-			return nil, err
-		}
-		for name, sources := range state {
-			if union[name] == nil {
-				union[name] = map[string]struct{}{}
+		for _, path := range a.managedStatePaths(adapter.Target()) {
+			state, err := syncshared.LoadManagedState(path)
+			if err != nil {
+				return nil, err
 			}
-			for _, source := range sources {
-				union[name][source] = struct{}{}
+			for name, sources := range state {
+				if union[name] == nil {
+					union[name] = map[string]struct{}{}
+				}
+				for _, source := range sources {
+					union[name][source] = struct{}{}
+				}
 			}
 		}
 	}
@@ -551,9 +576,11 @@ func (a cliApp) cmdSync(args []string) error {
 	var dryRun bool
 	var configPath string
 	var jsonOut bool
+	var scope string
 	fs.BoolVar(&dryRun, "dry-run", false, "Preview changes without writing files")
 	fs.StringVar(&configPath, "config-path", "", "Override client config path")
 	fs.BoolVar(&jsonOut, "json", false, "Emit JSON instead of text (requires --dry-run)")
+	fs.StringVar(&scope, "scope", "", "Target config scope for claude-code: project (default) or user")
 	if err := fs.Parse(args[1:]); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			printSyncHelp(a.stdout)
@@ -567,6 +594,15 @@ func (a cliApp) cmdSync(args []string) error {
 	if jsonOut && !dryRun {
 		return commandInputError("sync", "--json requires --dry-run")
 	}
+	scope = strings.TrimSpace(scope)
+	if scope != "" {
+		if target != claudecode.Target {
+			return commandInputError("sync", fmt.Sprintf("--scope is only supported for %s", claudecode.Target))
+		}
+		if scope != clients.ScopeProject && scope != clients.ScopeUser {
+			return commandInputError("sync", fmt.Sprintf("unknown scope %q (supported: %s, %s)", scope, clients.ScopeProject, clients.ScopeUser))
+		}
+	}
 	adapter, ok := syncAdapters[target]
 	if !ok {
 		return commandInputError("sync", fmt.Sprintf("unsupported sync target %q (supported: %s)", target, strings.Join(supportedSyncTargets(), ", ")))
@@ -579,9 +615,13 @@ func (a cliApp) cmdSync(args []string) error {
 	syncable, skipped := filterSyncableManifests(manifests, target)
 
 	statePath := a.managedStatePath(target)
+	if scope == clients.ScopeUser {
+		statePath = a.managedUserStatePath(target)
+	}
 	result, err := adapter.Sync(syncable, clients.SyncOptions{
 		ConfigPath: configPath,
 		StatePath:  statePath,
+		Scope:      scope,
 		DryRun:     dryRun,
 	})
 	if err != nil {
@@ -599,9 +639,10 @@ func (a cliApp) cmdSync(args []string) error {
 			Removed:       nonNilStrings(result.Removed),
 			Unchanged:     nonNilStrings(result.Unchanged),
 			Skipped:       nonNilStrings(skipped),
+			Refused:       nonNilStrings(result.Refused),
 		})
 	}
-	printSyncSummary(a.stdout, a.stderr, target, result.ConfigPath, result.DryRun, result.Added, result.Updated, result.Removed, result.Unchanged, skipped)
+	printSyncSummary(a.stdout, a.stderr, target, result.ConfigPath, result.DryRun, result.Added, result.Updated, result.Removed, result.Unchanged, skipped, result.Refused)
 	return nil
 }
 
@@ -1276,7 +1317,7 @@ func formatNameList(names []string) string {
 	return strings.Join(names, ",")
 }
 
-func printSyncSummary(stdout, stderr io.Writer, target, configPath string, dryRun bool, added, updated, removed, unchanged, skipped []string) {
+func printSyncSummary(stdout, stderr io.Writer, target, configPath string, dryRun bool, added, updated, removed, unchanged, skipped, refused []string) {
 	mode := "applied"
 	if dryRun {
 		mode = "dry-run"
@@ -1292,6 +1333,12 @@ func printSyncSummary(stdout, stderr io.Writer, target, configPath string, dryRu
 		fmt.Fprintf(stdout, "skipped: %s\n", formatNameList(skipped))
 		for _, name := range skipped {
 			fmt.Fprintf(stderr, "warning: skipped %s because command path is not an executable file\n", name)
+		}
+	}
+	if len(refused) > 0 {
+		fmt.Fprintf(stdout, "refused: %s\n", formatNameList(refused))
+		for _, name := range refused {
+			fmt.Fprintf(stderr, "warning: refused %s: secret env values cannot be written to the repo-scoped config; run `madari sync %s --scope user` or remove the static [env] value for keys marked in [secret_env]\n", name, target)
 		}
 	}
 	if len(unchanged) > 0 {
@@ -1389,6 +1436,7 @@ func printAddHelp(out io.Writer) {
 	fmt.Fprintln(out, "  --arg <value>              Command argument (repeatable)")
 	fmt.Fprintln(out, "  --env KEY=VALUE            Environment variable (repeatable)")
 	fmt.Fprintln(out, "  --required-env <KEY>       Required runtime env key (repeatable)")
+	fmt.Fprintln(out, "  --secret-env <KEY>         Secret env key barred from repo-scoped configs (repeatable)")
 	fmt.Fprintln(out, "  --description <text>       Server description")
 	fmt.Fprintln(out, "  --disabled                 Add server in disabled state")
 	fmt.Fprintln(out)
@@ -1409,6 +1457,7 @@ func printInstallHelp(out io.Writer) {
 	fmt.Fprintln(out, "  --arg <value>              Command argument (repeatable)")
 	fmt.Fprintln(out, "  --env KEY=VALUE            Environment variable (repeatable)")
 	fmt.Fprintln(out, "  --required-env <KEY>       Required runtime env key (repeatable)")
+	fmt.Fprintln(out, "  --secret-env <KEY>         Secret env key barred from repo-scoped configs (repeatable)")
 	fmt.Fprintln(out, "  --description <text>       Server description")
 	fmt.Fprintln(out, "  --disabled                 Add server in disabled state")
 	fmt.Fprintln(out, "  --skip-install             Skip package installation")
@@ -1460,16 +1509,20 @@ func printEnableDisableHelp(command string, out io.Writer) {
 
 func printSyncHelp(out io.Writer) {
 	fmt.Fprintln(out, "Usage:")
-	fmt.Fprintln(out, "  madari sync <client> [--dry-run] [--config-path <path>] [--json]")
+	fmt.Fprintln(out, "  madari sync <client> [--dry-run] [--config-path <path>] [--json] [--scope project|user]")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Options:")
 	fmt.Fprintln(out, "  --dry-run                  Preview changes without writing files")
 	fmt.Fprintln(out, "  --config-path <path>       Override target client config path")
 	fmt.Fprintln(out, "  --json                     Emit JSON instead of text (requires --dry-run)")
+	fmt.Fprintln(out, "  --scope project|user       Claude Code only: target the repo-scoped .mcp.json")
+	fmt.Fprintln(out, "                             (project, default) or the user-scoped ~/.claude.json")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Description:")
 	fmt.Fprintln(out, "  Sync enabled servers from Madari registry into a target client config.")
 	fmt.Fprintf(out, "  Supported clients: %s.\n", strings.Join(supportedSyncTargets(), ", "))
+	fmt.Fprintln(out, "  Servers with static values for [secret_env] keys are refused at project")
+	fmt.Fprintln(out, "  scope; sync them with --scope user.")
 }
 
 func printClientsHelp(out io.Writer) {

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -461,6 +461,27 @@ func (a cliApp) managedStatePaths(target string) []string {
 	return paths
 }
 
+// driftTargets enumerates the managed-state/config pairs doctor and status
+// diff for drift; claude-code gets one per scope.
+func (a cliApp) driftTargets(adapters []clients.ClientAdapter, configPathOverrides map[string]string) []doctor.DriftTarget {
+	targets := make([]doctor.DriftTarget, 0, len(adapters)+1)
+	for _, adapter := range adapters {
+		targets = append(targets, doctor.DriftTarget{
+			Adapter:    adapter,
+			StatePath:  a.managedStatePath(adapter.Target()),
+			ConfigPath: configPathOverrides[adapter.Target()],
+		})
+		if adapter.Target() == claudecode.Target {
+			targets = append(targets, doctor.DriftTarget{
+				Adapter:   adapter,
+				Scope:     clients.ScopeUser,
+				StatePath: a.managedUserStatePath(adapter.Target()),
+			})
+		}
+	}
+	return targets
+}
+
 // managedSourcesByServer unions managed-state sources per server name across
 // all sync targets and scopes.
 func (a cliApp) managedSourcesByServer() (map[string][]string, error) {
@@ -747,6 +768,7 @@ func (a cliApp) cmdDoctor(args []string) error {
 	report, err := doctor.Run(a.store, doctor.Options{
 		Adapters:            adapters,
 		ConfigPathOverrides: configPathOverrides,
+		DriftTargets:        a.driftTargets(adapters, configPathOverrides),
 	})
 	if err != nil {
 		return err
@@ -795,6 +817,7 @@ func (a cliApp) cmdDoctor(args []string) error {
 				Message: cc.Message,
 			})
 		}
+		payload.Drift = driftToJSON(report.Drift)
 		if err := writeJSON(a.stdout, payload); err != nil {
 			return err
 		}
@@ -813,6 +836,33 @@ func (a cliApp) cmdDoctor(args []string) error {
 		if cc.Message != "" {
 			fmt.Fprintf(a.stdout, "%s detail: %s\n", cc.Target, cc.Message)
 		}
+	}
+
+	for _, dr := range report.Drift {
+		label := dr.Target
+		fix := "madari sync " + dr.Target
+		if dr.Scope == clients.ScopeUser {
+			label += " (user scope)"
+			fix += " --scope user"
+		}
+		if dr.Issue != "" {
+			fmt.Fprintf(a.stdout, "%s drift: [%s] %s\n", label, dr.Status, dr.Issue)
+			continue
+		}
+		if dr.Status == doctor.StatusReady {
+			fmt.Fprintf(a.stdout, "%s drift: [ready] in sync\n", label)
+			continue
+		}
+		fmt.Fprintf(
+			a.stdout,
+			"%s drift: [%s] stale=%s missing=%s orphaned=%s (fix: %s)\n",
+			label,
+			dr.Status,
+			formatNameList(dr.Stale),
+			formatNameList(dr.Missing),
+			formatNameList(dr.Orphaned),
+			fix,
+		)
 	}
 
 	if len(report.ManifestErrors) > 0 {
@@ -890,6 +940,7 @@ func (a cliApp) cmdStatus(args []string) error {
 	report, err := doctor.Run(a.store, doctor.Options{
 		Adapters:            adapters,
 		ConfigPathOverrides: configPathOverrides,
+		DriftTargets:        a.driftTargets(adapters, configPathOverrides),
 	})
 	if err != nil {
 		return err
@@ -932,6 +983,7 @@ func (a cliApp) cmdStatus(args []string) error {
 			ClientConfigs:  make([]statusConfigJSON, 0, len(report.ClientConfigs)),
 			Managed:        make([]managedJSON, 0, len(managed)),
 			ManifestErrors: len(report.ManifestErrors),
+			Drift:          driftToJSON(report.Drift),
 		}
 		for _, cc := range report.ClientConfigs {
 			payload.ClientConfigs = append(payload.ClientConfigs, statusConfigJSON{
@@ -974,6 +1026,22 @@ func (a cliApp) cmdStatus(args []string) error {
 			continue
 		}
 		fmt.Fprintf(a.stdout, "%s-managed: entries=%d sources=%s\n", m.target, m.entries, strings.Join(m.sources, ","))
+	}
+	for _, dr := range report.Drift {
+		if dr.Status == doctor.StatusReady {
+			continue
+		}
+		label := dr.Target
+		fix := "madari sync " + dr.Target
+		if dr.Scope == clients.ScopeUser {
+			label += "-user"
+			fix += " --scope user"
+		}
+		if dr.Issue != "" {
+			fmt.Fprintf(a.stdout, "%s-drift: error %s\n", label, dr.Issue)
+			continue
+		}
+		fmt.Fprintf(a.stdout, "%s-drift: stale=%d missing=%d orphaned=%d (fix: %s)\n", label, len(dr.Stale), len(dr.Missing), len(dr.Orphaned), fix)
 	}
 	if len(report.ManifestErrors) > 0 {
 		fmt.Fprintf(a.stdout, "manifest-errors: %d\n", len(report.ManifestErrors))
@@ -1544,6 +1612,8 @@ func printDoctorHelp(out io.Writer) {
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Description:")
 	fmt.Fprintln(out, "  Validate server manifests, command paths, required env keys, and client config health.")
+	fmt.Fprintln(out, "  Reports drift between manifests and materialized client entries (stale,")
+	fmt.Fprintln(out, "  missing, orphaned) with the sync command that reconciles each target.")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Examples:")
 	fmt.Fprintln(out, "  madari doctor")
@@ -1561,7 +1631,8 @@ func printStatusHelp(out io.Writer) {
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Description:")
 	fmt.Fprintln(out, "  Show a concise readiness summary, including managed sync entries per")
-	fmt.Fprintln(out, "  client with their owning sources. Use `madari doctor` for full details.")
+	fmt.Fprintln(out, "  client with their owning sources and any drift between manifests and")
+	fmt.Fprintln(out, "  materialized client entries. Use `madari doctor` for full details.")
 }
 
 func printExportHelp(out io.Writer) {

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -1443,7 +1443,7 @@ func TestRunWithStoreStatusJSON(t *testing.T) {
 	}
 
 	payload := decodeJSONObject(t, result.stdout)
-	assertJSONKeys(t, payload, "schema_version", "command", "summary", "client_configs", "managed", "manifest_errors")
+	assertJSONKeys(t, payload, "schema_version", "command", "summary", "client_configs", "managed", "manifest_errors", "drift")
 	if payload["schema_version"].(float64) != 1 {
 		t.Fatalf("unexpected schema_version: %v", payload["schema_version"])
 	}
@@ -1505,7 +1505,7 @@ func TestRunWithStoreDoctorJSONReportsErrorsAndExitCode(t *testing.T) {
 	}
 
 	payload := decodeJSONObject(t, result.stdout)
-	assertJSONKeys(t, payload, "schema_version", "command", "servers_dir", "servers", "manifest_errors", "client_configs", "summary")
+	assertJSONKeys(t, payload, "schema_version", "command", "servers_dir", "servers", "manifest_errors", "client_configs", "drift", "summary")
 	if payload["command"].(string) != "doctor" {
 		t.Fatalf("unexpected command: %v", payload["command"])
 	}
@@ -1588,6 +1588,65 @@ func TestRunWithStoreSecretEnvPlacementFlow(t *testing.T) {
 	}
 	if !strings.Contains(result.stdout, "vault\tenabled\t"+commandPath+"\tclaude-code\tstandalone") {
 		t.Fatalf("expected user-scope managed sources in list, got: %s", result.stdout)
+	}
+}
+
+func TestRunWithStoreStatusReportsDrift(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	if result := runCmd(store, "add", "driftee", "--command", commandPath, "--client", "claude-code"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+
+	configPath := filepath.Join(t.TempDir(), ".mcp.json")
+	if err := os.WriteFile(configPath, []byte(`{"mcpServers":{}}`), 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+	if result := runCmd(store, "sync", "claude-code", "--config-path", configPath); result.code != 0 {
+		t.Fatalf("sync failed: %s", result.stderr)
+	}
+
+	// No drift right after sync.
+	result := runCmd(store, "status", "--client-config", "claude-code="+configPath)
+	if result.code != 0 {
+		t.Fatalf("status failed: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	if strings.Contains(result.stdout, "-drift:") {
+		t.Fatalf("expected no drift line right after sync, got: %s", result.stdout)
+	}
+
+	// Disabling the server orphans its materialized entry.
+	if result := runCmd(store, "disable", "driftee"); result.code != 0 {
+		t.Fatalf("disable failed: %s", result.stderr)
+	}
+
+	result = runCmd(store, "status", "--client-config", "claude-code="+configPath)
+	if result.code != 0 {
+		t.Fatalf("status with drift should stay exit 0 (warning), got code=%d stderr=%s", result.code, result.stderr)
+	}
+	if !strings.Contains(result.stdout, "claude-code-drift: stale=0 missing=0 orphaned=1 (fix: madari sync claude-code)") {
+		t.Fatalf("expected drift line with fix hint, got: %s", result.stdout)
+	}
+
+	// Doctor JSON carries the same drift report.
+	result = runCmd(store, "doctor", "--json", "--client-config", "claude-code="+configPath)
+	if result.code != 0 {
+		t.Fatalf("doctor --json failed: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	payload := decodeJSONObject(t, result.stdout)
+	drift := payload["drift"].([]any)
+	if len(drift) != 1 {
+		t.Fatalf("expected one drift entry, got: %v", drift)
+	}
+	entry := drift[0].(map[string]any)
+	assertJSONKeys(t, entry, "target", "scope", "config_path", "status", "stale", "missing", "orphaned", "issue")
+	if entry["target"] != "claude-code" || entry["status"] != "warn" {
+		t.Fatalf("unexpected drift entry: %v", entry)
+	}
+	orphaned := entry["orphaned"].([]any)
+	if len(orphaned) != 1 || orphaned[0] != "driftee" {
+		t.Fatalf("expected driftee orphaned, got: %v", orphaned)
 	}
 }
 

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -1467,7 +1467,7 @@ func TestRunWithStoreStatusJSON(t *testing.T) {
 	var desktop map[string]any
 	for _, item := range managed {
 		entry := item.(map[string]any)
-		assertJSONKeys(t, entry, "target", "entries", "sources")
+		assertJSONKeys(t, entry, "target", "scope", "entries", "sources")
 		if entry["target"] == "claude-desktop" {
 			desktop = entry
 		}
@@ -1588,6 +1588,13 @@ func TestRunWithStoreSecretEnvPlacementFlow(t *testing.T) {
 	}
 	if !strings.Contains(result.stdout, "vault\tenabled\t"+commandPath+"\tclaude-code\tstandalone") {
 		t.Fatalf("expected user-scope managed sources in list, got: %s", result.stdout)
+	}
+
+	// status counts user-scope managed entries (no exit-code assertion:
+	// user-scope drift inspects the machine's real ~/.claude.json).
+	result = runCmd(store, "status", "--client-config", "claude-code="+projectConfig)
+	if !strings.Contains(result.stdout, "claude-code-user-managed: entries=1 sources=standalone") {
+		t.Fatalf("expected user-scope managed summary in status, got: %s", result.stdout)
 	}
 }
 

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -1398,7 +1398,8 @@ func TestRunWithStoreSyncDryRunJSON(t *testing.T) {
   "updated": [],
   "removed": [],
   "unchanged": [],
-  "skipped": []
+  "skipped": [],
+  "refused": []
 }
 `, configPath)
 	if result.stdout != expected {
@@ -1525,6 +1526,69 @@ func TestRunWithStoreDoctorJSONReportsErrorsAndExitCode(t *testing.T) {
 		t.Fatalf("expected client config entries, got none")
 	}
 	assertJSONKeys(t, configs[0].(map[string]any), "target", "path", "exists", "status", "message")
+}
+
+func TestRunWithStoreSyncScopeValidation(t *testing.T) {
+	store := newTestStore(t)
+
+	result := runCmd(store, "sync", "claude-desktop", "--scope", "user")
+	if result.code == 0 {
+		t.Fatalf("expected --scope on claude-desktop to fail")
+	}
+	if !strings.Contains(result.stderr, "--scope is only supported for claude-code") {
+		t.Fatalf("expected scope support error, got: %s", result.stderr)
+	}
+
+	result = runCmd(store, "sync", "claude-code", "--scope", "global")
+	if result.code == 0 {
+		t.Fatalf("expected unknown scope to fail")
+	}
+	if !strings.Contains(result.stderr, "unknown scope") {
+		t.Fatalf("expected unknown-scope error, got: %s", result.stderr)
+	}
+}
+
+func TestRunWithStoreSecretEnvPlacementFlow(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	if result := runCmd(store, "add", "vault", "--command", commandPath, "--client", "claude-code",
+		"--env", "VAULT_TOKEN=shhh", "--secret-env", "VAULT_TOKEN"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+
+	projectConfig := filepath.Join(t.TempDir(), ".mcp.json")
+	result := runCmd(store, "sync", "claude-code", "--config-path", projectConfig)
+	if result.code != 0 {
+		t.Fatalf("expected per-entry refusal to keep sync successful, stderr=%s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "refused: vault") {
+		t.Fatalf("expected refused summary line, got: %s", result.stdout)
+	}
+	if !strings.Contains(result.stderr, "refused vault") || !strings.Contains(result.stderr, "--scope user") {
+		t.Fatalf("expected refusal warning with user-scope guidance, got: %s", result.stderr)
+	}
+	payload, err := os.ReadFile(projectConfig)
+	if err != nil {
+		t.Fatalf("read project config: %v", err)
+	}
+	if strings.Contains(string(payload), "shhh") {
+		t.Fatalf("expected secret value to stay out of repo-scoped config, got: %s", payload)
+	}
+
+	userConfig := filepath.Join(t.TempDir(), "claude.json")
+	result = runCmd(store, "sync", "claude-code", "--scope", "user", "--config-path", userConfig)
+	if result.code != 0 {
+		t.Fatalf("user-scope sync failed: %s", result.stderr)
+	}
+
+	result = runCmd(store, "list")
+	if result.code != 0 {
+		t.Fatalf("list failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "vault\tenabled\t"+commandPath+"\tclaude-code\tstandalone") {
+		t.Fatalf("expected user-scope managed sources in list, got: %s", result.stdout)
+	}
 }
 
 func TestRunWithStoreStatusReturnsErrorForInvalidConfig(t *testing.T) {

--- a/docs/adr/002-launcher-shim-rejected.md
+++ b/docs/adr/002-launcher-shim-rejected.md
@@ -1,0 +1,62 @@
+# ADR 002: Launcher Shim Rejected
+
+- Status: Accepted (rejection recorded)
+- Date: 2026-06-10
+
+## Context
+
+When designing secret handling and the upcoming Rings feature, one candidate
+architecture was a launcher shim: instead of materializing real server
+commands into client configs, every managed entry would point at `madari` as
+its command (e.g. `madari launch <name>`), and madari would resolve the
+manifest, inject env (including secrets from a local store), and exec the
+real server at launch time.
+
+The shim would have solved secret placement (secret values never written to
+any client config) and made drift structurally impossible (configs only ever
+reference madari).
+
+## Decision
+
+Reject the launcher shim. Materialized sync — writing real commands, args,
+and env into client configs — remains the only sync mode.
+
+Rationale:
+
+- **Survivability.** Uninstalling or breaking madari would break every
+  managed server in every client at once. With materialized sync, client
+  configs keep working if madari disappears; madari is a manager, not a
+  runtime dependency.
+- **Transparency.** A user reading their client config should see what
+  actually runs. A shim hides the real command behind an indirection that
+  must be resolved through madari's own state.
+- **Cost/benefit.** The shim pays the runtime-presence costs of a
+  multiplexer (madari in every launch path, version skew between shim and
+  state, debugging through an extra layer) without delivering mux payoffs
+  such as connection sharing or fan-out.
+
+The problems the shim would have solved are addressed by placement policy
+and detection instead:
+
+- Secrets: manifests mark secret env keys (`[secret_env]`); sync refuses to
+  materialize their static values into repo-scoped configs and routes them
+  to user-scoped configs (`madari sync claude-code --scope user`).
+- Drift: `status`/`doctor` diff materialized client entries against
+  manifests and report stale, missing, and orphaned entries with the sync
+  command that reconciles them.
+
+## Revisit Trigger
+
+Revisit this decision if and when a multiplexer/proxy design lands on the
+roadmap. A mux changes the cost/benefit calculus because madari would already
+be in the runtime path, and the shim's marginal costs would largely be paid.
+
+## Consequences
+
+- No background daemon, proxy, or launch-time indirection in the current
+  architecture (matches the non-goals in AGENTS.md).
+- Secret env values can exist in user-scoped client configs; users who need
+  stronger secret isolation should rely on runtime-provided env
+  (`[required_env]`) instead of static `[env]` values.
+- Drift is detected, not prevented; reconciliation stays an explicit
+  `madari sync` away.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,15 +38,23 @@
 - Verifies command/binary resolution.
 - Validates required env values are present.
 - Validates client config parseability.
-- Drift detection between manifests and materialized client entries is
-  planned, not yet implemented.
+- Detects drift between manifests and materialized client entries (stale,
+  missing, orphaned) for every target+scope with managed entries.
 
 ## Safety Model
 
 - Never overwrite unknown config blocks.
-- Keep managed entries isolated via per-target managed state tracking files.
+- Keep managed entries isolated via per-target managed state tracking files
+  (per scope for clients with both repo- and user-scoped configs).
 - Never adopt pre-existing entries Madari did not create, even when their
   values match a manifest; ownership is only taken for entries sync introduces.
 - Remove managed entries from client config only when no recorded source owns them.
+- Never materialize static values for secret-marked env keys into repo-scoped
+  configs; refused entries are reported (and scrubbed if previously written),
+  and sync scope is declared explicitly, never inferred from paths.
 - Always backup before write.
 - Fail closed on parse errors.
+
+Materialized sync is the only mode: client configs always contain real
+commands and survive madari's removal. A launcher shim was considered and
+rejected (docs/adr/002-launcher-shim-rejected.md).

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -108,9 +108,27 @@ summaries cover every sync target):
     {"target": "claude-code", "entries": 0, "sources": []},
     {"target": "claude-desktop", "entries": 1, "sources": ["standalone"]}
   ],
-  "manifest_errors": 0
+  "manifest_errors": 0,
+  "drift": [
+    {
+      "target": "claude-desktop",
+      "scope": "default",
+      "config_path": "/path/to/claude_desktop_config.json",
+      "status": "ready",
+      "stale": [],
+      "missing": [],
+      "orphaned": [],
+      "issue": ""
+    }
+  ]
 }
 ```
+
+Drift entries appear per target+scope that has managed entries: `stale`
+(materialized value differs from the manifest), `missing` (managed entry
+deleted from the client config), and `orphaned` (no longer desired; the next
+sync removes it). Drift is warning-level and never changes the exit code by
+itself.
 
 `madari doctor --json`:
 
@@ -145,6 +163,18 @@ summaries cover every sync target):
       "exists": true,
       "status": "ready",
       "message": "ok"
+    }
+  ],
+  "drift": [
+    {
+      "target": "claude-desktop",
+      "scope": "default",
+      "config_path": "/path/to/claude_desktop_config.json",
+      "status": "warn",
+      "stale": ["stewreads"],
+      "missing": [],
+      "orphaned": [],
+      "issue": ""
     }
   ],
   "summary": {"total": 1, "ready": 0, "warning": 1, "error": 1, "skipped": 0}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -105,8 +105,9 @@ summaries cover every sync target):
     {"target": "claude-desktop", "status": "ready"}
   ],
   "managed": [
-    {"target": "claude-code", "entries": 0, "sources": []},
-    {"target": "claude-desktop", "entries": 1, "sources": ["standalone"]}
+    {"target": "claude-code", "scope": "default", "entries": 0, "sources": []},
+    {"target": "claude-code", "scope": "user", "entries": 0, "sources": []},
+    {"target": "claude-desktop", "scope": "default", "entries": 1, "sources": ["standalone"]}
   ],
   "manifest_errors": 0,
   "drift": [

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -27,7 +27,15 @@ madari sync claude-desktop --dry-run
 madari sync claude-desktop
 madari sync claude-code --dry-run
 madari sync claude-code
+madari sync claude-code --scope user
 ```
+
+`--scope` applies to `claude-code` only: `project` (default) targets the
+repo-scoped `.mcp.json`, `user` targets the user-scoped `~/.claude.json`.
+Each scope tracks its managed entries independently. Servers carrying static
+values for `[secret_env]` keys are refused per entry at project scope (other
+servers keep syncing; a previously materialized secret entry is scrubbed)
+and must sync with `--scope user`.
 
 ## Diagnostics
 
@@ -156,7 +164,8 @@ summaries cover every sync target):
   "updated": [],
   "removed": [],
   "unchanged": [],
-  "skipped": []
+  "skipped": [],
+  "refused": []
 }
 ```
 

--- a/docs/manifest-spec.md
+++ b/docs/manifest-spec.md
@@ -28,6 +28,13 @@ Key/value static environment variables.
 
 - `keys` (array of strings): env vars that must exist in runtime context.
 
+### `[secret_env]`
+
+- `keys` (array of strings): env vars whose values are secrets. Sync refuses
+  to materialize a static `[env]` value for a secret key into repo-scoped
+  client configs (for example the Claude Code project `.mcp.json`); secret
+  values may only land in user-scoped configs.
+
 ## Example
 
 ```toml

--- a/internal/clients/adapter.go
+++ b/internal/clients/adapter.go
@@ -21,6 +21,15 @@ import (
 // Adapters may treat exact-value matches as unchanged instead of conflicts.
 var ErrConflict = errors.New("sync conflict with unmanaged server")
 
+// Sync scopes. ScopeProject targets a repo-scoped config (e.g. the Claude
+// Code project .mcp.json); ScopeUser targets the user-level config. Scope is
+// never inferred from paths — it must be declared explicitly, and adapters
+// fail closed (project) when it is not.
+const (
+	ScopeProject = "project"
+	ScopeUser    = "user"
+)
+
 // ClientAdapter synchronizes Madari manifests into a client's MCP config shape.
 //
 // Safety and behavior invariants:
@@ -49,6 +58,12 @@ type SyncOptions struct {
 	// StatePath stores entries currently managed by Madari for this target,
 	// each mapped to the sources that own it (e.g. "standalone").
 	StatePath string
+	// Scope declares whether the target config is repo-scoped
+	// (ScopeProject) or user-scoped (ScopeUser). Empty means the adapter's
+	// default. Adapters whose config location is inherently user-scoped
+	// (e.g. Claude Desktop) may ignore it; adapters with repo-scoped
+	// configs default to ScopeProject and fail closed on unknown values.
+	Scope string
 	// DryRun computes a plan without writing config or managed state.
 	DryRun bool
 }
@@ -67,6 +82,11 @@ type SyncResult struct {
 	Removed []string
 	// Unchanged are desired names already matching target config values.
 	Unchanged []string
+	// Refused are names excluded because they carry static secret env
+	// values that must not materialize into a repo-scoped config. A
+	// previously managed refused name is also removed from the config,
+	// scrubbing the secret value on the next sync.
+	Refused []string
 }
 
 // HasChanges reports whether sync produces any mutation.

--- a/internal/clients/claudecode/sync.go
+++ b/internal/clients/claudecode/sync.go
@@ -44,7 +44,7 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 	if err != nil {
 		return SyncResult{}, err
 	}
-	statePath, err := resolveStatePath(opts.StatePath)
+	statePath, err := resolveStatePath(opts.StatePath, userScope)
 	if err != nil {
 		return SyncResult{}, err
 	}
@@ -138,6 +138,17 @@ func DefaultStatePath() (string, error) {
 	return filepath.Join(root, "state", Target+"-managed.json"), nil
 }
 
+// DefaultUserStatePath locates managed state for the user-scoped config.
+// Project and user scopes must never share a state file: ownership recorded
+// for one config would drive removals against the other.
+func DefaultUserStatePath() (string, error) {
+	root, err := registry.DefaultRootDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, "state", Target+"-user-managed.json"), nil
+}
+
 func resolveConfigPath(configPath string, userScope bool) (string, error) {
 	if userScope {
 		return syncshared.ResolvePath(configPath, DefaultUserConfigPath)
@@ -158,7 +169,10 @@ func resolveScope(scope string) (bool, error) {
 	}
 }
 
-func resolveStatePath(statePath string) (string, error) {
+func resolveStatePath(statePath string, userScope bool) (string, error) {
+	if userScope {
+		return syncshared.ResolvePath(statePath, DefaultUserStatePath)
+	}
 	return syncshared.ResolvePath(statePath, DefaultStatePath)
 }
 

--- a/internal/clients/claudecode/sync.go
+++ b/internal/clients/claudecode/sync.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/ankitvg/madari/internal/clients"
 	"github.com/ankitvg/madari/internal/clients/syncshared"
@@ -25,8 +27,20 @@ type SyncOptions = clients.SyncOptions
 type SyncResult = clients.SyncResult
 
 // Sync synchronizes enabled Claude Code-targeted manifests into the Claude Code config file.
+//
+// The default scope is project (repo-scoped .mcp.json). Manifests carrying a
+// static env value for a secret_env key are refused at project scope — they
+// are excluded from the desired set (and removed if previously managed,
+// scrubbing the secret) and reported via SyncResult.Refused. User scope
+// materializes them normally; scope is declared via opts.Scope, never
+// inferred.
 func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
-	configPath, err := resolveConfigPath(opts.ConfigPath)
+	userScope, err := resolveScope(opts.Scope)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	configPath, err := resolveConfigPath(opts.ConfigPath, userScope)
 	if err != nil {
 		return SyncResult{}, err
 	}
@@ -44,13 +58,14 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 		return SyncResult{}, err
 	}
 
-	desiredServers := desiredServersForTarget(manifests)
+	desiredServers, refused := desiredServersForTarget(manifests, userScope)
 	result, err := buildPlan(existingServers, managedState, desiredServers)
 	if err != nil {
 		return SyncResult{}, err
 	}
 	result.ConfigPath = configPath
 	result.DryRun = opts.DryRun
+	result.Refused = refused
 
 	if opts.DryRun {
 		return result, nil
@@ -105,6 +120,16 @@ func DefaultProjectConfigPath() (string, error) {
 	return filepath.Join(cwd, ".mcp.json"), nil
 }
 
+// DefaultUserConfigPath locates the user-scoped Claude Code config, where
+// secret env values are allowed to materialize.
+func DefaultUserConfigPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user home: %w", err)
+	}
+	return filepath.Join(home, ".claude.json"), nil
+}
+
 func DefaultStatePath() (string, error) {
 	root, err := registry.DefaultRootDir()
 	if err != nil {
@@ -113,21 +138,42 @@ func DefaultStatePath() (string, error) {
 	return filepath.Join(root, "state", Target+"-managed.json"), nil
 }
 
-func resolveConfigPath(configPath string) (string, error) {
+func resolveConfigPath(configPath string, userScope bool) (string, error) {
+	if userScope {
+		return syncshared.ResolvePath(configPath, DefaultUserConfigPath)
+	}
 	return syncshared.ResolvePath(configPath, DefaultProjectConfigPath)
+}
+
+// resolveScope reports whether opts.Scope selects the user-scoped config.
+// Empty defaults to project (fail closed); unknown values are rejected.
+func resolveScope(scope string) (bool, error) {
+	switch strings.TrimSpace(scope) {
+	case "", clients.ScopeProject:
+		return false, nil
+	case clients.ScopeUser:
+		return true, nil
+	default:
+		return false, fmt.Errorf("unknown sync scope %q (supported: %s, %s)", scope, clients.ScopeProject, clients.ScopeUser)
+	}
 }
 
 func resolveStatePath(statePath string) (string, error) {
 	return syncshared.ResolvePath(statePath, DefaultStatePath)
 }
 
-func desiredServersForTarget(manifests []registry.Manifest) map[string]serverConfig {
+func desiredServersForTarget(manifests []registry.Manifest, userScope bool) (map[string]serverConfig, []string) {
 	servers := map[string]serverConfig{}
+	var refused []string
 	for _, manifest := range manifests {
 		if !manifest.Enabled {
 			continue
 		}
 		if !manifest.HasClient(Target) {
+			continue
+		}
+		if !userScope && manifest.HasSecretValue() {
+			refused = append(refused, manifest.Name)
 			continue
 		}
 
@@ -143,7 +189,8 @@ func desiredServersForTarget(manifests []registry.Manifest) map[string]serverCon
 		}
 		servers[manifest.Name] = entry
 	}
-	return servers
+	sort.Strings(refused)
+	return servers, refused
 }
 
 func buildPlan(existing map[string]serverConfig, managed map[string][]string, desired map[string]serverConfig) (SyncResult, error) {

--- a/internal/clients/claudecode/sync_test.go
+++ b/internal/clients/claudecode/sync_test.go
@@ -374,6 +374,156 @@ func TestSyncDoesNotAdoptEqualUnmanagedEntry(t *testing.T) {
 	}
 }
 
+func newSecretManifest() registry.Manifest {
+	manifest := newStewreadsManifest()
+	manifest.Env["STEWREADS_API_KEY"] = "shhh"
+	manifest.SecretEnv = registry.SecretEnv{Keys: []string{"STEWREADS_API_KEY"}}
+	return manifest
+}
+
+func TestSyncRefusesSecretEnvAtProjectScope(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".mcp.json")
+	statePath := filepath.Join(tmp, "state", "claude-code-managed.json")
+
+	plain := newStewreadsManifest()
+	plain.Name = "plain"
+
+	result, err := Sync([]registry.Manifest{newSecretManifest(), plain}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("expected per-entry refusal without sync error, got: %v", err)
+	}
+	if len(result.Refused) != 1 || result.Refused[0] != "stewreads" {
+		t.Fatalf("expected stewreads refused at project scope, got: %+v", result)
+	}
+	if len(result.Added) != 1 || result.Added[0] != "plain" {
+		t.Fatalf("expected plain server to sync alongside refusal, got: %+v", result)
+	}
+
+	servers := readServers(t, configPath)
+	if _, ok := servers["stewreads"]; ok {
+		t.Fatalf("expected secret-bearing entry to stay out of repo-scoped config")
+	}
+	if _, ok := servers["plain"]; !ok {
+		t.Fatalf("expected plain entry in repo-scoped config")
+	}
+	managedNames := readManagedNames(t, statePath)
+	if len(managedNames) != 1 || managedNames[0] != "plain" {
+		t.Fatalf("expected only plain to be managed, got: %#v", managedNames)
+	}
+}
+
+func TestSyncScrubsPreviouslyManagedSecretEntryAtProjectScope(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".mcp.json")
+	statePath := filepath.Join(tmp, "state", "claude-code-managed.json")
+
+	// Simulate a pre-secret_env state: the entry was materialized into the
+	// repo-scoped config and is managed.
+	config := []byte(`{
+  "mcpServers": {
+    "stewreads": {
+      "command": "stewreads-mcp",
+      "env": {
+        "STEWREADS_API_KEY": "shhh",
+        "STEWREADS_CONFIG_PATH": "~/.config/stewreads/config.toml"
+      }
+    }
+  }
+}
+`)
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
+		t.Fatalf("create state dir: %v", err)
+	}
+	if err := os.WriteFile(statePath, []byte(`{"managed_servers":["stewreads"]}`), 0o644); err != nil {
+		t.Fatalf("write state fixture: %v", err)
+	}
+
+	result, err := Sync([]registry.Manifest{newSecretManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	if len(result.Refused) != 1 || result.Refused[0] != "stewreads" {
+		t.Fatalf("expected refusal, got: %+v", result)
+	}
+	if len(result.Removed) != 1 || result.Removed[0] != "stewreads" {
+		t.Fatalf("expected managed secret entry to be scrubbed from repo config, got: %+v", result)
+	}
+
+	servers := readServers(t, configPath)
+	if _, ok := servers["stewreads"]; ok {
+		t.Fatalf("expected secret value scrubbed from repo-scoped config")
+	}
+}
+
+func TestSyncAllowsSecretEnvAtUserScope(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "claude.json")
+	statePath := filepath.Join(tmp, "state", "claude-code-user-managed.json")
+
+	result, err := Sync([]registry.Manifest{newSecretManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+		Scope:      clients.ScopeUser,
+	})
+	if err != nil {
+		t.Fatalf("expected user-scope sync to succeed, got: %v", err)
+	}
+	if len(result.Added) != 1 || result.Added[0] != "stewreads" {
+		t.Fatalf("expected stewreads add, got: %+v", result)
+	}
+
+	servers := readServers(t, configPath)
+	if servers["stewreads"].Env["STEWREADS_API_KEY"] != "shhh" {
+		t.Fatalf("expected secret env value in user-scoped config, got: %#v", servers["stewreads"].Env)
+	}
+}
+
+func TestSyncSecretKeysWithoutValuesAllowedAtProjectScope(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".mcp.json")
+	statePath := filepath.Join(tmp, "state", "claude-code-managed.json")
+
+	manifest := newStewreadsManifest()
+	manifest.SecretEnv = registry.SecretEnv{Keys: []string{"STEWREADS_API_KEY"}}
+
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("expected sync to succeed when no static secret value exists, got: %v", err)
+	}
+	if len(result.Added) != 1 {
+		t.Fatalf("expected add result, got: %+v", result)
+	}
+}
+
+func TestSyncRejectsUnknownScope(t *testing.T) {
+	tmp := t.TempDir()
+
+	_, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: filepath.Join(tmp, ".mcp.json"),
+		StatePath:  filepath.Join(tmp, "state", "claude-code-managed.json"),
+		Scope:      "global",
+	})
+	if err == nil {
+		t.Fatalf("expected error for unknown scope")
+	}
+	if !strings.Contains(err.Error(), "unknown sync scope") {
+		t.Fatalf("expected unknown-scope error, got: %v", err)
+	}
+}
+
 func TestSyncMigratesV1ManagedStateToV2(t *testing.T) {
 	tmp := t.TempDir()
 	configPath := filepath.Join(tmp, ".mcp.json")

--- a/internal/clients/claudecode/sync_test.go
+++ b/internal/clients/claudecode/sync_test.go
@@ -508,6 +508,31 @@ func TestSyncSecretKeysWithoutValuesAllowedAtProjectScope(t *testing.T) {
 	}
 }
 
+func TestSyncUserScopeDefaultsToUserStateFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("MADARI_CONFIG_DIR", tmp)
+	configPath := filepath.Join(tmp, "claude.json")
+
+	// StatePath deliberately empty: the default must vary with scope so
+	// user-scope ownership never lands in the project state file.
+	_, err := Sync([]registry.Manifest{newSecretManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		Scope:      clients.ScopeUser,
+	})
+	if err != nil {
+		t.Fatalf("user-scope sync failed: %v", err)
+	}
+
+	userStatePath := filepath.Join(tmp, "state", Target+"-user-managed.json")
+	if _, err := os.Stat(userStatePath); err != nil {
+		t.Fatalf("expected user-scope state file at %s: %v", userStatePath, err)
+	}
+	projectStatePath := filepath.Join(tmp, "state", Target+"-managed.json")
+	if _, err := os.Stat(projectStatePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected no project state write for user-scope sync, err=%v", err)
+	}
+}
+
 func TestSyncRejectsUnknownScope(t *testing.T) {
 	tmp := t.TempDir()
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -160,7 +160,14 @@ func Run(store *registry.Store, opts Options) (Report, error) {
 		report.ClientConfigs = append(report.ClientConfigs, cr)
 	}
 
-	report.Drift = checkDrift(manifests, opts.DriftTargets)
+	// Drift is only meaningful against a fully parsed registry: a manifest
+	// that failed to load would otherwise read as "orphaned" with a sync fix
+	// hint, while the real sync command refuses to run until the manifest is
+	// repaired.
+	report.Drift = []DriftReport{}
+	if len(manifestErrors) == 0 {
+		report.Drift = checkDrift(manifests, opts.DriftTargets)
+	}
 
 	report.Summary = summarize(report)
 	return report, nil
@@ -189,7 +196,7 @@ func checkDrift(manifests []registry.Manifest, targets []DriftTarget) []DriftRep
 			continue
 		}
 
-		plan, err := target.Adapter.Sync(manifests, clients.SyncOptions{
+		plan, err := target.Adapter.Sync(syncableForTarget(manifests, target.Adapter.Target()), clients.SyncOptions{
 			ConfigPath: target.ConfigPath,
 			StatePath:  target.StatePath,
 			Scope:      target.Scope,
@@ -216,6 +223,22 @@ func checkDrift(manifests []registry.Manifest, targets []DriftTarget) []DriftRep
 		reports = append(reports, dr)
 	}
 	return reports
+}
+
+// syncableForTarget mirrors the sync command's manifest filtering: entries
+// enabled for this target whose command fails validation never reach the
+// adapter, so the drift plan matches what `madari sync` would actually do.
+func syncableForTarget(manifests []registry.Manifest, target string) []registry.Manifest {
+	out := make([]registry.Manifest, 0, len(manifests))
+	for _, manifest := range manifests {
+		if manifest.Enabled && manifest.HasClient(target) {
+			if issue := validateAbsoluteExecutablePath(manifest.Command); issue != nil {
+				continue
+			}
+		}
+		out = append(out, manifest)
+	}
+	return out
 }
 
 func summarize(report Report) Summary {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/ankitvg/madari/internal/clients"
+	"github.com/ankitvg/madari/internal/clients/syncshared"
 	"github.com/ankitvg/madari/internal/registry"
 )
 
@@ -71,13 +72,48 @@ type Report struct {
 	Servers        []ServerReport
 	ManifestErrors []ManifestError
 	ClientConfigs  []ClientConfigReport
+	Drift          []DriftReport
 	Summary        Summary
+}
+
+// DriftTarget names one managed-state/config pair to diff against manifests.
+type DriftTarget struct {
+	Adapter clients.ClientAdapter
+	// Scope is passed through to the adapter ("" = adapter default).
+	Scope string
+	// StatePath locates managed state for this target+scope; drift is only
+	// checked when it tracks at least one entry.
+	StatePath string
+	// ConfigPath overrides the adapter's default config path when non-empty.
+	ConfigPath string
+}
+
+// DriftReport diffs materialized client entries against current manifests
+// for one target+scope.
+type DriftReport struct {
+	Target     string
+	Scope      string
+	ConfigPath string
+	// Stale are managed entries whose materialized values differ from the
+	// manifest.
+	Stale []string
+	// Missing are managed entries absent from the client config.
+	Missing []string
+	// Orphaned are managed entries no longer desired; the next sync removes
+	// them.
+	Orphaned []string
+	// Issue carries a sync-plan error (e.g. unmanaged-entry conflict).
+	Issue  string
+	Status Status
 }
 
 type Options struct {
 	Adapters            []clients.ClientAdapter
 	ConfigPathOverrides map[string]string // keyed by Target(), e.g. {"claude-desktop": "/custom/path"}
 	EnvLookup           func(string) string
+	// DriftTargets enables drift detection for the listed state/config
+	// pairs.
+	DriftTargets []DriftTarget
 }
 
 func Run(store *registry.Store, opts Options) (Report, error) {
@@ -124,8 +160,62 @@ func Run(store *registry.Store, opts Options) (Report, error) {
 		report.ClientConfigs = append(report.ClientConfigs, cr)
 	}
 
+	report.Drift = checkDrift(manifests, opts.DriftTargets)
+
 	report.Summary = summarize(report)
 	return report, nil
+}
+
+// checkDrift diffs materialized client entries against manifests by reading
+// each target's dry-run sync plan. Targets without managed entries are
+// skipped: no ownership, nothing to drift.
+func checkDrift(manifests []registry.Manifest, targets []DriftTarget) []DriftReport {
+	reports := []DriftReport{}
+	for _, target := range targets {
+		dr := DriftReport{
+			Target: target.Adapter.Target(),
+			Scope:  target.Scope,
+			Status: StatusReady,
+		}
+
+		state, err := syncshared.LoadManagedState(target.StatePath)
+		if err != nil {
+			dr.Status = StatusError
+			dr.Issue = fmt.Sprintf("read managed state: %v", err)
+			reports = append(reports, dr)
+			continue
+		}
+		if len(state) == 0 {
+			continue
+		}
+
+		plan, err := target.Adapter.Sync(manifests, clients.SyncOptions{
+			ConfigPath: target.ConfigPath,
+			StatePath:  target.StatePath,
+			Scope:      target.Scope,
+			DryRun:     true,
+		})
+		if err != nil {
+			dr.Status = StatusError
+			dr.Issue = fmt.Sprintf("compute sync plan: %v", err)
+			reports = append(reports, dr)
+			continue
+		}
+
+		dr.ConfigPath = plan.ConfigPath
+		dr.Stale = append([]string(nil), plan.Updated...)
+		for _, name := range plan.Added {
+			if _, managed := state[name]; managed {
+				dr.Missing = append(dr.Missing, name)
+			}
+		}
+		dr.Orphaned = append([]string(nil), plan.Removed...)
+		if len(dr.Stale)+len(dr.Missing)+len(dr.Orphaned) > 0 {
+			dr.Status = StatusWarning
+		}
+		reports = append(reports, dr)
+	}
+	return reports
 }
 
 func summarize(report Report) Summary {
@@ -148,6 +238,13 @@ func summarize(report Report) Summary {
 		if cc.Status == StatusError {
 			summary.Error++
 		} else if cc.Status == StatusWarning {
+			summary.Warning++
+		}
+	}
+	for _, dr := range report.Drift {
+		if dr.Status == StatusError {
+			summary.Error++
+		} else if dr.Status == StatusWarning {
 			summary.Warning++
 		}
 	}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -304,6 +304,9 @@ func TestRunDriftDetection(t *testing.T) {
 		{Name: "stale-server", Command: commandPath, Args: []string{"--v2"}, Enabled: true, Clients: []string{"claude-code"}},
 		{Name: "missing-server", Command: commandPath, Enabled: true, Clients: []string{"claude-code"}},
 		{Name: "orphan-server", Command: commandPath, Enabled: false, Clients: []string{"claude-code"}},
+		// Enabled but unsyncable: the sync command filters it out, so the
+		// real plan removes its managed entry — drift must agree.
+		{Name: "unsync-server", Command: filepath.Join(tmp, "missing-bin"), Enabled: true, Clients: []string{"claude-code"}},
 	}
 	for _, manifest := range manifests {
 		if err := store.Save(manifest); err != nil {
@@ -315,7 +318,8 @@ func TestRunDriftDetection(t *testing.T) {
 	config := `{
   "mcpServers": {
     "stale-server": {"command": "` + commandPath + `", "args": ["--v1"]},
-    "orphan-server": {"command": "` + commandPath + `"}
+    "orphan-server": {"command": "` + commandPath + `"},
+    "unsync-server": {"command": "` + commandPath + `"}
   }
 }
 `
@@ -327,7 +331,7 @@ func TestRunDriftDetection(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
 		t.Fatalf("create state dir: %v", err)
 	}
-	state := `{"version":2,"managed_servers":{"stale-server":["standalone"],"missing-server":["standalone"],"orphan-server":["standalone"]}}`
+	state := `{"version":2,"managed_servers":{"stale-server":["standalone"],"missing-server":["standalone"],"orphan-server":["standalone"],"unsync-server":["standalone"]}}`
 	if err := os.WriteFile(statePath, []byte(state), 0o644); err != nil {
 		t.Fatalf("write state fixture: %v", err)
 	}
@@ -362,10 +366,62 @@ func TestRunDriftDetection(t *testing.T) {
 	if len(dr.Missing) != 1 || dr.Missing[0] != "missing-server" {
 		t.Fatalf("expected missing-server missing, got: %#v", dr)
 	}
-	if len(dr.Orphaned) != 1 || dr.Orphaned[0] != "orphan-server" {
-		t.Fatalf("expected orphan-server orphaned, got: %#v", dr)
+	if len(dr.Orphaned) != 2 || dr.Orphaned[0] != "orphan-server" || dr.Orphaned[1] != "unsync-server" {
+		t.Fatalf("expected orphan-server and unsync-server orphaned, got: %#v", dr)
 	}
 	if report.Summary.Warning < 1 {
 		t.Fatalf("expected drift to count as warning, got summary: %#v", report.Summary)
+	}
+}
+
+func TestRunDriftSkippedOnManifestErrors(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix fixture mode bits are used in this test")
+	}
+	tmp := t.TempDir()
+	store := registry.NewStore(filepath.Join(tmp, "servers"))
+	commandPath := writeTestExecutable(t, tmp, "drift-mcp")
+
+	if err := store.Save(registry.Manifest{
+		Name:    "healthy",
+		Command: commandPath,
+		Enabled: true,
+		Clients: []string{"claude-code"},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "servers", "broken.toml"), []byte("not = valid {"), 0o644); err != nil {
+		t.Fatalf("write broken manifest: %v", err)
+	}
+
+	configPath := filepath.Join(tmp, ".mcp.json")
+	if err := os.WriteFile(configPath, []byte(`{"mcpServers":{}}`), 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+	statePath := filepath.Join(tmp, "state", "claude-code-managed.json")
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
+		t.Fatalf("create state dir: %v", err)
+	}
+	if err := os.WriteFile(statePath, []byte(`{"version":2,"managed_servers":{"healthy":["standalone"]}}`), 0o644); err != nil {
+		t.Fatalf("write state fixture: %v", err)
+	}
+
+	adapter := claudecode.Adapter{}
+	report, err := Run(store, Options{
+		Adapters:            []clients.ClientAdapter{adapter},
+		ConfigPathOverrides: map[string]string{"claude-code": configPath},
+		DriftTargets: []DriftTarget{
+			{Adapter: adapter, StatePath: statePath, ConfigPath: configPath},
+		},
+	})
+	if err != nil {
+		t.Fatalf("doctor run failed: %v", err)
+	}
+
+	if len(report.ManifestErrors) == 0 {
+		t.Fatalf("expected manifest error to be reported")
+	}
+	if len(report.Drift) != 0 {
+		t.Fatalf("expected drift to be skipped while manifests fail to parse, got: %#v", report.Drift)
 	}
 }

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/ankitvg/madari/internal/clients"
+	"github.com/ankitvg/madari/internal/clients/claudecode"
 	"github.com/ankitvg/madari/internal/registry"
 )
 
@@ -289,4 +290,82 @@ func writeTestExecutable(t *testing.T, dir, name string) string {
 		t.Fatalf("write test executable: %v", err)
 	}
 	return path
+}
+
+func TestRunDriftDetection(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix fixture mode bits are used in this test")
+	}
+	tmp := t.TempDir()
+	store := registry.NewStore(filepath.Join(tmp, "servers"))
+	commandPath := writeTestExecutable(t, tmp, "drift-mcp")
+
+	manifests := []registry.Manifest{
+		{Name: "stale-server", Command: commandPath, Args: []string{"--v2"}, Enabled: true, Clients: []string{"claude-code"}},
+		{Name: "missing-server", Command: commandPath, Enabled: true, Clients: []string{"claude-code"}},
+		{Name: "orphan-server", Command: commandPath, Enabled: false, Clients: []string{"claude-code"}},
+	}
+	for _, manifest := range manifests {
+		if err := store.Save(manifest); err != nil {
+			t.Fatalf("save manifest %s: %v", manifest.Name, err)
+		}
+	}
+
+	configPath := filepath.Join(tmp, ".mcp.json")
+	config := `{
+  "mcpServers": {
+    "stale-server": {"command": "` + commandPath + `", "args": ["--v1"]},
+    "orphan-server": {"command": "` + commandPath + `"}
+  }
+}
+`
+	if err := os.WriteFile(configPath, []byte(config), 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	statePath := filepath.Join(tmp, "state", "claude-code-managed.json")
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
+		t.Fatalf("create state dir: %v", err)
+	}
+	state := `{"version":2,"managed_servers":{"stale-server":["standalone"],"missing-server":["standalone"],"orphan-server":["standalone"]}}`
+	if err := os.WriteFile(statePath, []byte(state), 0o644); err != nil {
+		t.Fatalf("write state fixture: %v", err)
+	}
+
+	emptyStatePath := filepath.Join(tmp, "state", "claude-code-user-managed.json")
+
+	adapter := claudecode.Adapter{}
+	report, err := Run(store, Options{
+		Adapters: []clients.ClientAdapter{adapter},
+		ConfigPathOverrides: map[string]string{
+			"claude-code": configPath,
+		},
+		DriftTargets: []DriftTarget{
+			{Adapter: adapter, StatePath: statePath, ConfigPath: configPath},
+			{Adapter: adapter, Scope: clients.ScopeUser, StatePath: emptyStatePath},
+		},
+	})
+	if err != nil {
+		t.Fatalf("doctor run failed: %v", err)
+	}
+
+	if len(report.Drift) != 1 {
+		t.Fatalf("expected one drift report (empty-state target skipped), got: %#v", report.Drift)
+	}
+	dr := report.Drift[0]
+	if dr.Status != StatusWarning {
+		t.Fatalf("expected drift warning, got: %#v", dr)
+	}
+	if len(dr.Stale) != 1 || dr.Stale[0] != "stale-server" {
+		t.Fatalf("expected stale-server stale, got: %#v", dr)
+	}
+	if len(dr.Missing) != 1 || dr.Missing[0] != "missing-server" {
+		t.Fatalf("expected missing-server missing, got: %#v", dr)
+	}
+	if len(dr.Orphaned) != 1 || dr.Orphaned[0] != "orphan-server" {
+		t.Fatalf("expected orphan-server orphaned, got: %#v", dr)
+	}
+	if report.Summary.Warning < 1 {
+		t.Fatalf("expected drift to count as warning, got summary: %#v", report.Summary)
+	}
 }

--- a/internal/registry/manifest.go
+++ b/internal/registry/manifest.go
@@ -37,9 +37,11 @@ type SecretEnv struct {
 
 // HasSecretValue reports whether the manifest carries a static env value for
 // any key marked secret — the case placement policy must guard against.
+// Keys are trimmed to match Validate, which accepts padded secret_env
+// entries; an untrimmed lookup here would fail open and leak the value.
 func (m Manifest) HasSecretValue() bool {
 	for _, key := range m.SecretEnv.Keys {
-		if _, exists := m.Env[key]; exists {
+		if _, exists := m.Env[strings.TrimSpace(key)]; exists {
 			return true
 		}
 	}

--- a/internal/registry/manifest.go
+++ b/internal/registry/manifest.go
@@ -21,11 +21,29 @@ type Manifest struct {
 	Description string            `toml:"description,omitempty" json:"description,omitempty"`
 	Env         map[string]string `toml:"env,omitempty" json:"env,omitempty"`
 	RequiredEnv RequiredEnv       `toml:"required_env,omitempty" json:"required_env,omitempty"`
+	SecretEnv   SecretEnv         `toml:"secret_env,omitempty" json:"secret_env,omitempty"`
 }
 
 // RequiredEnv describes environment variables that must be present at runtime.
 type RequiredEnv struct {
 	Keys []string `toml:"keys,omitempty" json:"keys,omitempty"`
+}
+
+// SecretEnv marks environment variable keys whose values are secrets and must
+// never be materialized into repo-scoped client configs.
+type SecretEnv struct {
+	Keys []string `toml:"keys,omitempty" json:"keys,omitempty"`
+}
+
+// HasSecretValue reports whether the manifest carries a static env value for
+// any key marked secret — the case placement policy must guard against.
+func (m Manifest) HasSecretValue() bool {
+	for _, key := range m.SecretEnv.Keys {
+		if _, exists := m.Env[key]; exists {
+			return true
+		}
+	}
+	return false
 }
 
 // HasClient reports whether target appears in the manifest's client list.
@@ -95,6 +113,20 @@ func (m Manifest) Validate() error {
 			continue
 		}
 		seenRequired[key] = struct{}{}
+	}
+
+	seenSecret := map[string]struct{}{}
+	for _, key := range m.SecretEnv.Keys {
+		key = strings.TrimSpace(key)
+		if !envKeyPattern.MatchString(key) {
+			errs = append(errs, fmt.Sprintf("invalid secret_env key %q", key))
+			continue
+		}
+		if _, exists := seenSecret[key]; exists {
+			errs = append(errs, fmt.Sprintf("duplicate secret_env key %q", key))
+			continue
+		}
+		seenSecret[key] = struct{}{}
 	}
 
 	if len(errs) > 0 {

--- a/internal/registry/manifest_test.go
+++ b/internal/registry/manifest_test.go
@@ -75,6 +75,20 @@ func TestManifestValidateErrors(t *testing.T) {
 			},
 			expects: "duplicate required_env key",
 		},
+		{
+			name: "duplicate secret_env keys",
+			mutate: func(m *Manifest) {
+				m.SecretEnv.Keys = []string{"FOO", "FOO"}
+			},
+			expects: "duplicate secret_env key",
+		},
+		{
+			name: "invalid secret_env key",
+			mutate: func(m *Manifest) {
+				m.SecretEnv.Keys = []string{"not-valid"}
+			},
+			expects: "invalid secret_env key",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/registry/parser.go
+++ b/internal/registry/parser.go
@@ -12,6 +12,7 @@ const (
 	sectionTop         = ""
 	sectionEnv         = "env"
 	sectionRequiredEnv = "required_env"
+	sectionSecretEnv   = "secret_env"
 )
 
 // ParseManifest parses a constrained TOML manifest format and rejects unknown fields.
@@ -45,7 +46,7 @@ func ParseManifest(data []byte) (Manifest, error) {
 			}
 			name := strings.TrimSpace(line[1 : len(line)-1])
 			switch name {
-			case sectionEnv, sectionRequiredEnv:
+			case sectionEnv, sectionRequiredEnv, sectionSecretEnv:
 				section = name
 			default:
 				return Manifest{}, fmt.Errorf("line %d: unknown section %q", lineNo, name)
@@ -78,6 +79,15 @@ func ParseManifest(data []byte) (Manifest, error) {
 				return Manifest{}, fmt.Errorf("line %d: invalid required_env keys: %w", lineNo, err)
 			}
 			m.RequiredEnv.Keys = arr
+		case sectionSecretEnv:
+			if key != "keys" {
+				return Manifest{}, fmt.Errorf("line %d: unknown key %q in [secret_env]", lineNo, key)
+			}
+			arr, err := parseStringArray(value)
+			if err != nil {
+				return Manifest{}, fmt.Errorf("line %d: invalid secret_env keys: %w", lineNo, err)
+			}
+			m.SecretEnv.Keys = arr
 		default:
 			return Manifest{}, fmt.Errorf("line %d: unknown parse section", lineNo)
 		}
@@ -126,6 +136,13 @@ func MarshalManifest(m Manifest) ([]byte, error) {
 		keys := append([]string(nil), m.RequiredEnv.Keys...)
 		sort.Strings(keys)
 		b.WriteString("\n[required_env]\n")
+		fmt.Fprintf(&b, "keys = %s\n", formatStringArray(keys))
+	}
+
+	if len(m.SecretEnv.Keys) > 0 {
+		keys := append([]string(nil), m.SecretEnv.Keys...)
+		sort.Strings(keys)
+		b.WriteString("\n[secret_env]\n")
 		fmt.Fprintf(&b, "keys = %s\n", formatStringArray(keys))
 	}
 

--- a/internal/registry/parser_test.go
+++ b/internal/registry/parser_test.go
@@ -120,6 +120,73 @@ unexpected = ["MISSING_KEY"]
 	}
 }
 
+func TestParseManifestSecretEnvRoundTrip(t *testing.T) {
+	in := Manifest{
+		Name:        "stewreads",
+		Command:     "stewreads-mcp",
+		Args:        []string{},
+		Enabled:     true,
+		Clients:     []string{"claude-desktop"},
+		Env: map[string]string{
+			"STEWREADS_API_KEY": "shhh",
+		},
+		SecretEnv: SecretEnv{Keys: []string{"STEWREADS_API_KEY"}},
+	}
+
+	encoded, err := MarshalManifest(in)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	if !strings.Contains(string(encoded), "[secret_env]") {
+		t.Fatalf("expected [secret_env] section in output, got:\n%s", encoded)
+	}
+
+	out, err := ParseManifest(encoded)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if len(out.SecretEnv.Keys) != 1 || out.SecretEnv.Keys[0] != "STEWREADS_API_KEY" {
+		t.Fatalf("expected secret_env keys to survive roundtrip, got: %#v", out.SecretEnv.Keys)
+	}
+	if !out.HasSecretValue() {
+		t.Fatalf("expected HasSecretValue for secret key with static env value")
+	}
+}
+
+func TestParseManifestRejectsUnknownSecretEnvKey(t *testing.T) {
+	manifest := `
+name = "stewreads"
+command = "/usr/local/bin/stewreads-mcp"
+args = []
+enabled = true
+clients = ["claude-desktop"]
+
+[secret_env]
+unexpected = ["STEWREADS_API_KEY"]
+`
+
+	_, err := ParseManifest([]byte(manifest))
+	if err == nil {
+		t.Fatalf("expected parse error for unknown secret_env key")
+	}
+	if !strings.Contains(err.Error(), "unknown key") || !strings.Contains(err.Error(), "[secret_env]") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHasSecretValueFalseWithoutStaticValue(t *testing.T) {
+	manifest := Manifest{
+		Name:      "stewreads",
+		Command:   "stewreads-mcp",
+		Enabled:   true,
+		Clients:   []string{"claude-desktop"},
+		SecretEnv: SecretEnv{Keys: []string{"STEWREADS_API_KEY"}},
+	}
+	if manifest.HasSecretValue() {
+		t.Fatalf("expected no secret value when [env] carries none")
+	}
+}
+
 func TestParseManifestRejectsMalformedStringArrays(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/internal/registry/parser_test.go
+++ b/internal/registry/parser_test.go
@@ -174,6 +174,25 @@ unexpected = ["STEWREADS_API_KEY"]
 	}
 }
 
+func TestHasSecretValueTrimsPaddedKeys(t *testing.T) {
+	manifest := Manifest{
+		Name:    "stewreads",
+		Command: "stewreads-mcp",
+		Enabled: true,
+		Clients: []string{"claude-code"},
+		Env: map[string]string{
+			"STEWREADS_API_KEY": "shhh",
+		},
+		SecretEnv: SecretEnv{Keys: []string{" STEWREADS_API_KEY "}},
+	}
+	if err := manifest.Validate(); err != nil {
+		t.Fatalf("expected padded secret_env key to validate, got: %v", err)
+	}
+	if !manifest.HasSecretValue() {
+		t.Fatalf("expected padded secret_env key to match its env value")
+	}
+}
+
 func TestHasSecretValueFalseWithoutStaticValue(t *testing.T) {
 	manifest := Manifest{
 		Name:      "stewreads",

--- a/internal/registry/snapshot.go
+++ b/internal/registry/snapshot.go
@@ -171,5 +171,13 @@ func manifestsEqual(a, b Manifest) bool {
 	bReq := append([]string(nil), b.RequiredEnv.Keys...)
 	sort.Strings(aReq)
 	sort.Strings(bReq)
-	return slices.Equal(aReq, bReq)
+	if !slices.Equal(aReq, bReq) {
+		return false
+	}
+
+	aSecret := append([]string(nil), a.SecretEnv.Keys...)
+	bSecret := append([]string(nil), b.SecretEnv.Keys...)
+	sort.Strings(aSecret)
+	sort.Strings(bSecret)
+	return slices.Equal(aSecret, bSecret)
 }


### PR DESCRIPTION
v0.1.5 groundwork from the Rings release plan (next_actions 4–5). Structured as **four self-contained commits, each test-green on its own**, in dependency order — reviewable commit by commit:

## Commit 1 — `registry: add secret_env manifest section`
`[secret_env] keys = [...]` mirrors `[required_env]` through the strict parser, deterministic marshaler, validation, and snapshot equality. `Manifest.HasSecretValue` reports when a static `[env]` value exists for a secret key — the case the placement policy guards. Spec documented in `docs/manifest-spec.md`.

## Commit 2 — `sync: refuse secret env values in repo-scoped configs; add user scope`
- `madari sync claude-code --scope user` targets the user-scoped `~/.claude.json`; default stays the repo-scoped project `.mcp.json`. **Scope is declared, never inferred from paths** (the plan's fail-closed answer to the scope-detection risk); unknown values are rejected.
- At project scope, secret-bearing entries are **refused per entry**: excluded from the desired set, reported via `SyncResult.Refused` + a stderr warning with guidance, while other servers sync normally. A previously materialized secret entry is **scrubbed** from the repo file on the next sync.
- Each scope tracks managed entries in its **own state file** so removals in one scope never orphan entries in the other; `list` unions sources across both.
- `add`/`install` gain `--secret-env`; `sync --json` gains a `refused` array.

Design note for review: I initially built whole-sync refusal (hard error) and reworked it — one secret-bearing server would have permanently blocked project-scope syncs of unrelated servers, and doctor's drift dry-runs would have false-positived. Per-entry refusal matches the plan's wording ("refuses to write secret-bearing *entries*") and composes with mixed setups.

## Commit 3 — `doctor/status: detect drift between manifests and client configs`
For every managed-state/config pair with ≥1 managed entry, doctor reads the adapter's **dry-run sync plan** and reports `stale` (materialized value differs), `missing` (deleted from client config), and `orphaned` (no longer desired) — each with the exact `madari sync …` command that reconciles it. Reusing the plan keeps drift consistent with sync by construction; targets without managed entries are skipped (no ownership, nothing to drift). Drift is warning-level and never flips the exit code; plan errors (unmanaged conflicts) surface as error-level issues. `status`/`doctor --json` gain a `drift` array (backward-compatible addition, documented).

Known limitation: `--client-config claude-code=<path>` overrides the project-scope config only; user-scope drift always checks the default `~/.claude.json`. Right for real usage, but flag it if you want an override key.

## Commit 4 — `docs: record launcher-shim rejection as ADR-002`
ADR-002 records why madari stays out of the launch path (survivability, transparency, mux-shaped costs without mux payoffs), with revisit trigger = a multiplexer design. Architecture doc aligned: drift is now implemented, secrets safety rules added, materialized-sync-only stated.

## Tests
- `go test -count=1 ./...` and `go vet ./...` green at every commit and on the branch head.
- New coverage: secret_env parse/marshal/validation round-trips; per-entry refusal, secret scrub, user-scope materialization, unknown-scope rejection (adapter); CLI scope validation + end-to-end secret placement flow; doctor drift unit test (stale/missing/orphaned + empty-state skip) and CLI drift flow with JSON key-set assertions.
- Manual smoke: refusal+guidance with no secret leaked to the repo file, user-scope routing, independent per-scope drift lines with fix hints.

**Per request: PR only — not merging.** After your review/merge, I'll cut the v0.1.5 tag with release notes on your go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)