### PR TITLE
sync: preserve unmanaged config entries' JSON values

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ go test ./...
 ## Architecture
 
 - Reads registry state, writes client configs; no daemon or proxy
-- Only touches entries Madari registered; leaves everything else alone
+- Only touches entries Madari registered; everything else keeps its JSON value, including fields and server shapes Madari does not model
 - Backup + atomic write on every sync; skips invalid entries rather than aborting
 - `doctor` and `status` for diagnostics
 - Supports `uv` and `npm` package manager installs, plus manual `add` for any runtime/framework

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,6 +44,10 @@
 ## Safety Model
 
 - Never overwrite unknown config blocks.
+- Entries Madari does not manage keep their JSON value, including fields and
+  server shapes Madari does not model (e.g. `type`/`url` remote entries);
+  only managed or newly added entries are serialized from manifests. The
+  enclosing document is reformatted on write.
 - Keep managed entries isolated via per-target managed state tracking files
   (per scope for clients with both repo- and user-scoped configs).
 - Never adopt pre-existing entries Madari did not create, even when their

--- a/internal/clients/claude-desktop/sync.go
+++ b/internal/clients/claude-desktop/sync.go
@@ -37,7 +37,7 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 		return SyncResult{}, err
 	}
 
-	root, existingServers, configExists, err := loadClaudeConfig(configPath)
+	root, rawServers, existingServers, configExists, err := loadClaudeConfig(configPath)
 	if err != nil {
 		return SyncResult{}, err
 	}
@@ -58,12 +58,28 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 		return result, nil
 	}
 
-	mutated := copyServers(existingServers)
+	// Rebuild from the raw entries so anything madari does not write keeps
+	// its JSON value, including fields and server shapes madari does not
+	// model. Only entries madari owns (managed) or introduces are serialized.
+	mutated := make(map[string]json.RawMessage, len(rawServers)+len(desiredServers))
+	for name, raw := range rawServers {
+		mutated[name] = raw
+	}
 	for _, name := range result.Removed {
 		delete(mutated, name)
 	}
 	for name, server := range desiredServers {
-		mutated[name] = server
+		if _, exists := rawServers[name]; exists && len(managedState[name]) == 0 {
+			// Unmanaged entry whose values equal the manifest (buildPlan
+			// guarantees, else it errored as a conflict): no adoption, no
+			// rewrite — its JSON value stays untouched.
+			continue
+		}
+		entryPayload, err := json.Marshal(server)
+		if err != nil {
+			return SyncResult{}, fmt.Errorf("marshal server %q: %w", name, err)
+		}
+		mutated[name] = entryPayload
 	}
 
 	updatedRoot := make(map[string]json.RawMessage, len(root)+1)
@@ -187,49 +203,43 @@ func equalServer(a, b serverConfig) bool {
 	return true
 }
 
-func loadClaudeConfig(path string) (map[string]json.RawMessage, map[string]serverConfig, bool, error) {
+// loadClaudeConfig returns the config root plus two views of mcpServers:
+// the raw JSON per entry (preserved verbatim for entries madari does not
+// write) and the typed view used for planning.
+func loadClaudeConfig(path string) (map[string]json.RawMessage, map[string]json.RawMessage, map[string]serverConfig, bool, error) {
 	payload, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return map[string]json.RawMessage{}, map[string]serverConfig{}, false, nil
+			return map[string]json.RawMessage{}, map[string]json.RawMessage{}, map[string]serverConfig{}, false, nil
 		}
-		return nil, nil, false, fmt.Errorf("read Claude config %q: %w", path, err)
+		return nil, nil, nil, false, fmt.Errorf("read Claude config %q: %w", path, err)
 	}
 
 	root := map[string]json.RawMessage{}
 	if err := json.Unmarshal(payload, &root); err != nil {
-		return nil, nil, true, fmt.Errorf("parse Claude config JSON: %w", err)
+		return nil, nil, nil, true, fmt.Errorf("parse Claude config JSON: %w", err)
 	}
 
