### PR TITLE
cli: ring create, list, and show

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ go install github.com/ankitvg/madari/cmd/madari@latest
 - `madari enable <name>`
 - `madari disable <name>`
 - `madari sync <client> [--dry-run] [--config-path <path>] [--json] [--scope project|user]`
+- `madari ring create <name> --member <server> [--member ...] [--description <text>]`
+- `madari ring list [--json]`
+- `madari ring show <name> [--json]`
 - `madari clients`
 - `madari doctor [--client-config target=path ...] [--json]`
 - `madari status [--client-config target=path ...] [--json]`
@@ -43,7 +46,8 @@ Notes:
 - `sync` skips servers with missing/non-executable command paths and continues syncing others.
 - Manifests can mark secret env keys (`[secret_env]`, or `--secret-env` on `add`/`install`); sync refuses to write their static values into the repo-scoped Claude Code `.mcp.json` — refused entries are reported with guidance (and scrubbed if previously materialized) while other servers sync normally. Use `madari sync claude-code --scope user` to materialize them into the user-scoped `~/.claude.json` instead.
 - `list` shows the managed sources owning each synced entry (`standalone` today; `-` when not synced), and `status` summarizes managed entries per client.
-- `list`, `status`, `doctor`, and `sync --dry-run` accept `--json` for machine-readable output with a versioned schema; schemas and exit codes are documented in `docs/cli-reference.md`.
+- `list`, `status`, `doctor`, `sync --dry-run`, `ring list`, and `ring show` accept `--json` for machine-readable output with a versioned schema; schemas and exit codes are documented in `docs/cli-reference.md`.
+- Rings are named capability sets of servers (`madari ring …`). Members reference registry entries by name — the server manifest stays the single source of truth for command, args, and env.
 - Supported sync clients: `claude-desktop` and `claude-code`.
 - Default sync config paths:
   - `claude-desktop`: platform-specific Claude Desktop config path.

--- a/cmd/madari/json_output.go
+++ b/cmd/madari/json_output.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 
 	"github.com/ankitvg/madari/internal/doctor"
+	"github.com/ankitvg/madari/internal/registry"
 )
 
 // jsonSchemaVersion identifies the envelope version shared by all --json
@@ -119,6 +121,34 @@ type syncJSON struct {
 	Unchanged     []string `json:"unchanged"`
 	Skipped       []string `json:"skipped"`
 	Refused       []string `json:"refused"`
+}
+
+type ringListJSON struct {
+	SchemaVersion int        `json:"schema_version"`
+	Command       string     `json:"command"`
+	Rings         []ringJSON `json:"rings"`
+}
+
+type ringShowJSON struct {
+	SchemaVersion int      `json:"schema_version"`
+	Command       string   `json:"command"`
+	Ring          ringJSON `json:"ring"`
+}
+
+type ringJSON struct {
+	Name        string   `json:"name"`
+	Members     []string `json:"members"`
+	Description string   `json:"description"`
+}
+
+func ringToJSON(ring registry.Ring) ringJSON {
+	members := append([]string(nil), ring.Members...)
+	sort.Strings(members)
+	return ringJSON{
+		Name:        ring.Name,
+		Members:     nonNilStrings(members),
+		Description: ring.Description,
+	}
 }
 
 // writeJSON emits one indented JSON document followed by a newline; --json

