### PR TITLE
registry: ring manifest type and store

### DIFF
--- a/docs/manifest-spec.md
+++ b/docs/manifest-spec.md
@@ -58,3 +58,27 @@ keys = ["STEWREADS_GMAIL_APP_PASSWORD"]
 - `clients` must contain unique values.
 - Unknown top-level keys are rejected.
 - Empty `command` is invalid.
+
+## Ring Files
+
+Rings are named capability sets of servers, stored one TOML document per
+ring at `<config-root>/rings/<name>.toml` (sibling of `servers/`).
+
+- `name` (string, required): stable ring ID; same pattern as server names.
+- `members` (array of strings, required, non-empty, unique): server names.
+  Members reference registry entries by name only — rings never embed
+  command, args, or env; the server manifest stays the single source of
+  truth. Every member must exist in the registry when a ring is created or
+  imported.
+- `description` (string, optional): friendly description.
+
+Ring manifests have no sections; unknown keys are rejected. Files are
+written deterministically with sorted members.
+
+### Example
+
+```toml
+name = "research"
+members = ["arxiv", "stewreads"]
+description = "Research helpers"
+```

--- a/internal/registry/ring.go
+++ b/internal/registry/ring.go
@@ -1,0 +1,139 @@
+package registry
+
+import (
+	"bufio"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Ring is a named capability set of MCP servers. Members reference registry
+// entries by name only; rings never embed command, args, or env — the server
+// manifest stays the single source of truth.
+type Ring struct {
+	Name        string   `toml:"name" json:"name"`
+	Members     []string `toml:"members" json:"members"`
+	Description string   `toml:"description,omitempty" json:"description,omitempty"`
+}
+
+// Validate enforces ring-level invariants. Member existence in the registry
+// is a store-level check; the parser cannot see the registry.
+func (r Ring) Validate() error {
+	var errs []string
+
+	if err := validateServerName(r.Name); err != nil {
+		errs = append(errs, err.Error())
+	}
+
+	if len(r.Members) == 0 {
+		errs = append(errs, "at least one member is required")
+	}
+	seen := map[string]struct{}{}
+	for _, member := range r.Members {
+		if err := validateServerName(strings.TrimSpace(member)); err != nil {
+			errs = append(errs, fmt.Sprintf("invalid member %q", member))
+			continue
+		}
+		member = strings.TrimSpace(member)
+		if _, exists := seen[member]; exists {
+			errs = append(errs, fmt.Sprintf("duplicate member %q", member))
+			continue
+		}
+		seen[member] = struct{}{}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("invalid ring: %s", strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+// HasMember reports whether name is a member of the ring.
+func (r Ring) HasMember(name string) bool {
+	name = strings.TrimSpace(name)
+	for _, member := range r.Members {
+		if strings.TrimSpace(member) == name {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseRing parses a constrained TOML ring manifest and rejects unknown
+// fields, mirroring ParseManifest's strictness.
+func ParseRing(data []byte) (Ring, error) {
+	ring := Ring{Members: []string{}}
+
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		line = stripInlineComment(line)
+		if line == "" {
+			continue
+		}
+
+		if strings.HasPrefix(line, "[") {
+			return Ring{}, fmt.Errorf("line %d: ring manifests have no sections", lineNo)
+		}
+
+		key, value, err := splitKeyValue(line)
+		if err != nil {
+			return Ring{}, fmt.Errorf("line %d: %w", lineNo, err)
+		}
+
+		switch key {
+		case "name":
+			sv, err := parseString(value)
+			if err != nil {
+				return Ring{}, fmt.Errorf("line %d: invalid name: %w", lineNo, err)
+			}
+			ring.Name = sv
+		case "members":
+			av, err := parseStringArray(value)
+			if err != nil {
+				return Ring{}, fmt.Errorf("line %d: invalid members: %w", lineNo, err)
+			}
+			ring.Members = av
+		case "description":
+			sv, err := parseString(value)
+			if err != nil {
+				return Ring{}, fmt.Errorf("line %d: invalid description: %w", lineNo, err)
+			}
+			ring.Description = sv
+		default:
+			return Ring{}, fmt.Errorf("line %d: unknown key %q", lineNo, key)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return Ring{}, fmt.Errorf("scan ring manifest: %w", err)
+	}
+
+	if err := ring.Validate(); err != nil {
+		return Ring{}, err
+	}
+	return ring, nil
+}
+
+// MarshalRing renders a deterministic TOML ring manifest with sorted members.
+func MarshalRing(ring Ring) ([]byte, error) {
+	if err := ring.Validate(); err != nil {
+		return nil, err
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "name = %s\n", strconv.Quote(ring.Name))
+	members := append([]string(nil), ring.Members...)
+	sort.Strings(members)
+	fmt.Fprintf(&b, "members = %s\n", formatStringArray(members))
+	if strings.TrimSpace(ring.Description) != "" {
+		fmt.Fprintf(&b, "description = %s\n", strconv.Quote(ring.Description))
+	}
+	return []byte(b.String()), nil
+}

--- a/internal/registry/ring_store.go
+++ b/internal/registry/ring_store.go
@@ -1,0 +1,154 @@
+package registry
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+var ErrRingNotFound = errors.New("ring not found")
+
+// RingsDir returns the on-disk rings directory, a sibling of the servers
+// directory under the same config root.
+func (s *Store) RingsDir() string {
+	return filepath.Join(filepath.Dir(s.serversDir), "rings")
+}
+
+// AddRing inserts a new ring; it fails if the ring already exists or any
+// member is missing from the registry.
+func (s *Store) AddRing(ring Ring) error {
+	if err := ring.Validate(); err != nil {
+		return err
+	}
+	if _, err := s.GetRing(ring.Name); err == nil {
+		return fmt.Errorf("ring %q already exists", ring.Name)
+	} else if !errors.Is(err, ErrRingNotFound) {
+		return err
+	}
+	if err := s.ValidateRingMembers(ring); err != nil {
+		return err
+	}
+	return s.SaveRing(ring)
+}
+
+// SaveRing writes or updates a ring manifest. Shape is validated; member
+// existence is the caller's responsibility (AddRing checks the registry,
+// snapshot import checks snapshot plus registry).
+func (s *Store) SaveRing(ring Ring) error {
+	if err := ring.Validate(); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(s.RingsDir(), 0o755); err != nil {
+		return fmt.Errorf("ensure rings directory: %w", err)
+	}
+
+	path, err := s.pathForRing(ring.Name)
+	if err != nil {
+		return err
+	}
+	payload, err := MarshalRing(ring)
+	if err != nil {
+		return err
+	}
+	if err := writeFileAtomically(path, payload, 0o644); err != nil {
+		return fmt.Errorf("save ring %q: %w", ring.Name, err)
+	}
+	return nil
+}
+
+// GetRing loads one ring by name.
+func (s *Store) GetRing(name string) (Ring, error) {
+	path, err := s.pathForRing(name)
+	if err != nil {
+		return Ring{}, err
+	}
+
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return Ring{}, ErrRingNotFound
+		}
+		return Ring{}, fmt.Errorf("read ring %q: %w", name, err)
+	}
+
+	ring, err := ParseRing(payload)
+	if err != nil {
+		return Ring{}, fmt.Errorf("parse ring %q: %w", name, err)
+	}
+	if ring.Name != name {
+		return Ring{}, fmt.Errorf("ring %q has mismatched name %q", name, ring.Name)
+	}
+	return ring, nil
+}
+
+// ListRings returns all rings sorted by name.
+func (s *Store) ListRings() ([]Ring, error) {
+	entries, err := os.ReadDir(s.RingsDir())
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return []Ring{}, nil
+		}
+		return nil, fmt.Errorf("read rings directory: %w", err)
+	}
+
+	rings := make([]Ring, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".toml" {
+			continue
+		}
+		name := strings.TrimSuffix(entry.Name(), ".toml")
+		ring, err := s.GetRing(name)
+		if err != nil {
+			return nil, err
+		}
+		rings = append(rings, ring)
+	}
+
+	sort.Slice(rings, func(i, j int) bool {
+		return rings[i].Name < rings[j].Name
+	})
+	return rings, nil
+}
+
+// RemoveRing deletes one ring by name.
+func (s *Store) RemoveRing(name string) error {
+	path, err := s.pathForRing(name)
+	if err != nil {
+		return err
+	}
+
+	if err := os.Remove(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return ErrRingNotFound
+		}
+		return fmt.Errorf("remove ring %q: %w", name, err)
+	}
+	return nil
+}
+
+// ValidateRingMembers checks that every ring member exists in the registry.
+func (s *Store) ValidateRingMembers(ring Ring) error {
+	var missing []string
+	for _, member := range ring.Members {
+		if _, err := s.Get(strings.TrimSpace(member)); errors.Is(err, ErrNotFound) {
+			missing = append(missing, member)
+		} else if err != nil {
+			return err
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return fmt.Errorf("ring %q references unknown servers: %s", ring.Name, strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+func (s *Store) pathForRing(name string) (string, error) {
+	if err := validateServerName(name); err != nil {
+		return "", err
+	}
+	return filepath.Join(s.RingsDir(), name+".toml"), nil
+}

--- a/internal/registry/ring_store_test.go
+++ b/internal/registry/ring_store_test.go
@@ -1,0 +1,125 @@
+package registry
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newRingTestStore(t *testing.T) *Store {
+	t.Helper()
+	store := NewStore(filepath.Join(t.TempDir(), "servers"))
+	for _, name := range []string{"stewreads", "arxiv"} {
+		if err := store.Save(Manifest{
+			Name:    name,
+			Command: "/bin/" + name,
+			Enabled: true,
+			Clients: []string{"claude-code"},
+		}); err != nil {
+			t.Fatalf("save manifest %s: %v", name, err)
+		}
+	}
+	return store
+}
+
+func TestRingStoreLifecycle(t *testing.T) {
+	store := newRingTestStore(t)
+
+	ring := Ring{Name: "research", Members: []string{"stewreads", "arxiv"}, Description: "Research helpers"}
+	if err := store.AddRing(ring); err != nil {
+		t.Fatalf("add ring: %v", err)
+	}
+
+	got, err := store.GetRing("research")
+	if err != nil {
+		t.Fatalf("get ring: %v", err)
+	}
+	if got.Name != "research" || len(got.Members) != 2 {
+		t.Fatalf("unexpected ring: %#v", got)
+	}
+
+	rings, err := store.ListRings()
+	if err != nil {
+		t.Fatalf("list rings: %v", err)
+	}
+	if len(rings) != 1 || rings[0].Name != "research" {
+		t.Fatalf("unexpected rings: %#v", rings)
+	}
+
+	if err := store.RemoveRing("research"); err != nil {
+		t.Fatalf("remove ring: %v", err)
+	}
+	if _, err := store.GetRing("research"); !errors.Is(err, ErrRingNotFound) {
+		t.Fatalf("expected ErrRingNotFound after removal, got: %v", err)
+	}
+	if err := store.RemoveRing("research"); !errors.Is(err, ErrRingNotFound) {
+		t.Fatalf("expected ErrRingNotFound for second removal, got: %v", err)
+	}
+}
+
+func TestAddRingRejectsDuplicate(t *testing.T) {
+	store := newRingTestStore(t)
+	ring := Ring{Name: "research", Members: []string{"stewreads"}}
+
+	if err := store.AddRing(ring); err != nil {
+		t.Fatalf("add ring: %v", err)
+	}
+	err := store.AddRing(ring)
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected duplicate error, got: %v", err)
+	}
+}
+
+func TestAddRingRejectsUnknownMembers(t *testing.T) {
+	store := newRingTestStore(t)
+
+	err := store.AddRing(Ring{Name: "research", Members: []string{"stewreads", "ghost", "phantom"}})
+	if err == nil {
+		t.Fatalf("expected unknown-member error")
+	}
+	if !strings.Contains(err.Error(), "unknown servers") ||
+		!strings.Contains(err.Error(), "ghost, phantom") {
+		t.Fatalf("expected sorted unknown member names, got: %v", err)
+	}
+	if _, getErr := store.GetRing("research"); !errors.Is(getErr, ErrRingNotFound) {
+		t.Fatalf("expected no ring written after member validation failure, got: %v", getErr)
+	}
+}
+
+func TestListRingsEmptyWithoutDirectory(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "servers"))
+	rings, err := store.ListRings()
+	if err != nil {
+		t.Fatalf("list rings: %v", err)
+	}
+	if len(rings) != 0 {
+		t.Fatalf("expected no rings, got: %#v", rings)
+	}
+}
+
+func TestGetRingRejectsMismatchedName(t *testing.T) {
+	store := newRingTestStore(t)
+	if err := store.SaveRing(Ring{Name: "research", Members: []string{"stewreads"}}); err != nil {
+		t.Fatalf("save ring: %v", err)
+	}
+	// Rename the file out from under the ring name.
+	oldPath := filepath.Join(store.RingsDir(), "research.toml")
+	newPath := filepath.Join(store.RingsDir(), "renamed.toml")
+	if err := os.Rename(oldPath, newPath); err != nil {
+		t.Fatalf("rename ring file: %v", err)
+	}
+
+	_, err := store.GetRing("renamed")
+	if err == nil || !strings.Contains(err.Error(), "mismatched name") {
+		t.Fatalf("expected mismatched-name error, got: %v", err)
+	}
+}
+
+func TestRingsDirIsSiblingOfServersDir(t *testing.T) {
+	store := NewStore("/tmp/example/servers")
+	if got := store.RingsDir(); got != filepath.Clean("/tmp/example/rings") {
+		t.Fatalf("unexpected rings dir: %s", got)
+	}
+}

--- a/internal/registry/ring_test.go
+++ b/internal/registry/ring_test.go
@@ -1,0 +1,144 @@
+package registry
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseAndMarshalRingRoundTrip(t *testing.T) {
+	in := Ring{
+		Name:        "research",
+		Members:     []string{"stewreads", "arxiv"},
+		Description: "Research helpers",
+	}
+
+	encoded, err := MarshalRing(in)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	out, err := ParseRing(encoded)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if out.Name != "research" || out.Description != "Research helpers" {
+		t.Fatalf("roundtrip mismatch: %#v", out)
+	}
+	if !reflect.DeepEqual(out.Members, []string{"arxiv", "stewreads"}) {
+		t.Fatalf("expected sorted members to survive roundtrip, got: %#v", out.Members)
+	}
+}
+
+func TestMarshalRingIsDeterministic(t *testing.T) {
+	a, err := MarshalRing(Ring{Name: "research", Members: []string{"beta", "alpha"}})
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	b, err := MarshalRing(Ring{Name: "research", Members: []string{"alpha", "beta"}})
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	if string(a) != string(b) {
+		t.Fatalf("expected member order not to affect output:\n%s\nvs\n%s", a, b)
+	}
+
+	expected := "name = \"research\"\nmembers = [\"alpha\", \"beta\"]\n"
+	if string(a) != expected {
+		t.Fatalf("expected deterministic output:\n%s\ngot:\n%s", expected, a)
+	}
+}
+
+func TestParseRingRejectsUnknownKey(t *testing.T) {
+	manifest := `
+name = "research"
+members = ["stewreads"]
+command = "/bin/echo"
+`
+	_, err := ParseRing([]byte(manifest))
+	if err == nil {
+		t.Fatalf("expected parse error for unknown key")
+	}
+	if !strings.Contains(err.Error(), "unknown key") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestParseRingRejectsSections(t *testing.T) {
+	manifest := `
+name = "research"
+members = ["stewreads"]
+
+[env]
+KEY = "value"
+`
+	_, err := ParseRing([]byte(manifest))
+	if err == nil {
+		t.Fatalf("expected parse error for section")
+	}
+	if !strings.Contains(err.Error(), "no sections") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRingValidate(t *testing.T) {
+	base := func() Ring {
+		return Ring{Name: "research", Members: []string{"stewreads"}}
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(*Ring)
+		expects string
+	}{
+		{
+			name:    "empty name",
+			mutate:  func(r *Ring) { r.Name = "" },
+			expects: "name is required",
+		},
+		{
+			name:    "invalid name",
+			mutate:  func(r *Ring) { r.Name = "Bad Name" },
+			expects: "name must match",
+		},
+		{
+			name:    "no members",
+			mutate:  func(r *Ring) { r.Members = nil },
+			expects: "at least one member is required",
+		},
+		{
+			name:    "duplicate members",
+			mutate:  func(r *Ring) { r.Members = []string{"stewreads", "stewreads"} },
+			expects: "duplicate member",
+		},
+		{
+			name:    "invalid member name",
+			mutate:  func(r *Ring) { r.Members = []string{"Not Valid"} },
+			expects: "invalid member",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ring := base()
+			tt.mutate(&ring)
+			err := ring.Validate()
+			if err == nil {
+				t.Fatalf("expected validation error")
+			}
+			if !strings.Contains(err.Error(), tt.expects) {
+				t.Fatalf("expected error containing %q, got: %v", tt.expects, err)
+			}
+		})
+	}
+}
+
+func TestRingHasMember(t *testing.T) {
+	ring := Ring{Name: "research", Members: []string{"stewreads", "arxiv"}}
+	if !ring.HasMember("arxiv") {
+		t.Fatalf("expected arxiv membership")
+	}
+	if ring.HasMember("other") {
+		t.Fatalf("did not expect other membership")
+	}
+}


### PR DESCRIPTION
**PR 1 of 7** in the v0.2.0 Rings plan — registry layer only, no CLI or sync changes. Two commits, each test-green:

## Commit 1 — `registry: add ring manifest type and strict parser`
- `Ring{Name, Members, Description}` — members reference registry entries **by name only**, never embedding command/args/env (artifact decision: the server manifest stays the single source of truth, no per-ring overrides).
- `ParseRing` mirrors `ParseManifest`'s strictness: unknown keys rejected, sections rejected, fail closed. `MarshalRing` is deterministic with sorted members. Ring names share the server-name pattern.
- Validation: name pattern, non-empty/deduped/valid members. Member *existence* is deliberately not a parse concern (the parser can't see the registry) — see commit 2.

## Commit 2 — `registry: add ring store operations`
- `RingsDir()` — `rings/` as a sibling of `servers/` under the config root.
- `AddRing` (duplicate check + member existence via the registry; nothing written on failure), `GetRing` (filename/name mismatch detection, mirroring server manifests), `ListRings` (sorted, tolerates missing dir), `RemoveRing` (`ErrRingNotFound`), `SaveRing` (shape-validated low-level write via the existing atomic-write helper).
- `ValidateRingMembers` exported for the PR-6 snapshot-import path, which validates against snapshot ∪ registry.
- Ring file format documented in `docs/manifest-spec.md`.

## What this deliberately does NOT include
- No `ring` CLI commands (PR 2: create/list/show; PR 6: delete — delete needs the attached-ring guard that only exists after attach/detach lands in PR 4).
- No sync/state/ownership changes (PR 3 is the ownership-vs-materialization engine).

## Tests
- `go test -count=1 ./...` and `go vet ./...` green at both commits.
- New: round-trip + determinism (member order doesn't affect output), unknown-key/section rejection, validation table (name pattern, empty/duplicate/invalid members), store lifecycle, duplicate-ring rejection, unknown-member rejection with sorted names and no partial write, missing-directory tolerance, mismatched-filename detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)