-	servers := map[string]serverConfig{}
+	rawServers := map[string]json.RawMessage{}
 	if raw, exists := root["mcpServers"]; exists {
-		if err := json.Unmarshal(raw, &servers); err != nil {
-			return nil, nil, true, fmt.Errorf("parse mcpServers: %w", err)
+		if err := json.Unmarshal(raw, &rawServers); err != nil {
+			return nil, nil, nil, true, fmt.Errorf("parse mcpServers: %w", err)
 		}
 	}
-	if servers == nil {
-		servers = map[string]serverConfig{}
+	if rawServers == nil {
+		rawServers = map[string]json.RawMessage{}
 	}
 
-	return root, servers, true, nil
-}
-
-func copyServers(in map[string]serverConfig) map[string]serverConfig {
-	out := make(map[string]serverConfig, len(in))
-	for name, server := range in {
-		clone := serverConfig{Command: server.Command}
-		if len(server.Args) > 0 {
-			clone.Args = append([]string(nil), server.Args...)
+	servers := make(map[string]serverConfig, len(rawServers))
+	for name, raw := range rawServers {
+		entry := serverConfig{}
+		if err := json.Unmarshal(raw, &entry); err != nil {
+			return nil, nil, nil, true, fmt.Errorf("parse mcpServers entry %q: %w", name, err)
 		}
-		if len(server.Env) > 0 {
-			clone.Env = map[string]string{}
-			for key, value := range server.Env {
-				clone.Env[key] = value
-			}
-		}
-		out[name] = clone
+		servers[name] = entry
 	}
-	return out
+
+	return root, rawServers, servers, true, nil
 }
 
 type serverConfig struct {

--- a/internal/clients/claude-desktop/sync_test.go
+++ b/internal/clients/claude-desktop/sync_test.go
@@ -437,6 +437,124 @@ func TestSyncMigratesV1ManagedStateToV2(t *testing.T) {
 	}
 }
 
+func TestSyncPreservesUnmanagedEntryFieldsAndShapes(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "claude_desktop_config.json")
+	statePath := filepath.Join(tmp, "state", "claude-desktop-managed.json")
+
+	config := []byte(`{
+  "mcpServers": {
+    "hand-managed": {
+      "command": "/bin/echo",
+      "note": "hand-managed metadata"
+    },
+    "remote-sse": {
+      "type": "sse",
+      "url": "https://example.com/mcp"
+    }
+  }
+}
+`)
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	assertPreserved := func(servers map[string]map[string]any) {
+		t.Helper()
+		if servers["hand-managed"]["note"] != "hand-managed metadata" {
+			t.Fatalf("expected unmanaged entry to keep unmodeled field, got: %#v", servers["hand-managed"])
+		}
+		remote := servers["remote-sse"]
+		if remote["type"] != "sse" || remote["url"] != "https://example.com/mcp" {
+			t.Fatalf("expected remote entry shape to survive, got: %#v", remote)
+		}
+		if _, injected := remote["command"]; injected {
+			t.Fatalf("expected no injected command on remote entry, got: %#v", remote)
+		}
+	}
+
+	result, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync apply failed: %v", err)
+	}
+	if len(result.Added) != 1 || result.Added[0] != "stewreads" {
+		t.Fatalf("expected stewreads add, got: %+v", result)
+	}
+	servers := readRawServerObjects(t, configPath)
+	if _, ok := servers["stewreads"]; !ok {
+		t.Fatalf("expected stewreads to be materialized")
+	}
+	assertPreserved(servers)
+
+	// Second sync: nothing changes, unmanaged values still intact.
+	result, err = Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("second sync failed: %v", err)
+	}
+	if result.HasChanges() {
+		t.Fatalf("expected no changes on second sync, got: %+v", result)
+	}
+	if len(result.Unchanged) != 1 || result.Unchanged[0] != "stewreads" {
+		t.Fatalf("expected stewreads unchanged, got: %+v", result)
+	}
+	assertPreserved(readRawServerObjects(t, configPath))
+}
+
+func TestSyncKeepsExtraFieldsOnEqualUnmanagedEntry(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "claude_desktop_config.json")
+	statePath := filepath.Join(tmp, "state", "claude-desktop-managed.json")
+
+	// Values equal the stewreads manifest; "note" is hand-added metadata.
+	config := []byte(`{
+  "mcpServers": {
+    "stewreads": {
+      "command": "stewreads-mcp",
+      "env": {
+        "STEWREADS_CONFIG_PATH": "~/.config/stewreads/config.toml"
+      },
+      "note": "mine"
+    }
+  }
+}
+`)
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	result, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync apply failed: %v", err)
+	}
+	if len(result.Unchanged) != 1 || result.Unchanged[0] != "stewreads" {
+		t.Fatalf("expected equal unmanaged entry to be unchanged, got: %+v", result)
+	}
+
+	servers := readRawServerObjects(t, configPath)
+	if servers["stewreads"]["note"] != "mine" {
+		t.Fatalf("expected unadopted equal entry to keep extra fields, got: %#v", servers["stewreads"])
+	}
+}
+
+func readRawServerObjects(t *testing.T, configPath string) map[string]map[string]any {
+	t.Helper()
+	root := readRoot(t, configPath)
+	servers := map[string]map[string]any{}
+	if err := json.Unmarshal(root["mcpServers"], &servers); err != nil {
+		t.Fatalf("parse mcpServers objects: %v", err)
+	}
+	return servers
+}
+
 func readRoot(t *testing.T, configPath string) map[string]json.RawMessage {
 	t.Helper()
 	payload, err := os.ReadFile(configPath)

--- a/internal/clients/claudecode/sync.go
+++ b/internal/clients/claudecode/sync.go
@@ -49,7 +49,7 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 		return SyncResult{}, err
 	}
 