--- a/cmd/madari/ring.go
+++ b/cmd/madari/ring.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+func (a cliApp) cmdRing(args []string) error {
+	if len(args) == 0 {
+		return commandUsageError("ring", "madari ring <create> [options]")
+	}
+	if isHelpToken(args[0]) {
+		printRingHelp(a.stdout)
+		return nil
+	}
+
+	sub, rest := args[0], args[1:]
+	switch sub {
+	case "create":
+		return a.cmdRingCreate(rest)
+	default:
+		return commandInputError("ring", fmt.Sprintf("unknown ring subcommand %q (supported: create)", sub))
+	}
+}
+
+func (a cliApp) cmdRingCreate(args []string) error {
+	if len(args) == 0 {
+		return commandUsageError("ring create", "madari ring create <name> --member <server> [--member ...] [--description <text>]")
+	}
+	if isHelpToken(args[0]) {
+		printRingCreateHelp(a.stdout)
+		return nil
+	}
+	name := strings.TrimSpace(args[0])
+
+	fs := flag.NewFlagSet("ring create", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var members stringList
+	var description string
+	fs.Var(&members, "member", "Ring member server name (repeatable)")
+	fs.StringVar(&description, "description", "", "Ring description")
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printRingCreateHelp(a.stdout)
+			return nil
+		}
+		return commandInputError("ring create", err.Error())
+	}
+	if fs.NArg() != 0 {
+		return commandUnexpectedArgsError("ring create", fs.Args())
+	}
+
+	ring := registry.Ring{
+		Name:        name,
+		Members:     append([]string(nil), members...),
+		Description: description,
+	}
+	if err := a.store.AddRing(ring); err != nil {
+		return err
+	}
+	fmt.Fprintf(a.stdout, "created ring %s with %d member(s)\n", name, len(members))
+	return nil
+}
+
+func printRingHelp(out io.Writer) {
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  madari ring <subcommand> [options]")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Subcommands:")
+	fmt.Fprintln(out, "  create    Create a ring from registry servers")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Description:")
+	fmt.Fprintln(out, "  Rings are named capability sets of MCP servers. Members reference")
+	fmt.Fprintln(out, "  registry entries by name; the server manifest stays the single source")
+	fmt.Fprintln(out, "  of truth for command, args, and env.")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Run `madari ring <subcommand> --help` for subcommand help.")
+}
+
+func printRingCreateHelp(out io.Writer) {
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  madari ring create <name> --member <server> [--member ...] [--description <text>]")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Options:")
+	fmt.Fprintln(out, "  --member <server>          Ring member server name (repeatable, required)")
+	fmt.Fprintln(out, "  --description <text>       Ring description")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Description:")
+	fmt.Fprintln(out, "  Create a ring referencing existing registry servers by name. Every")
+	fmt.Fprintln(out, "  member must already exist in the registry.")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Examples:")
+	fmt.Fprintln(out, "  madari ring create research --member stewreads --member arxiv")
+}

--- a/cmd/madari/ring.go
+++ b/cmd/madari/ring.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
 	"github.com/ankitvg/madari/internal/registry"