-	root, existingServers, configExists, err := loadClaudeCodeConfig(configPath)
+	root, rawServers, existingServers, configExists, err := loadClaudeCodeConfig(configPath)
 	if err != nil {
 		return SyncResult{}, err
 	}
@@ -71,12 +71,28 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 		return result, nil
 	}
 
-	mutated := copyServers(existingServers)
+	// Rebuild from the raw entries so anything madari does not write keeps
+	// its JSON value, including fields and server shapes madari does not
+	// model. Only entries madari owns (managed) or introduces are serialized.
+	mutated := make(map[string]json.RawMessage, len(rawServers)+len(desiredServers))
+	for name, raw := range rawServers {
+		mutated[name] = raw
+	}
 	for _, name := range result.Removed {
 		delete(mutated, name)
 	}
 	for name, server := range desiredServers {
-		mutated[name] = server
+		if _, exists := rawServers[name]; exists && len(managedState[name]) == 0 {
+			// Unmanaged entry whose values equal the manifest (buildPlan
+			// guarantees, else it errored as a conflict): no adoption, no
+			// rewrite — its JSON value stays untouched.
+			continue
+		}
+		entryPayload, err := json.Marshal(server)
+		if err != nil {
+			return SyncResult{}, fmt.Errorf("marshal server %q: %w", name, err)
+		}
+		mutated[name] = entryPayload
 	}
 
 	updatedRoot := make(map[string]json.RawMessage, len(root)+1)
@@ -234,49 +250,43 @@ func equalServer(a, b serverConfig) bool {
 	return true
 }
 
-func loadClaudeCodeConfig(path string) (map[string]json.RawMessage, map[string]serverConfig, bool, error) {
+// loadClaudeCodeConfig returns the config root plus two views of mcpServers:
+// the raw JSON per entry (preserved verbatim for entries madari does not
+// write) and the typed view used for planning.
+func loadClaudeCodeConfig(path string) (map[string]json.RawMessage, map[string]json.RawMessage, map[string]serverConfig, bool, error) {
 	payload, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return map[string]json.RawMessage{}, map[string]serverConfig{}, false, nil
+			return map[string]json.RawMessage{}, map[string]json.RawMessage{}, map[string]serverConfig{}, false, nil
 		}
-		return nil, nil, false, fmt.Errorf("read Claude Code config %q: %w", path, err)
+		return nil, nil, nil, false, fmt.Errorf("read Claude Code config %q: %w", path, err)
 	}
 
 	root := map[string]json.RawMessage{}
 	if err := json.Unmarshal(payload, &root); err != nil {
-		return nil, nil, true, fmt.Errorf("parse Claude Code config JSON: %w", err)
+		return nil, nil, nil, true, fmt.Errorf("parse Claude Code config JSON: %w", err)
 	}
 