@@ -12,7 +13,7 @@ import (
 
 func (a cliApp) cmdRing(args []string) error {
 	if len(args) == 0 {
-		return commandUsageError("ring", "madari ring <create> [options]")
+		return commandUsageError("ring", "madari ring <create|list|show> [options]")
 	}
 	if isHelpToken(args[0]) {
 		printRingHelp(a.stdout)
@@ -23,8 +24,12 @@ func (a cliApp) cmdRing(args []string) error {
 	switch sub {
 	case "create":
 		return a.cmdRingCreate(rest)
+	case "list":
+		return a.cmdRingList(rest)
+	case "show":
+		return a.cmdRingShow(rest)
 	default:
-		return commandInputError("ring", fmt.Sprintf("unknown ring subcommand %q (supported: create)", sub))
+		return commandInputError("ring", fmt.Sprintf("unknown ring subcommand %q (supported: create, list, show)", sub))
 	}
 }
 
@@ -67,12 +72,118 @@ func (a cliApp) cmdRingCreate(args []string) error {
 	return nil
 }
 
+func (a cliApp) cmdRingList(args []string) error {
+	if len(args) == 1 && isHelpToken(args[0]) {
+		printRingListHelp(a.stdout)
+		return nil
+	}
+	fs := flag.NewFlagSet("ring list", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var jsonOut bool
+	fs.BoolVar(&jsonOut, "json", false, "Emit JSON instead of text")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printRingListHelp(a.stdout)
+			return nil
+		}
+		return commandInputError("ring list", err.Error())
+	}
+	if fs.NArg() != 0 {
+		return commandUnexpectedArgsError("ring list", fs.Args())
+	}
+
+	rings, err := a.store.ListRings()
+	if err != nil {
+		return err
+	}
+
+	if jsonOut {
+		payload := ringListJSON{
+			SchemaVersion: jsonSchemaVersion,
+			Command:       "ring list",
+			Rings:         make([]ringJSON, 0, len(rings)),
+		}
+		for _, ring := range rings {
+			payload.Rings = append(payload.Rings, ringToJSON(ring))
+		}
+		return writeJSON(a.stdout, payload)
+	}
+
+	if len(rings) == 0 {
+		fmt.Fprintln(a.stdout, "no rings configured")
+		return nil
+	}
+	fmt.Fprintln(a.stdout, "NAME\tMEMBERS\tDESCRIPTION")
+	for _, ring := range rings {
+		members := append([]string(nil), ring.Members...)
+		sort.Strings(members)
+		fmt.Fprintf(a.stdout, "%s\t%s\t%s\n", ring.Name, strings.Join(members, ","), ring.Description)
+	}
+	return nil
+}
+
+func (a cliApp) cmdRingShow(args []string) error {
+	if len(args) == 0 {
+		return commandUsageError("ring show", "madari ring show <name> [--json]")
+	}
+	if isHelpToken(args[0]) {
+		printRingShowHelp(a.stdout)
+		return nil
+	}
+	name := strings.TrimSpace(args[0])
+
+	fs := flag.NewFlagSet("ring show", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var jsonOut bool
+	fs.BoolVar(&jsonOut, "json", false, "Emit JSON instead of text")
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printRingShowHelp(a.stdout)
+			return nil
+		}
+		return commandInputError("ring show", err.Error())
+	}
+	if fs.NArg() != 0 {
+		return commandUnexpectedArgsError("ring show", fs.Args())
+	}
+
+	ring, err := a.store.GetRing(name)
+	if err != nil {
+		if errors.Is(err, registry.ErrRingNotFound) {
+			return fmt.Errorf("ring %q not found", name)
+		}
+		return err
+	}
+
+	if jsonOut {
+		return writeJSON(a.stdout, ringShowJSON{
+			SchemaVersion: jsonSchemaVersion,
+			Command:       "ring show",
+			Ring:          ringToJSON(ring),
+		})
+	}
+
+	fmt.Fprintf(a.stdout, "name: %s\n", ring.Name)
+	if strings.TrimSpace(ring.Description) != "" {
+		fmt.Fprintf(a.stdout, "description: %s\n", ring.Description)
+	}
+	fmt.Fprintln(a.stdout, "members:")
+	members := append([]string(nil), ring.Members...)
+	sort.Strings(members)
+	for _, member := range members {
+		fmt.Fprintf(a.stdout, "  - %s\n", member)
+	}
+	return nil
+}
+
 func printRingHelp(out io.Writer) {
 	fmt.Fprintln(out, "Usage:")
 	fmt.Fprintln(out, "  madari ring <subcommand> [options]")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Subcommands:")
 	fmt.Fprintln(out, "  create    Create a ring from registry servers")
+	fmt.Fprintln(out, "  list      List configured rings")
+	fmt.Fprintln(out, "  show      Show one ring's members")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Description:")
 	fmt.Fprintln(out, "  Rings are named capability sets of MCP servers. Members reference")
@@ -96,4 +207,26 @@ func printRingCreateHelp(out io.Writer) {
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Examples:")
 	fmt.Fprintln(out, "  madari ring create research --member stewreads --member arxiv")
+}
+
+func printRingListHelp(out io.Writer) {
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  madari ring list [--json]")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Options:")
+	fmt.Fprintln(out, "  --json                     Emit JSON instead of text")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Description:")
+	fmt.Fprintln(out, "  List configured rings with members and description.")
+}
+
+func printRingShowHelp(out io.Writer) {
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  madari ring show <name> [--json]")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Options:")
+	fmt.Fprintln(out, "  --json                     Emit JSON instead of text")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Description:")
+	fmt.Fprintln(out, "  Show one ring's members and description.")
 }

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -142,6 +142,8 @@ func (a cliApp) dispatch(args []string) error {
 		return a.cmdImport(args[1:])
 	case "sync":
 		return a.cmdSync(args[1:])
+	case "ring":
+		return a.cmdRing(args[1:])
 	default:
 		return fmt.Errorf("unknown command: %s", args[0])
 	}