-	servers := map[string]serverConfig{}
+	rawServers := map[string]json.RawMessage{}
 	if raw, exists := root["mcpServers"]; exists {
-		if err := json.Unmarshal(raw, &servers); err != nil {
-			return nil, nil, true, fmt.Errorf("parse mcpServers: %w", err)
+		if err := json.Unmarshal(raw, &rawServers); err != nil {
+			return nil, nil, nil, true, fmt.Errorf("parse mcpServers: %w", err)
 		}
 	}
-	if servers == nil {
-		servers = map[string]serverConfig{}
+	if rawServers == nil {
+		rawServers = map[string]json.RawMessage{}
 	}
 
-	return root, servers, true, nil
-}
-
-func copyServers(in map[string]serverConfig) map[string]serverConfig {
-	out := make(map[string]serverConfig, len(in))
-	for name, server := range in {
-		clone := serverConfig{Command: server.Command}
-		if len(server.Args) > 0 {
-			clone.Args = append([]string(nil), server.Args...)
+	servers := make(map[string]serverConfig, len(rawServers))
+	for name, raw := range rawServers {
+		entry := serverConfig{}
+		if err := json.Unmarshal(raw, &entry); err != nil {
+			return nil, nil, nil, true, fmt.Errorf("parse mcpServers entry %q: %w", name, err)
 		}
-		if len(server.Env) > 0 {
-			clone.Env = map[string]string{}
-			for key, value := range server.Env {
-				clone.Env[key] = value
-			}
-		}
-		out[name] = clone
+		servers[name] = entry
 	}
-	return out
+
+	return root, rawServers, servers, true, nil
 }
 
 type serverConfig struct {

--- a/internal/clients/claudecode/sync_test.go
+++ b/internal/clients/claudecode/sync_test.go
@@ -612,6 +612,124 @@ func TestSyncMigratesV1ManagedStateToV2(t *testing.T) {
 	}
 }
 
+func TestSyncPreservesUnmanagedEntryFieldsAndShapes(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".mcp.json")
+	statePath := filepath.Join(tmp, "state", "claude-code-managed.json")
+
+	config := []byte(`{
+  "mcpServers": {
+    "hand-managed": {
+      "command": "/bin/echo",
+      "note": "hand-managed metadata"
+    },
+    "remote-sse": {
+      "type": "sse",
+      "url": "https://example.com/mcp"
+    }
+  }
+}
+`)
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	assertPreserved := func(servers map[string]map[string]any) {
+		t.Helper()
+		if servers["hand-managed"]["note"] != "hand-managed metadata" {
+			t.Fatalf("expected unmanaged entry to keep unmodeled field, got: %#v", servers["hand-managed"])
+		}
+		remote := servers["remote-sse"]
+		if remote["type"] != "sse" || remote["url"] != "https://example.com/mcp" {
+			t.Fatalf("expected remote entry shape to survive, got: %#v", remote)
+		}
+		if _, injected := remote["command"]; injected {
+			t.Fatalf("expected no injected command on remote entry, got: %#v", remote)
+		}
+	}
+
+	result, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync apply failed: %v", err)
+	}
+	if len(result.Added) != 1 || result.Added[0] != "stewreads" {
+		t.Fatalf("expected stewreads add, got: %+v", result)
+	}
+	servers := readRawServerObjects(t, configPath)
+	if _, ok := servers["stewreads"]; !ok {
+		t.Fatalf("expected stewreads to be materialized")
+	}
+	assertPreserved(servers)
+
+	// Second sync: nothing changes, unmanaged values still intact.
+	result, err = Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("second sync failed: %v", err)
+	}
+	if result.HasChanges() {
+		t.Fatalf("expected no changes on second sync, got: %+v", result)
+	}
+	if len(result.Unchanged) != 1 || result.Unchanged[0] != "stewreads" {
+		t.Fatalf("expected stewreads unchanged, got: %+v", result)
+	}
+	assertPreserved(readRawServerObjects(t, configPath))
+}
+
+func TestSyncKeepsExtraFieldsOnEqualUnmanagedEntry(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".mcp.json")
+	statePath := filepath.Join(tmp, "state", "claude-code-managed.json")
+
+	// Values equal the stewreads manifest; "note" is hand-added metadata.
+	config := []byte(`{
+  "mcpServers": {
+    "stewreads": {
+      "command": "stewreads-mcp",
+      "env": {
+        "STEWREADS_CONFIG_PATH": "~/.config/stewreads/config.toml"
+      },
+      "note": "mine"
+    }
+  }
+}
+`)
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	result, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync apply failed: %v", err)
+	}
+	if len(result.Unchanged) != 1 || result.Unchanged[0] != "stewreads" {
+		t.Fatalf("expected equal unmanaged entry to be unchanged, got: %+v", result)
+	}
+
+	servers := readRawServerObjects(t, configPath)
+	if servers["stewreads"]["note"] != "mine" {
+		t.Fatalf("expected unadopted equal entry to keep extra fields, got: %#v", servers["stewreads"])
+	}
+}
+
+func readRawServerObjects(t *testing.T, configPath string) map[string]map[string]any {
+	t.Helper()
+	root := readRoot(t, configPath)
+	servers := map[string]map[string]any{}
+	if err := json.Unmarshal(root["mcpServers"], &servers); err != nil {
+		t.Fatalf("parse mcpServers objects: %v", err)
+	}
+	return servers
+}
+
 func readRoot(t *testing.T, configPath string) map[string]json.RawMessage {
 	t.Helper()
 	payload, err := os.ReadFile(configPath)


### PR DESCRIPTION
Fixes the P1 from Codex's post-merge review of #39: both adapters decoded every `mcpServers` entry into the typed `serverConfig{Command, Args, Env}` and re-marshaled the whole map on apply, stripping any field madari doesn't model from **unmanaged** entries. Verification found a worse case than the review's example: an unmanaged **remote server entry** (`{"type": "sse", "url": ...}`, no `command`) was flattened to `{"command": ""}` — destroyed by a sync that didn't touch it logically. Both cases violated the documented safety model and were release-blocking for the not-yet-cut v0.1.5 tag.

## The fix
The config is now rebuilt from **raw JSON**: `mutated` starts from the raw `mcpServers` entries, `Removed` names are deleted, and only entries madari owns (managed) or introduces (added) are serialized from manifests. An unmanaged entry whose values equal a manifest (the #36 no-adoption case) is explicitly skipped — previously the desired-write loop overwrote it, dropping its extra fields:

```go
if _, exists := rawServers[name]; exists && len(managedState[name]) == 0 {
    continue // unmanaged + equal — leave its JSON value untouched
}
```

The typed view remains the basis for planning (equality/conflict logic unchanged, dry-run untouched), with identical fail-closed parsing. The precise guarantee — deliberately *not* "byte-for-byte", since `json.MarshalIndent` reformats the enclosing document — is: **unmanaged entries preserve their JSON value, including fields and server shapes madari does not model.**

## Commits
1. `claudecode: preserve unmanaged config entries' JSON values` — adapter + tests
2. `claudedesktop: preserve unmanaged config entries' JSON values` — mirrored adapter + tests
3. `docs: state JSON-value preservation of unmanaged entries` — safety model + README wording

## Tests
- `go test -count=1 ./...` and `go vet ./...` green at every commit and on the branch head.
- New, in both adapter suites: unknown field (`note`) survives apply; remote `type`/`url` entry survives with **no injected empty `command`**, and a second sync reports no changes with values still intact; unmanaged-but-equal entry keeps its extra fields (must not be rewritten at all).
- Manual re-run of the original reproduction: both unmanaged entries preserved, `demo` added, second sync `no changes`.

Pre-existing bug (inherited, not introduced by #39), but fixed before v0.1.5 puts a spotlight on sync safety. **PR only — not merging.** Once merged, the v0.1.5 tag will include this and the release notes will call it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)