@@ -1477,6 +1479,8 @@ func printCommandHelp(command string, out io.Writer) bool {
 		printEnableDisableHelp("disable", out)
 	case "sync":
 		printSyncHelp(out)
+	case "ring":
+		printRingHelp(out)
 	case "clients":
 		printClientsHelp(out)
 	case "doctor":
@@ -1698,6 +1702,7 @@ func printHelp(out io.Writer) {
 	fmt.Fprintln(out, "  enable    Enable a server")
 	fmt.Fprintln(out, "  disable   Disable a server")
 	fmt.Fprintln(out, "  sync      Sync server manifests to a client config")
+	fmt.Fprintln(out, "  ring      Manage rings (named capability sets of servers)")
 	fmt.Fprintln(out, "  clients   List supported clients and config readiness")
 	fmt.Fprintln(out, "  doctor    Run diagnostics on local MCP setup")
 	fmt.Fprintln(out, "  status    Show concise readiness summary")

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -1856,3 +1856,111 @@ func TestRunWithStoreRingDispatch(t *testing.T) {
 		t.Fatalf("expected ring help, got code=%d stdout=%s", result.code, result.stdout)
 	}
 }
+
+func TestRunWithStoreRingListAndShow(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	result := runCmd(store, "ring", "list")
+	if result.code != 0 || !strings.Contains(result.stdout, "no rings configured") {
+		t.Fatalf("expected empty ring list, got code=%d stdout=%s", result.code, result.stdout)
+	}
+
+	for _, name := range []string{"stewreads", "arxiv"} {
+		if result := runCmd(store, "add", name, "--command", commandPath, "--client", "claude-code"); result.code != 0 {
+			t.Fatalf("setup add %s failed: %s", name, result.stderr)
+		}
+	}
+	if result := runCmd(store, "ring", "create", "research", "--member", "stewreads", "--member", "arxiv", "--description", "Research helpers"); result.code != 0 {
+		t.Fatalf("ring create failed: %s", result.stderr)
+	}
+
+	result = runCmd(store, "ring", "list")
+	if result.code != 0 {
+		t.Fatalf("ring list failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "NAME\tMEMBERS\tDESCRIPTION") {
+		t.Fatalf("expected ring list header, got: %s", result.stdout)
+	}
+	if !strings.Contains(result.stdout, "research\tarxiv,stewreads\tResearch helpers") {
+		t.Fatalf("expected ring row with sorted members, got: %s", result.stdout)
+	}
+
+	result = runCmd(store, "ring", "show", "research")
+	if result.code != 0 {
+		t.Fatalf("ring show failed: %s", result.stderr)
+	}
+	for _, want := range []string{"name: research", "description: Research helpers", "  - arxiv", "  - stewreads"} {
+		if !strings.Contains(result.stdout, want) {
+			t.Fatalf("expected %q in ring show output, got: %s", want, result.stdout)
+		}
+	}
+
+	result = runCmd(store, "ring", "show", "ghost")
+	if result.code == 0 || !strings.Contains(result.stderr, `ring "ghost" not found`) {
+		t.Fatalf("expected not-found error, got code=%d stderr=%s", result.code, result.stderr)
+	}
+}
+
+func TestRunWithStoreRingListJSON(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	result := runCmd(store, "ring", "list", "--json")
+	if result.code != 0 {
+		t.Fatalf("ring list --json failed: %s", result.stderr)
+	}
+	expectedEmpty := `{
+  "schema_version": 1,
+  "command": "ring list",
+  "rings": []
+}
+`
+	if result.stdout != expectedEmpty {
+		t.Fatalf("ring list --json schema drift:\nwant:\n%s\ngot:\n%s", expectedEmpty, result.stdout)
+	}
+
+	if result := runCmd(store, "add", "stewreads", "--command", commandPath, "--client", "claude-code"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "ring", "create", "research", "--member", "stewreads"); result.code != 0 {
+		t.Fatalf("ring create failed: %s", result.stderr)
+	}
+
+	result = runCmd(store, "ring", "list", "--json")
+	if result.code != 0 {
+		t.Fatalf("ring list --json failed: %s", result.stderr)
+	}
+	expected := `{
+  "schema_version": 1,
+  "command": "ring list",
+  "rings": [
+    {
+      "name": "research",
+      "members": [
+        "stewreads"
+      ],
+      "description": ""
+    }
+  ]
+}
+`
+	if result.stdout != expected {
+		t.Fatalf("ring list --json schema drift:\nwant:\n%s\ngot:\n%s", expected, result.stdout)
+	}
+
+	result = runCmd(store, "ring", "show", "research", "--json")
+	if result.code != 0 {
+		t.Fatalf("ring show --json failed: %s", result.stderr)
+	}
+	payload := decodeJSONObject(t, result.stdout)
+	assertJSONKeys(t, payload, "schema_version", "command", "ring")
+	if payload["command"] != "ring show" {
+		t.Fatalf("unexpected command field: %v", payload["command"])
+	}
+	ring := payload["ring"].(map[string]any)
+	assertJSONKeys(t, ring, "name", "members", "description")
+	if ring["name"] != "research" {
+		t.Fatalf("unexpected ring payload: %v", ring)
+	}
+}

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -374,6 +374,7 @@ func TestRunHelpSubcommandOutput(t *testing.T) {
 		{name: "help install", args: []string{"help", "install"}, contains: "madari install <package>"},
 		{name: "help add", args: []string{"help", "add"}, contains: "madari add <name>"},
 		{name: "help sync", args: []string{"help", "sync"}, contains: "madari sync <client>"},
+		{name: "help ring", args: []string{"help", "ring"}, contains: "madari ring <subcommand>"},
 		{name: "help list", args: []string{"help", "list"}, contains: "madari list"},
 		{name: "help doctor", args: []string{"help", "doctor"}, contains: "madari doctor"},
 		{name: "help status", args: []string{"help", "status"}, contains: "madari status"},
@@ -1797,5 +1798,61 @@ func TestDeriveServerName(t *testing.T) {
 				t.Fatalf("deriveServerName(%q) = %q, expected %q", tt.packageName, actual, tt.expected)
 			}
 		})
+	}
+}
+
+func TestRunWithStoreRingCreate(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	for _, name := range []string{"stewreads", "arxiv"} {
+		if result := runCmd(store, "add", name, "--command", commandPath, "--client", "claude-code"); result.code != 0 {
+			t.Fatalf("setup add %s failed: %s", name, result.stderr)
+		}
+	}
+
+	result := runCmd(store, "ring", "create", "research", "--member", "stewreads", "--member", "arxiv", "--description", "Research helpers")
+	if result.code != 0 {
+		t.Fatalf("ring create failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "created ring research with 2 member(s)") {
+		t.Fatalf("expected creation confirmation, got: %s", result.stdout)
+	}
+
+	// Duplicate refused.
+	result = runCmd(store, "ring", "create", "research", "--member", "stewreads")
+	if result.code == 0 || !strings.Contains(result.stderr, "already exists") {
+		t.Fatalf("expected duplicate-ring error, got code=%d stderr=%s", result.code, result.stderr)
+	}
+
+	// Unknown member refused.
+	result = runCmd(store, "ring", "create", "broken", "--member", "ghost")
+	if result.code == 0 || !strings.Contains(result.stderr, "unknown servers: ghost") {
+		t.Fatalf("expected unknown-member error, got code=%d stderr=%s", result.code, result.stderr)
+	}
+
+	// Member required.
+	result = runCmd(store, "ring", "create", "empty")
+	if result.code == 0 || !strings.Contains(result.stderr, "at least one member is required") {
+		t.Fatalf("expected member-required error, got code=%d stderr=%s", result.code, result.stderr)
+	}
+}
+
+func TestRunWithStoreRingDispatch(t *testing.T) {
+	store := newTestStore(t)
+
+	result := runCmd(store, "ring")
+	if result.code == 0 || !strings.Contains(result.stderr, "usage: madari ring") {
+		t.Fatalf("expected ring usage error, got code=%d stderr=%s", result.code, result.stderr)
+	}
+
+	result = runCmd(store, "ring", "explode")
+	if result.code == 0 || !strings.Contains(result.stderr, "unknown ring subcommand") {
+		t.Fatalf("expected unknown-subcommand error, got code=%d stderr=%s", result.code, result.stderr)
+	}
+
+	result = runCmd(store, "ring", "--help")
+	if result.code != 0 || !strings.Contains(result.stdout, "madari ring <subcommand>") {
+		t.Fatalf("expected ring help, got code=%d stdout=%s", result.code, result.stdout)
 	}
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -37,6 +37,18 @@ values for `[secret_env]` keys are refused per entry at project scope (other
 servers keep syncing; a previously materialized secret entry is scrubbed)
 and must sync with `--scope user`.
 
+## Rings
+
+```bash
+madari ring create research --member stewreads --member arxiv --description "Research helpers"
+madari ring list
+madari ring show research
+```
+
+Rings are named capability sets of servers stored at
+`<config-root>/rings/<name>.toml` (see the manifest spec). Members reference
+registry entries by name and must exist when the ring is created.
+
 ## Diagnostics
 
 ```bash
@@ -56,17 +68,20 @@ madari import --file madari-snapshot.json --apply
 
 ## JSON Output
 
-`list`, `status`, `doctor`, and `sync --dry-run` accept `--json` and emit a
-single JSON document on stdout with nothing else. Every payload carries the
-envelope fields `schema_version` (currently `1`) and `command`. Field
-additions are backward-compatible; renames or removals bump `schema_version`.
-List-valued fields are always present (empty arrays, never `null`).
+`list`, `status`, `doctor`, `sync --dry-run`, `ring list`, and `ring show`
+accept `--json` and emit a single JSON document on stdout with nothing else.
+Every payload carries the envelope fields `schema_version` (currently `1`)
+and `command`. Field additions are backward-compatible; renames or removals
+bump `schema_version`. List-valued fields are always present (empty arrays,
+never `null`).
 
 ```bash
 madari list --json
 madari status --json
 madari doctor --json
 madari sync claude-code --dry-run --json
+madari ring list --json
+madari ring show research --json
 ```
 
 `sync --json` requires `--dry-run`; the apply-mode output contract is not yet
@@ -197,6 +212,36 @@ itself.
   "unchanged": [],
   "skipped": [],
   "refused": []
+}
+```
+
+`madari ring list --json`:
+
+```json
+{
+  "schema_version": 1,
+  "command": "ring list",
+  "rings": [
+    {
+      "name": "research",
+      "members": ["arxiv", "stewreads"],
+      "description": "Research helpers"
+    }
+  ]
+}
+```
+
+`madari ring show <name> --json` wraps the same ring object:
+
+```json
+{
+  "schema_version": 1,
+  "command": "ring show",
+  "ring": {
+    "name": "research",
+    "members": ["arxiv", "stewreads"],
+    "description": "Research helpers"
+  }
 }
 ```
 


### PR DESCRIPTION
**PR 2 of 7** in the v0.2.0 Rings plan — the first user-facing ring surface, built on the PR-1 registry layer. Three commits, each test-green:

## Commit 1 — `cli: add ring command group with create`
- New `ring` subcommand group in the dispatcher with group/subcommand help and `madari help ring`.
- `ring create <name> --member <server> [--member ...] [--description <text>]` — duplicates, unknown members (store-validated against the registry), and member-less rings are refused.

## Commit 2 — `cli: ring list and show with --json`
- `ring list`: NAME/MEMBERS/DESCRIPTION rows, sorted members, `no rings configured` when empty.
- `ring show <name>`: details view with a friendly not-found error.
- Both take `--json` (schema_version 1 envelope; commands identified as `"ring list"` / `"ring show"`); ring payloads always carry `name`, `members` (sorted, never null), `description`. Golden + key-set tests pin the schemas per the established pattern.

## Commit 3 — `docs: ring create/list/show reference`
README command lines + notes bullet; cli-reference Rings section + JSON schemas.

## Deliberately absent (per the approved plan)
- `ring delete` — waits for the attached-ring guard (PR 6, after attach/detach).
- No sync/state/ownership changes — PR 3 is the ownership-vs-materialization engine with the ordering matrix written first.

## Tests
- `go test -count=1 ./...` + `go vet` green at every commit.
- New: create lifecycle (success, duplicate, unknown member, member-required), dispatch/usage/help coverage (incl. the `help ring` table row), list/show text assertions, JSON goldens (empty + populated list) and key-set checks.
- Manual smoke: create → list → show → `--json | python3 -m json.tool` → deterministic `rings/research.toml` on disk with sorted members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)