### PR TITLE
clients+cli: ring attach/detach with membership reconciliation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ go install github.com/ankitvg/madari/cmd/madari@latest
 - `madari ring create <name> --member <server> [--member ...] [--description <text>]`
 - `madari ring list [--json]`
 - `madari ring show <name> [--json]`
+- `madari ring attach <ring> <client> [--scope project|user] [--dry-run] [--config-path <path>]`
+- `madari ring detach <ring> <client> [--scope project|user] [--dry-run] [--config-path <path>]`
 - `madari clients`
 - `madari doctor [--client-config target=path ...] [--json]`
 - `madari status [--client-config target=path ...] [--json]`
@@ -48,6 +50,7 @@ Notes:
 - `list` shows the managed sources owning each synced entry (`standalone` today; `-` when not synced), and `status` summarizes managed entries per client.
 - `list`, `status`, `doctor`, `sync --dry-run`, `ring list`, and `ring show` accept `--json` for machine-readable output with a versioned schema; schemas and exit codes are documented in `docs/cli-reference.md`.
 - Rings are named capability sets of servers (`madari ring …`). Members reference registry entries by name — the server manifest stays the single source of truth for command, args, and env.
+- `ring attach` records reference-counted ownership (`ring:<name>` sources) and materializes eligible members; `ring detach` releases it, and an entry only leaves the client config when nothing owns it anymore. Overlapping rings and standalone+ring combinations resolve by refcount, in any order. Attaching onto an entry madari does not manage is refused — even when values match.
 - Supported sync clients: `claude-desktop` and `claude-code`.
 - Default sync config paths:
   - `claude-desktop`: platform-specific Claude Desktop config path.

--- a/cmd/madari/ring.go
+++ b/cmd/madari/ring.go
@@ -5,15 +5,19 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"slices"
 	"sort"
 	"strings"
 
+	"github.com/ankitvg/madari/internal/clients"
+	"github.com/ankitvg/madari/internal/clients/claudecode"
+	"github.com/ankitvg/madari/internal/clients/syncshared"
 	"github.com/ankitvg/madari/internal/registry"
 )
 
 func (a cliApp) cmdRing(args []string) error {
 	if len(args) == 0 {
-		return commandUsageError("ring", "madari ring <create|list|show> [options]")
+		return commandUsageError("ring", "madari ring <create|list|show|attach|detach> [options]")
 	}
 	if isHelpToken(args[0]) {
 		printRingHelp(a.stdout)
@@ -28,8 +32,180 @@ func (a cliApp) cmdRing(args []string) error {
 		return a.cmdRingList(rest)
 	case "show":
 		return a.cmdRingShow(rest)
+	case "attach":
+		return a.cmdRingAttach(rest)
+	case "detach":
+		return a.cmdRingDetach(rest)
 	default:
-		return commandInputError("ring", fmt.Sprintf("unknown ring subcommand %q (supported: create, list, show)", sub))
+		return commandInputError("ring", fmt.Sprintf("unknown ring subcommand %q (supported: create, list, show, attach, detach)", sub))
+	}
+}
+
+// parseRingOpArgs parses `<ring> <client> [flags]` shared by attach/detach.
+func (a cliApp) parseRingOpArgs(command string, args []string, usage string, printHelp func(io.Writer)) (ringName, target, configPath, scope string, dryRun bool, err error) {
+	if len(args) == 0 {
+		return "", "", "", "", false, commandUsageError(command, usage)
+	}
+	if isHelpToken(args[0]) {
+		printHelp(a.stdout)
+		return "", "", "", "", false, errRingHelpShown
+	}
+	if len(args) < 2 {
+		return "", "", "", "", false, commandUsageError(command, usage)
+	}
+	ringName = strings.TrimSpace(args[0])
+	target = strings.TrimSpace(args[1])
+
+	fs := flag.NewFlagSet(command, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.BoolVar(&dryRun, "dry-run", false, "Preview changes without writing files")
+	fs.StringVar(&configPath, "config-path", "", "Override client config path")
+	fs.StringVar(&scope, "scope", "", "Target config scope for claude-code: project (default) or user")
+	if parseErr := fs.Parse(args[2:]); parseErr != nil {
+		if errors.Is(parseErr, flag.ErrHelp) {
+			printHelp(a.stdout)
+			return "", "", "", "", false, errRingHelpShown
+		}
+		return "", "", "", "", false, commandInputError(command, parseErr.Error())
+	}
+	if fs.NArg() != 0 {
+		return "", "", "", "", false, commandUnexpectedArgsError(command, fs.Args())
+	}
+
+	scope = strings.TrimSpace(scope)
+	if scope != "" {
+		if target != claudecode.Target {
+			return "", "", "", "", false, commandInputError(command, fmt.Sprintf("--scope is only supported for %s", claudecode.Target))
+		}
+		if scope != clients.ScopeProject && scope != clients.ScopeUser {
+			return "", "", "", "", false, commandInputError(command, fmt.Sprintf("unknown scope %q (supported: %s, %s)", scope, clients.ScopeProject, clients.ScopeUser))
+		}
+	}
+	if _, ok := syncAdapters[target]; !ok {
+		return "", "", "", "", false, commandInputError(command, fmt.Sprintf("unsupported sync target %q (supported: %s)", target, strings.Join(supportedSyncTargets(), ", ")))
+	}
+	return ringName, target, configPath, scope, dryRun, nil
+}
+
+// errRingHelpShown signals the caller that help was printed and parsing
+// stopped without an error.
+var errRingHelpShown = errors.New("ring help shown")
+
+func (a cliApp) ringOpStatePath(target, scope string) string {
+	if scope == clients.ScopeUser {
+		return a.managedUserStatePath(target)
+	}
+	return a.managedStatePath(target)
+}
+
+func (a cliApp) cmdRingAttach(args []string) error {
+	ringName, target, configPath, scope, dryRun, err := a.parseRingOpArgs(
+		"ring attach", args,
+		"madari ring attach <ring> <client> [--scope project|user] [--dry-run] [--config-path <path>]",
+		printRingAttachHelp,
+	)
+	if errors.Is(err, errRingHelpShown) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	ring, err := a.store.GetRing(ringName)
+	if err != nil {
+		if errors.Is(err, registry.ErrRingNotFound) {
+			return fmt.Errorf("ring %q not found", ringName)
+		}
+		return err
+	}
+	manifests, err := a.store.List()
+	if err != nil {
+		return err
+	}
+	rings, err := a.store.ListRings()
+	if err != nil {
+		return err
+	}
+
+	a.warnRingMembers(ring, manifests, target)
+	syncable, skipped := filterSyncableManifests(manifests, target)
+
+	adapter := syncAdapters[target]
+	result, err := adapter.AttachRing(ring, syncable, clients.SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  a.ringOpStatePath(target, scope),
+		Rings:      rings,
+		Scope:      scope,
+		DryRun:     dryRun,
+	})
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(a.stdout, "ring: %s\n", ringName)
+	printSyncSummary(a.stdout, a.stderr, target, result.ConfigPath, result.DryRun, result.Added, result.Updated, result.Removed, result.Unchanged, skipped, result.Refused)
+	return nil
+}
+
+func (a cliApp) cmdRingDetach(args []string) error {
+	ringName, target, configPath, scope, dryRun, err := a.parseRingOpArgs(
+		"ring detach", args,
+		"madari ring detach <ring> <client> [--scope project|user] [--dry-run] [--config-path <path>]",
+		printRingDetachHelp,
+	)
+	if errors.Is(err, errRingHelpShown) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	statePath := a.ringOpStatePath(target, scope)
+	state, err := syncshared.LoadManagedState(statePath)
+	if err != nil {
+		return err
+	}
+	if !slices.Contains(syncshared.AttachedRings(state), ringName) {
+		fmt.Fprintf(a.stdout, "ring %s is not attached to %s; nothing to do\n", ringName, target)
+		return nil
+	}
+
+	rings, err := a.store.ListRings()
+	if err != nil {
+		return err
+	}
+
+	adapter := syncAdapters[target]
+	result, err := adapter.DetachRing(ringName, clients.SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+		Rings:      rings,
+		Scope:      scope,
+		DryRun:     dryRun,
+	})
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(a.stdout, "ring: %s\n", ringName)
+	printSyncSummary(a.stdout, a.stderr, target, result.ConfigPath, result.DryRun, result.Added, result.Updated, result.Removed, result.Unchanged, nil, result.Refused)
+	return nil
+}
+
+// warnRingMembers reports members that will be owned but not materialized.
+func (a cliApp) warnRingMembers(ring registry.Ring, manifests []registry.Manifest, target string) {
+	byName := make(map[string]registry.Manifest, len(manifests))
+	for _, manifest := range manifests {
+		byName[manifest.Name] = manifest
+	}
+	for _, member := range ring.Members {
+		manifest, known := byName[strings.TrimSpace(member)]
+		switch {
+		case !known:
+			fmt.Fprintf(a.stderr, "warning: ring member %s no longer exists in the registry; ownership recorded, nothing materialized\n", member)
+		case !manifest.Enabled:
+			fmt.Fprintf(a.stderr, "warning: ring member %s is disabled; ownership recorded, not materialized until re-enabled\n", member)
+		case !manifest.HasClient(target):
+			fmt.Fprintf(a.stderr, "warning: ring member %s does not target %s; ownership recorded, not materialized\n", member, target)
+		}
 	}
 }
 
@@ -184,6 +360,8 @@ func printRingHelp(out io.Writer) {
 	fmt.Fprintln(out, "  create    Create a ring from registry servers")
 	fmt.Fprintln(out, "  list      List configured rings")
 	fmt.Fprintln(out, "  show      Show one ring's members")
+	fmt.Fprintln(out, "  attach    Attach a ring to a client (materialize members)")
+	fmt.Fprintln(out, "  detach    Detach a ring from a client")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Description:")
 	fmt.Fprintln(out, "  Rings are named capability sets of MCP servers. Members reference")
@@ -207,6 +385,37 @@ func printRingCreateHelp(out io.Writer) {
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Examples:")
 	fmt.Fprintln(out, "  madari ring create research --member stewreads --member arxiv")
+}
+
+func printRingAttachHelp(out io.Writer) {
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  madari ring attach <ring> <client> [--scope project|user] [--dry-run] [--config-path <path>]")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Options:")
+	fmt.Fprintln(out, "  --scope project|user       Claude Code only: target scope (default: project)")
+	fmt.Fprintln(out, "  --dry-run                  Preview changes without writing files")
+	fmt.Fprintln(out, "  --config-path <path>       Override client config path")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Description:")
+	fmt.Fprintln(out, "  Record ring ownership for every member and materialize the eligible")
+	fmt.Fprintln(out, "  ones into the client config. Attaching onto an entry madari does not")
+	fmt.Fprintln(out, "  manage is refused, even when values match. Disabled or secret-refused")
+	fmt.Fprintln(out, "  members stay owned but absent until they become eligible.")
+}
+
+func printRingDetachHelp(out io.Writer) {
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  madari ring detach <ring> <client> [--scope project|user] [--dry-run] [--config-path <path>]")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Options:")
+	fmt.Fprintln(out, "  --scope project|user       Claude Code only: target scope (default: project)")
+	fmt.Fprintln(out, "  --dry-run                  Preview changes without writing files")
+	fmt.Fprintln(out, "  --config-path <path>       Override client config path")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Description:")
+	fmt.Fprintln(out, "  Release the ring's ownership; entries owned by nothing else leave the")
+	fmt.Fprintln(out, "  client config. Works by name even if the ring file no longer exists.")
+	fmt.Fprintln(out, "  Detaching a ring that is not attached is a no-op.")
 }
 
 func printRingListHelp(out io.Writer) {

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -652,6 +652,11 @@ func (a cliApp) cmdSync(args []string) error {
 	}
 	syncable, skipped := filterSyncableManifests(manifests, target)
 
+	rings, err := a.store.ListRings()
+	if err != nil {
+		return err
+	}
+
 	statePath := a.managedStatePath(target)
 	if scope == clients.ScopeUser {
 		statePath = a.managedUserStatePath(target)
@@ -659,6 +664,7 @@ func (a cliApp) cmdSync(args []string) error {
 	result, err := adapter.Sync(syncable, clients.SyncOptions{
 		ConfigPath: configPath,
 		StatePath:  statePath,
+		Rings:      rings,
 		Scope:      scope,
 		DryRun:     dryRun,
 	})
@@ -782,10 +788,15 @@ func (a cliApp) cmdDoctor(args []string) error {
 	}
 
 	adapters := sortedAdapters()
+	rings, err := a.store.ListRings()
+	if err != nil {
+		return err
+	}
 	report, err := doctor.Run(a.store, doctor.Options{
 		Adapters:            adapters,
 		ConfigPathOverrides: configPathOverrides,
 		DriftTargets:        a.driftTargets(adapters, configPathOverrides),
+		Rings:               rings,
 	})
 	if err != nil {
 		return err
@@ -954,10 +965,15 @@ func (a cliApp) cmdStatus(args []string) error {
 	}
 
 	adapters := sortedAdapters()
+	rings, err := a.store.ListRings()
+	if err != nil {
+		return err
+	}
 	report, err := doctor.Run(a.store, doctor.Options{
 		Adapters:            adapters,
 		ConfigPathOverrides: configPathOverrides,
 		DriftTargets:        a.driftTargets(adapters, configPathOverrides),
+		Rings:               rings,
 	})
 	if err != nil {
 		return err

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -1964,3 +1964,101 @@ func TestRunWithStoreRingListJSON(t *testing.T) {
 		t.Fatalf("unexpected ring payload: %v", ring)
 	}
 }
+
+func TestRunWithStoreRingAttachDetachFlow(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	for _, name := range []string{"stewreads", "arxiv"} {
+		if result := runCmd(store, "add", name, "--command", commandPath, "--client", "claude-code"); result.code != 0 {
+			t.Fatalf("setup add %s failed: %s", name, result.stderr)
+		}
+	}
+	if result := runCmd(store, "ring", "create", "r1", "--member", "stewreads"); result.code != 0 {
+		t.Fatalf("ring create r1 failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "ring", "create", "r2", "--member", "stewreads", "--member", "arxiv"); result.code != 0 {
+		t.Fatalf("ring create r2 failed: %s", result.stderr)
+	}
+
+	configPath := filepath.Join(t.TempDir(), ".mcp.json")
+
+	// Attach unknown ring fails.
+	result := runCmd(store, "ring", "attach", "ghost", "claude-code", "--config-path", configPath)
+	if result.code == 0 || !strings.Contains(result.stderr, `ring "ghost" not found`) {
+		t.Fatalf("expected unknown-ring error, got code=%d stderr=%s", result.code, result.stderr)
+	}
+
+	// Attach both rings (overlapping member).
+	result = runCmd(store, "ring", "attach", "r1", "claude-code", "--config-path", configPath)
+	if result.code != 0 {
+		t.Fatalf("attach r1 failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "added: stewreads") {
+		t.Fatalf("expected stewreads added, got: %s", result.stdout)
+	}
+	result = runCmd(store, "ring", "attach", "r2", "claude-code", "--config-path", configPath)
+	if result.code != 0 {
+		t.Fatalf("attach r2 failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "added: arxiv") {
+		t.Fatalf("expected arxiv added, got: %s", result.stdout)
+	}
+
+	// list shows ring sources.
+	result = runCmd(store, "list")
+	if !strings.Contains(result.stdout, "stewreads\tenabled\t"+commandPath+"\tclaude-code\tring:r1,ring:r2") {
+		t.Fatalf("expected overlapping ring sources in list, got: %s", result.stdout)
+	}
+
+	// Detach r1: shared member survives via r2.
+	result = runCmd(store, "ring", "detach", "r1", "claude-code", "--config-path", configPath)
+	if result.code != 0 {
+		t.Fatalf("detach r1 failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "no changes") {
+		t.Fatalf("expected no config changes while r2 owns shared member, got: %s", result.stdout)
+	}
+
+	// Detach r2: everything leaves the config.
+	result = runCmd(store, "ring", "detach", "r2", "claude-code", "--config-path", configPath)
+	if result.code != 0 {
+		t.Fatalf("detach r2 failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "removed: arxiv,stewreads") {
+		t.Fatalf("expected both members removed, got: %s", result.stdout)
+	}
+
+	// Re-detach is a friendly no-op.
+	result = runCmd(store, "ring", "detach", "r2", "claude-code", "--config-path", configPath)
+	if result.code != 0 || !strings.Contains(result.stdout, "not attached") {
+		t.Fatalf("expected no-op notice, got code=%d stdout=%s", result.code, result.stdout)
+	}
+}
+
+func TestRunWithStoreRingAttachWarnsDisabledMember(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	if result := runCmd(store, "add", "stewreads", "--command", commandPath, "--client", "claude-code"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "ring", "create", "r1", "--member", "stewreads"); result.code != 0 {
+		t.Fatalf("ring create failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "disable", "stewreads"); result.code != 0 {
+		t.Fatalf("disable failed: %s", result.stderr)
+	}
+
+	configPath := filepath.Join(t.TempDir(), ".mcp.json")
+	result := runCmd(store, "ring", "attach", "r1", "claude-code", "--config-path", configPath)
+	if result.code != 0 {
+		t.Fatalf("attach failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stderr, "stewreads is disabled; ownership recorded") {
+		t.Fatalf("expected disabled-member warning, got: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "no changes") {
+		t.Fatalf("expected no materialization, got: %s", result.stdout)
+	}
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -43,11 +43,23 @@ and must sync with `--scope user`.
 madari ring create research --member stewreads --member arxiv --description "Research helpers"
 madari ring list
 madari ring show research
+madari ring attach research claude-code
+madari ring attach research claude-code --scope user
+madari ring detach research claude-code
 ```
 
 Rings are named capability sets of servers stored at
 `<config-root>/rings/<name>.toml` (see the manifest spec). Members reference
 registry entries by name and must exist when the ring is created.
+
+Attach records a `ring:<name>` ownership source for every member and
+materializes the eligible ones; detach releases the source, and an entry
+leaves the client config only when no source owns it. Ownership is
+reference-counted: overlapping rings and standalone+ring combinations resolve
+in any attach/detach order. Disabled, secret-refused, or missing members stay
+owned but absent until they become eligible. Ring membership edits (including
+snapshot imports) reconcile on the next sync, attach, or detach. Attaching
+onto an entry madari does not manage is refused, even when values match.
 
 ## Diagnostics
 

--- a/internal/clients/adapter.go
+++ b/internal/clients/adapter.go
@@ -49,6 +49,15 @@ type ClientAdapter interface {
 	// state consistent with the returned plan. Name collisions with unmanaged
 	// entries should return an error wrapping ErrConflict.
 	Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error)
+	// AttachRing records ring ownership for every member and materializes
+	// the eligible ones. Any unmanaged name collision — equal values
+	// included — must return an error wrapping ErrConflict: rings never
+	// adopt hand-managed entries.
+	AttachRing(ring registry.Ring, manifests []registry.Manifest, opts SyncOptions) (SyncResult, error)
+	// DetachRing releases the ring's ownership sources by name (the ring
+	// file may no longer exist); entries losing their last source leave the
+	// config. Detaching an unattached ring is a no-op.
+	DetachRing(ring string, opts SyncOptions) (SyncResult, error)
 }
 
 // SyncOptions controls adapter sync behavior.

--- a/internal/clients/adapter.go
+++ b/internal/clients/adapter.go
@@ -67,6 +67,10 @@ type SyncOptions struct {
 	// StatePath stores entries currently managed by Madari for this target,
 	// each mapped to the sources that own it (e.g. "standalone").
 	StatePath string
+	// Rings carries the current ring definitions so operations can
+	// reconcile recorded ring sources against present membership. Rings
+	// missing from this list keep their sources untouched.
+	Rings []registry.Ring
 	// Scope declares whether the target config is repo-scoped
 	// (ScopeProject) or user-scoped (ScopeUser). Empty means the adapter's
 	// default. Adapters whose config location is inherently user-scoped

--- a/internal/clients/claude-desktop/adapter.go
+++ b/internal/clients/claude-desktop/adapter.go
@@ -21,3 +21,11 @@ func (Adapter) DefaultConfigPath() (string, error) {
 func (Adapter) Sync(manifests []registry.Manifest, opts clients.SyncOptions) (clients.SyncResult, error) {
 	return Sync(manifests, opts)
 }
+
+func (Adapter) AttachRing(ring registry.Ring, manifests []registry.Manifest, opts clients.SyncOptions) (clients.SyncResult, error) {
+	return AttachRing(ring, manifests, opts)
+}
+
+func (Adapter) DetachRing(ring string, opts clients.SyncOptions) (clients.SyncResult, error) {
+	return DetachRing(ring, opts)
+}

--- a/internal/clients/claude-desktop/sync.go
+++ b/internal/clients/claude-desktop/sync.go
@@ -46,7 +46,7 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 		return SyncResult{}, err
 	}
 
-	result, nextState, writeSet, err := syncshared.PlanSync(existingServers, managedState, entriesForTarget(manifests), equalServer, ErrConflict)
+	result, nextState, writeSet, err := syncshared.PlanSync(existingServers, managedState, entriesForTarget(manifests), opts.Rings, equalServer, ErrConflict)
 	if err != nil {
 		return SyncResult{}, err
 	}
@@ -86,7 +86,7 @@ func AttachRing(ring registry.Ring, manifests []registry.Manifest, opts SyncOpti
 		return SyncResult{}, err
 	}
 
-	result, nextState, writeSet, err := syncshared.PlanAttach(existingServers, managedState, ring.Name, ring.Members, entriesForTarget(manifests), equalServer, ErrConflict)
+	result, nextState, writeSet, err := syncshared.PlanAttach(existingServers, managedState, ring.Name, ring.Members, entriesForTarget(manifests), opts.Rings, equalServer, ErrConflict)
 	if err != nil {
 		return SyncResult{}, err
 	}
@@ -124,7 +124,7 @@ func DetachRing(ringName string, opts SyncOptions) (SyncResult, error) {
 		return SyncResult{}, err
 	}
 
-	result, nextState := syncshared.PlanDetach(existingServers, managedState, ringName)
+	result, nextState := syncshared.PlanDetach(existingServers, managedState, ringName, opts.Rings)
 	result.ConfigPath = configPath
 	result.DryRun = opts.DryRun
 

--- a/internal/clients/claude-desktop/sync.go
+++ b/internal/clients/claude-desktop/sync.go
@@ -57,21 +57,108 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 		return result, nil
 	}
 
-	// Rebuild from the raw entries so anything madari does not write keeps
-	// its JSON value, including fields and server shapes madari does not
-	// model. The write set contains exactly the entries madari owns or
-	// introduces; pre-existing unmanaged entries are never serialized.
+	if err := applyPlan(configPath, statePath, root, rawServers, configExists, result.Removed, writeSet, nextState); err != nil {
+		return SyncResult{}, err
+	}
+	return result, nil
+}
+
+// AttachRing adds the ring's ownership source to every member and
+// materializes the eligible ones into the Claude Desktop config. Attaching
+// onto any pre-existing unmanaged entry — equal values included — refuses
+// with ErrConflict.
+func AttachRing(ring registry.Ring, manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
+	configPath, err := resolveConfigPath(opts.ConfigPath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	statePath, err := resolveStatePath(opts.StatePath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	root, rawServers, existingServers, configExists, err := loadClaudeConfig(configPath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	managedState, err := syncshared.LoadManagedState(statePath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	result, nextState, writeSet, err := syncshared.PlanAttach(existingServers, managedState, ring.Name, ring.Members, entriesForTarget(manifests), equalServer, ErrConflict)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	result.ConfigPath = configPath
+	result.DryRun = opts.DryRun
+
+	if opts.DryRun {
+		return result, nil
+	}
+	if err := applyPlan(configPath, statePath, root, rawServers, configExists, result.Removed, writeSet, nextState); err != nil {
+		return SyncResult{}, err
+	}
+	return result, nil
+}
+
+// DetachRing removes the ring's ownership source everywhere; entries that
+// lose their last source leave the config. The ring file is not required, so
+// stale sources can always be released.
+func DetachRing(ringName string, opts SyncOptions) (SyncResult, error) {
+	configPath, err := resolveConfigPath(opts.ConfigPath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	statePath, err := resolveStatePath(opts.StatePath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	root, rawServers, existingServers, configExists, err := loadClaudeConfig(configPath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	managedState, err := syncshared.LoadManagedState(statePath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	result, nextState := syncshared.PlanDetach(existingServers, managedState, ringName)
+	result.ConfigPath = configPath
+	result.DryRun = opts.DryRun
+
+	if opts.DryRun {
+		return result, nil
+	}
+	if err := applyPlan(configPath, statePath, root, rawServers, configExists, result.Removed, nil, nextState); err != nil {
+		return SyncResult{}, err
+	}
+	return result, nil
+}
+
+// applyPlan writes the mutated config (backup + atomic write) and ownership
+// state. The raw entries pass through untouched except for removals and the
+// write set; pre-existing unmanaged entries are never serialized.
+func applyPlan(
+	configPath, statePath string,
+	root, rawServers map[string]json.RawMessage,
+	configExists bool,
+	removed []string,
+	writeSet map[string]serverConfig,
+	nextState map[string][]string,
+) error {
 	mutated := make(map[string]json.RawMessage, len(rawServers)+len(writeSet))
 	for name, raw := range rawServers {
 		mutated[name] = raw
 	}
-	for _, name := range result.Removed {
+	for _, name := range removed {
 		delete(mutated, name)
 	}
 	for name, server := range writeSet {
 		entryPayload, err := json.Marshal(server)
 		if err != nil {
-			return SyncResult{}, fmt.Errorf("marshal server %q: %w", name, err)
+			return fmt.Errorf("marshal server %q: %w", name, err)
 		}
 		mutated[name] = entryPayload
 	}
@@ -82,30 +169,29 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 	}
 	serversPayload, err := json.Marshal(mutated)
 	if err != nil {
-		return SyncResult{}, fmt.Errorf("marshal mcpServers: %w", err)
+		return fmt.Errorf("marshal mcpServers: %w", err)
 	}
 	updatedRoot["mcpServers"] = serversPayload
 
 	payload, err := json.MarshalIndent(updatedRoot, "", "  ")
 	if err != nil {
-		return SyncResult{}, fmt.Errorf("marshal Claude config: %w", err)
+		return fmt.Errorf("marshal Claude config: %w", err)
 	}
 	payload = append(payload, '\n')
 
 	if configExists {
 		if _, err := syncshared.BackupFile(configPath); err != nil {
-			return SyncResult{}, fmt.Errorf("backup Claude config: %w", err)
+			return fmt.Errorf("backup Claude config: %w", err)
 		}
 	}
 	if err := syncshared.WriteFileAtomically(configPath, payload, 0o644); err != nil {
-		return SyncResult{}, fmt.Errorf("write Claude config: %w", err)
+		return fmt.Errorf("write Claude config: %w", err)
 	}
 
 	if err := syncshared.SaveManagedState(statePath, nextState); err != nil {
-		return SyncResult{}, fmt.Errorf("write managed sync state: %w", err)
+		return fmt.Errorf("write managed sync state: %w", err)
 	}
-
-	return result, nil
+	return nil
 }
 
 func DefaultDesktopConfigPath() (string, error) {

--- a/internal/clients/claudecode/adapter.go
+++ b/internal/clients/claudecode/adapter.go
@@ -21,3 +21,11 @@ func (Adapter) DefaultConfigPath() (string, error) {
 func (Adapter) Sync(manifests []registry.Manifest, opts clients.SyncOptions) (clients.SyncResult, error) {
 	return Sync(manifests, opts)
 }
+
+func (Adapter) AttachRing(ring registry.Ring, manifests []registry.Manifest, opts clients.SyncOptions) (clients.SyncResult, error) {
+	return AttachRing(ring, manifests, opts)
+}
+
+func (Adapter) DetachRing(ring string, opts clients.SyncOptions) (clients.SyncResult, error) {
+	return DetachRing(ring, opts)
+}

--- a/internal/clients/claudecode/sync.go
+++ b/internal/clients/claudecode/sync.go
@@ -68,21 +68,116 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 		return result, nil
 	}
 
-	// Rebuild from the raw entries so anything madari does not write keeps
-	// its JSON value, including fields and server shapes madari does not
-	// model. The write set contains exactly the entries madari owns or
-	// introduces; pre-existing unmanaged entries are never serialized.
+	if err := applyPlan(configPath, statePath, root, rawServers, configExists, result.Removed, writeSet, nextState); err != nil {
+		return SyncResult{}, err
+	}
+	return result, nil
+}
+
+// AttachRing adds the ring's ownership source to every member and
+// materializes the eligible ones into the Claude Code config. Attaching onto
+// any pre-existing unmanaged entry — equal values included — refuses with
+// ErrConflict.
+func AttachRing(ring registry.Ring, manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
+	userScope, err := resolveScope(opts.Scope)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	configPath, err := resolveConfigPath(opts.ConfigPath, userScope)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	statePath, err := resolveStatePath(opts.StatePath, userScope)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	root, rawServers, existingServers, configExists, err := loadClaudeCodeConfig(configPath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	managedState, err := syncshared.LoadManagedState(statePath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	result, nextState, writeSet, err := syncshared.PlanAttach(existingServers, managedState, ring.Name, ring.Members, entriesForTarget(manifests, userScope), equalServer, ErrConflict)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	result.ConfigPath = configPath
+	result.DryRun = opts.DryRun
+
+	if opts.DryRun {
+		return result, nil
+	}
+	if err := applyPlan(configPath, statePath, root, rawServers, configExists, result.Removed, writeSet, nextState); err != nil {
+		return SyncResult{}, err
+	}
+	return result, nil
+}
+
+// DetachRing removes the ring's ownership source everywhere; entries that
+// lose their last source leave the config. The ring file is not required, so
+// stale sources can always be released.
+func DetachRing(ringName string, opts SyncOptions) (SyncResult, error) {
+	userScope, err := resolveScope(opts.Scope)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	configPath, err := resolveConfigPath(opts.ConfigPath, userScope)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	statePath, err := resolveStatePath(opts.StatePath, userScope)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	root, rawServers, existingServers, configExists, err := loadClaudeCodeConfig(configPath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	managedState, err := syncshared.LoadManagedState(statePath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	result, nextState := syncshared.PlanDetach(existingServers, managedState, ringName)
+	result.ConfigPath = configPath
+	result.DryRun = opts.DryRun
+
+	if opts.DryRun {
+		return result, nil
+	}
+	if err := applyPlan(configPath, statePath, root, rawServers, configExists, result.Removed, nil, nextState); err != nil {
+		return SyncResult{}, err
+	}
+	return result, nil
+}
+
+// applyPlan writes the mutated config (backup + atomic write) and ownership
+// state. The raw entries pass through untouched except for removals and the
+// write set; pre-existing unmanaged entries are never serialized.
+func applyPlan(
+	configPath, statePath string,
+	root, rawServers map[string]json.RawMessage,
+	configExists bool,
+	removed []string,
+	writeSet map[string]serverConfig,
+	nextState map[string][]string,
+) error {
 	mutated := make(map[string]json.RawMessage, len(rawServers)+len(writeSet))
 	for name, raw := range rawServers {
 		mutated[name] = raw
 	}
-	for _, name := range result.Removed {
+	for _, name := range removed {
 		delete(mutated, name)
 	}
 	for name, server := range writeSet {
 		entryPayload, err := json.Marshal(server)
 		if err != nil {
-			return SyncResult{}, fmt.Errorf("marshal server %q: %w", name, err)
+			return fmt.Errorf("marshal server %q: %w", name, err)
 		}
 		mutated[name] = entryPayload
 	}
@@ -93,30 +188,29 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 	}
 	serversPayload, err := json.Marshal(mutated)
 	if err != nil {
-		return SyncResult{}, fmt.Errorf("marshal mcpServers: %w", err)
+		return fmt.Errorf("marshal mcpServers: %w", err)
 	}
 	updatedRoot["mcpServers"] = serversPayload
 
 	payload, err := json.MarshalIndent(updatedRoot, "", "  ")
 	if err != nil {
-		return SyncResult{}, fmt.Errorf("marshal Claude Code config: %w", err)
+		return fmt.Errorf("marshal Claude Code config: %w", err)
 	}
 	payload = append(payload, '\n')
 
 	if configExists {
 		if _, err := syncshared.BackupFile(configPath); err != nil {
-			return SyncResult{}, fmt.Errorf("backup Claude Code config: %w", err)
+			return fmt.Errorf("backup Claude Code config: %w", err)
 		}
 	}
 	if err := syncshared.WriteFileAtomically(configPath, payload, 0o644); err != nil {
-		return SyncResult{}, fmt.Errorf("write Claude Code config: %w", err)
+		return fmt.Errorf("write Claude Code config: %w", err)
 	}
 
 	if err := syncshared.SaveManagedState(statePath, nextState); err != nil {
-		return SyncResult{}, fmt.Errorf("write managed sync state: %w", err)
+		return fmt.Errorf("write managed sync state: %w", err)
 	}
-
-	return result, nil
+	return nil
 }
 
 func DefaultProjectConfigPath() (string, error) {

--- a/internal/clients/claudecode/sync.go
+++ b/internal/clients/claudecode/sync.go
@@ -57,7 +57,7 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 		return SyncResult{}, err
 	}
 
-	result, nextState, writeSet, err := syncshared.PlanSync(existingServers, managedState, entriesForTarget(manifests, userScope), equalServer, ErrConflict)
+	result, nextState, writeSet, err := syncshared.PlanSync(existingServers, managedState, entriesForTarget(manifests, userScope), opts.Rings, equalServer, ErrConflict)
 	if err != nil {
 		return SyncResult{}, err
 	}
@@ -101,7 +101,7 @@ func AttachRing(ring registry.Ring, manifests []registry.Manifest, opts SyncOpti
 		return SyncResult{}, err
 	}
 
-	result, nextState, writeSet, err := syncshared.PlanAttach(existingServers, managedState, ring.Name, ring.Members, entriesForTarget(manifests, userScope), equalServer, ErrConflict)
+	result, nextState, writeSet, err := syncshared.PlanAttach(existingServers, managedState, ring.Name, ring.Members, entriesForTarget(manifests, userScope), opts.Rings, equalServer, ErrConflict)
 	if err != nil {
 		return SyncResult{}, err
 	}
@@ -143,7 +143,7 @@ func DetachRing(ringName string, opts SyncOptions) (SyncResult, error) {
 		return SyncResult{}, err
 	}
 
-	result, nextState := syncshared.PlanDetach(existingServers, managedState, ringName)
+	result, nextState := syncshared.PlanDetach(existingServers, managedState, ringName, opts.Rings)
 	result.ConfigPath = configPath
 	result.DryRun = opts.DryRun
 

--- a/internal/clients/claudecode/sync_test.go
+++ b/internal/clients/claudecode/sync_test.go
@@ -1015,3 +1015,45 @@ func newStewreadsManifest() registry.Manifest {
 		},
 	}
 }
+
+func TestSyncConvergesEditedRingMembership(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".mcp.json")
+	statePath := filepath.Join(tmp, "state", "claude-code-managed.json")
+	opts := SyncOptions{ConfigPath: configPath, StatePath: statePath}
+
+	oldMember := newStewreadsManifest()
+	newMember := newStewreadsManifest()
+	newMember.Name = "arxiv"
+	manifests := []registry.Manifest{oldMember, newMember}
+
+	// Attach with stewreads as the only member.
+	if _, err := AttachRing(registry.Ring{Name: "r1", Members: []string{"stewreads"}}, manifests, opts); err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+
+	// The ring was edited (snapshot import or hand edit): member is now
+	// arxiv. The next sync converges config and ownership.
+	editedRing := registry.Ring{Name: "r1", Members: []string{"arxiv"}}
+	syncOpts := opts
+	syncOpts.Rings = []registry.Ring{editedRing}
+	result, err := Sync(manifests, syncOpts)
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	if !reflect.DeepEqual(result.Removed, []string{"stewreads"}) {
+		t.Fatalf("expected ex-member removed... got: %+v", result)
+	}
+	if !reflect.DeepEqual(result.Added, []string{"arxiv"}) {
+		t.Fatalf("expected new member materialized, got: %+v", result)
+	}
+
+	state, err := syncshared.LoadManagedState(statePath)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if !reflect.DeepEqual(state, map[string][]string{"arxiv": {"ring:r1"}}) {
+		t.Fatalf("expected converged ring-only ownership, got: %#v", state)
+	}
+}

--- a/internal/clients/claudecode/sync_test.go
+++ b/internal/clients/claudecode/sync_test.go
@@ -590,6 +590,187 @@ func TestSyncNeverPromotesRingOnlyEntries(t *testing.T) {
 	}
 }
 
+func TestAttachDetachOverlappingRingsAtConfigLevel(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".mcp.json")
+	statePath := filepath.Join(tmp, "state", "claude-code-managed.json")
+	opts := SyncOptions{ConfigPath: configPath, StatePath: statePath}
+
+	shared := newStewreadsManifest()
+	only2 := newStewreadsManifest()
+	only2.Name = "arxiv"
+	manifests := []registry.Manifest{shared, only2}
+
+	r1 := registry.Ring{Name: "r1", Members: []string{"stewreads"}}
+	r2 := registry.Ring{Name: "r2", Members: []string{"stewreads", "arxiv"}}
+
+	if _, err := AttachRing(r1, manifests, opts); err != nil {
+		t.Fatalf("attach r1: %v", err)
+	}
+	result, err := AttachRing(r2, manifests, opts)
+	if err != nil {
+		t.Fatalf("attach r2: %v", err)
+	}
+	if len(result.Added) != 1 || result.Added[0] != "arxiv" {
+		t.Fatalf("expected arxiv added on r2 attach, got: %+v", result)
+	}
+
+	state, err := syncshared.LoadManagedState(statePath)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	expected := map[string][]string{
+		"stewreads": {"ring:r1", "ring:r2"},
+		"arxiv":     {"ring:r2"},
+	}
+	if !reflect.DeepEqual(state, expected) {
+		t.Fatalf("expected overlapping refcounts, got: %#v", state)
+	}
+
+	// Detach r1: shared member survives via r2; config untouched.
+	result, err = DetachRing("r1", opts)
+	if err != nil {
+		t.Fatalf("detach r1: %v", err)
+	}
+	if len(result.Removed) != 0 {
+		t.Fatalf("expected no removals while r2 owns shared member, got: %+v", result)
+	}
+	servers := readServers(t, configPath)
+	if _, ok := servers["stewreads"]; !ok {
+		t.Fatalf("expected shared member to survive r1 detach")
+	}
+
+	// Detach r2: everything leaves config and state ends clean.
+	result, err = DetachRing("r2", opts)
+	if err != nil {
+		t.Fatalf("detach r2: %v", err)
+	}
+	if !reflect.DeepEqual(result.Removed, []string{"arxiv", "stewreads"}) {
+		t.Fatalf("expected both members removed, got: %+v", result)
+	}
+	servers = readServers(t, configPath)
+	if len(servers) != 0 {
+		t.Fatalf("expected clean config, got: %#v", servers)
+	}
+	state, err = syncshared.LoadManagedState(statePath)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if len(state) != 0 {
+		t.Fatalf("expected clean state, got: %#v", state)
+	}
+
+	// Idempotency: detaching again is a no-op.
+	result, err = DetachRing("r2", opts)
+	if err != nil {
+		t.Fatalf("re-detach r2: %v", err)
+	}
+	if result.HasChanges() {
+		t.Fatalf("expected no-op re-detach, got: %+v", result)
+	}
+}
+
+func TestAttachRingConflictsOnEqualUnmanagedEntry(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".mcp.json")
+	statePath := filepath.Join(tmp, "state", "claude-code-managed.json")
+
+	// Hand-managed entry with values identical to the manifest: plain sync
+	// tolerates it; attach must refuse.
+	config := []byte(`{
+  "mcpServers": {
+    "stewreads": {
+      "command": "stewreads-mcp",
+      "env": {
+        "STEWREADS_CONFIG_PATH": "~/.config/stewreads/config.toml"
+      }
+    }
+  }
+}
+`)
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	_, err := AttachRing(
+		registry.Ring{Name: "r1", Members: []string{"stewreads"}},
+		[]registry.Manifest{newStewreadsManifest()},
+		SyncOptions{ConfigPath: configPath, StatePath: statePath},
+	)
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected ErrConflict for equal-value unmanaged collision, got: %v", err)
+	}
+	if _, statErr := os.Stat(statePath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected no state write after conflict, got: %v", statErr)
+	}
+}
+
+func TestAttachRingStandaloneMemberSurvivesDetach(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".mcp.json")
+	statePath := filepath.Join(tmp, "state", "claude-code-managed.json")
+	opts := SyncOptions{ConfigPath: configPath, StatePath: statePath}
+	manifests := []registry.Manifest{newStewreadsManifest()}
+
+	// Standalone first (plain sync), then ring on top.
+	if _, err := Sync(manifests, opts); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if _, err := AttachRing(registry.Ring{Name: "r1", Members: []string{"stewreads"}}, manifests, opts); err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+
+	result, err := DetachRing("r1", opts)
+	if err != nil {
+		t.Fatalf("detach: %v", err)
+	}
+	if len(result.Removed) != 0 {
+		t.Fatalf("expected standalone member to survive ring detach, got: %+v", result)
+	}
+
+	state, err := syncshared.LoadManagedState(statePath)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if !reflect.DeepEqual(state, map[string][]string{"stewreads": {"standalone"}}) {
+		t.Fatalf("expected standalone ownership preserved, got: %#v", state)
+	}
+}
+
+func TestAttachRingRecordsOwnershipForDisabledMember(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".mcp.json")
+	statePath := filepath.Join(tmp, "state", "claude-code-managed.json")
+
+	disabled := newStewreadsManifest()
+	disabled.Enabled = false
+
+	result, err := AttachRing(
+		registry.Ring{Name: "r1", Members: []string{"stewreads"}},
+		[]registry.Manifest{disabled},
+		SyncOptions{ConfigPath: configPath, StatePath: statePath},
+	)
+	if err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	if result.HasChanges() {
+		t.Fatalf("expected no materialization for disabled member, got: %+v", result)
+	}
+
+	state, err := syncshared.LoadManagedState(statePath)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if !reflect.DeepEqual(state, map[string][]string{"stewreads": {"ring:r1"}}) {
+		t.Fatalf("expected ring ownership recorded for disabled member, got: %#v", state)
+	}
+
+	servers := readServers(t, configPath)
+	if _, ok := servers["stewreads"]; ok {
+		t.Fatalf("expected disabled member absent from config")
+	}
+}
+
 func TestSyncMigratesV1ManagedStateToV2(t *testing.T) {
 	tmp := t.TempDir()
 	configPath := filepath.Join(tmp, ".mcp.json")

--- a/internal/clients/syncshared/ownership.go
+++ b/internal/clients/syncshared/ownership.go
@@ -83,13 +83,16 @@ func AttachedRings(state map[string][]string) []string {
 
 // ReconcileRingSources recomputes ring sources against current ring
 // membership for every ring that is attached per the state: new members gain
-// the ring's source, ex-members lose it. Sources of rings absent from the
-// given definitions (e.g. the ring file was deleted outside madari) are left
-// intact — doctor flags them and detach-by-name can always release them.
-// Returns the reconciled state plus the names whose sources emptied
-// (released entries leave the client config). The input map is never
-// mutated.
-func ReconcileRingSources(state map[string][]string, rings []registry.Ring) (map[string][]string, []string) {
+// the ring's source, ex-members lose it. Names in blocked are never granted
+// a source — callers pass the unmanaged config collisions so a membership
+// edit can never adopt or overwrite a hand-managed entry (the collision
+// surfaces through the normal conflict path instead). Sources of rings
+// absent from the given definitions (e.g. the ring file was deleted outside
+// madari) are left intact — doctor flags them and detach-by-name can always
+// release them. Returns the reconciled state plus the names whose sources
+// emptied (released entries leave the client config). The input map is
+// never mutated.
+func ReconcileRingSources(state map[string][]string, rings []registry.Ring, blocked map[string]bool) (map[string][]string, []string) {
 	attached := map[string]bool{}
 	for _, ring := range AttachedRings(state) {
 		attached[ring] = true
@@ -115,6 +118,9 @@ func ReconcileRingSources(state map[string][]string, rings []registry.Ring) (map
 			next[name] = withoutSource(sources, source)
 		}
 		for member := range members {
+			if blocked[member] {
+				continue
+			}
 			if !slices.Contains(next[member], source) {
 				next[member] = append(append([]string(nil), next[member]...), source)
 			}

--- a/internal/clients/syncshared/ownership.go
+++ b/internal/clients/syncshared/ownership.go
@@ -3,6 +3,8 @@ package syncshared
 import (
 	"slices"
 	"strings"
+
+	"github.com/ankitvg/madari/internal/registry"
 )
 
 const ringSourcePrefix = "ring:"
@@ -77,6 +79,56 @@ func AttachedRings(state map[string][]string) []string {
 	}
 	slices.Sort(rings)
 	return rings
+}
+
+// ReconcileRingSources recomputes ring sources against current ring
+// membership for every ring that is attached per the state: new members gain
+// the ring's source, ex-members lose it. Sources of rings absent from the
+// given definitions (e.g. the ring file was deleted outside madari) are left
+// intact — doctor flags them and detach-by-name can always release them.
+// Returns the reconciled state plus the names whose sources emptied
+// (released entries leave the client config). The input map is never
+// mutated.
+func ReconcileRingSources(state map[string][]string, rings []registry.Ring) (map[string][]string, []string) {
+	attached := map[string]bool{}
+	for _, ring := range AttachedRings(state) {
+		attached[ring] = true
+	}
+
+	next := copyState(state)
+	for _, ring := range rings {
+		if !attached[ring.Name] {
+			continue
+		}
+		source := RingSource(ring.Name)
+		members := map[string]bool{}
+		for _, member := range ring.Members {
+			member = strings.TrimSpace(member)
+			if member != "" {
+				members[member] = true
+			}
+		}
+		for name, sources := range next {
+			if members[name] || !slices.Contains(sources, source) {
+				continue
+			}
+			next[name] = withoutSource(sources, source)
+		}
+		for member := range members {
+			if !slices.Contains(next[member], source) {
+				next[member] = append(append([]string(nil), next[member]...), source)
+			}
+		}
+	}
+
+	var released []string
+	for name, sources := range state {
+		if len(sources) > 0 && len(next[name]) == 0 {
+			released = append(released, name)
+		}
+	}
+	slices.Sort(released)
+	return normalizeManagedState(next), released
 }
 
 // SyncOwnership computes post-plain-sync ownership. The standalone claim is

--- a/internal/clients/syncshared/ownership_test.go
+++ b/internal/clients/syncshared/ownership_test.go
@@ -3,6 +3,8 @@ package syncshared
 import (
 	"reflect"
 	"testing"
+
+	"github.com/ankitvg/madari/internal/registry"
 )
 
 // ownershipStep applies one operation to state and asserts the exact result.
@@ -316,5 +318,65 @@ func TestRingSourceHelpers(t *testing.T) {
 	}
 	if got := AttachedRings(state); !reflect.DeepEqual(got, []string{"r1", "r2"}) {
 		t.Fatalf("unexpected attached rings: %#v", got)
+	}
+}
+
+func TestReconcileRingSources(t *testing.T) {
+	state := map[string][]string{
+		"ex-member":  {"ring:r1"},
+		"kept":       {"ring:r1", "standalone"},
+		"stale-ring": {"ring:ghost"},
+	}
+	rings := []registry.Ring{
+		{Name: "r1", Members: []string{"kept", "joined"}},
+		{Name: "unattached", Members: []string{"other"}},
+	}
+
+	next, released := ReconcileRingSources(state, rings)
+
+	expected := map[string][]string{
+		"kept":       {"ring:r1", "standalone"},
+		"joined":     {"ring:r1"},
+		"stale-ring": {"ring:ghost"},
+	}
+	if !reflect.DeepEqual(next, expected) {
+		t.Fatalf("expected reconciled state %#v, got %#v", expected, next)
+	}
+	if !reflect.DeepEqual(released, []string{"ex-member"}) {
+		t.Fatalf("expected ex-member released, got: %#v", released)
+	}
+}
+
+func TestPlanSyncConvergesRingMembershipEdits(t *testing.T) {
+	// Ring r1 was attached when its member was "old"; the ring file now
+	// lists "new". Plain sync must release old (removing it from config),
+	// grant new the ring source, and materialize it without standalone.
+	result, next, writeSet, err := PlanSync(
+		map[string]string{"old": "v-old"},
+		map[string][]string{"old": {"ring:r1"}},
+		map[string]Entry[string]{
+			"old": {Value: "v-old", Eligible: true},
+			"new": {Value: "v-new", Eligible: true},
+		},
+		[]registry.Ring{{Name: "r1", Members: []string{"new"}}},
+		func(a, b string) bool { return a == b },
+		errTestConflict,
+	)
+	if err != nil {
+		t.Fatalf("plan sync: %v", err)
+	}
+
+	if !reflect.DeepEqual(result.Removed, []string{"old"}) {
+		t.Fatalf("expected released ex-member removed, got: %+v", result)
+	}
+	if !reflect.DeepEqual(result.Added, []string{"new"}) {
+		t.Fatalf("expected new member materialized, got: %+v", result)
+	}
+	expectedState := map[string][]string{"new": {"ring:r1"}}
+	if !reflect.DeepEqual(next, expectedState) {
+		t.Fatalf("expected converged ownership %#v, got %#v", expectedState, next)
+	}
+	if _, written := writeSet["old"]; written {
+		t.Fatalf("expected released member unwritten, got: %#v", writeSet)
 	}
 }

--- a/internal/clients/syncshared/ownership_test.go
+++ b/internal/clients/syncshared/ownership_test.go
@@ -332,7 +332,7 @@ func TestReconcileRingSources(t *testing.T) {
 		{Name: "unattached", Members: []string{"other"}},
 	}
 
-	next, released := ReconcileRingSources(state, rings)
+	next, released := ReconcileRingSources(state, rings, nil)
 
 	expected := map[string][]string{
 		"kept":       {"ring:r1", "standalone"},

--- a/internal/clients/syncshared/plan.go
+++ b/internal/clients/syncshared/plan.go
@@ -44,8 +44,9 @@ func PlanSync[T any](
 
 	// Ring membership edits converge here: reconciled sources drive
 	// ownership, while removal candidates are judged against the original
-	// state so fully released entries still leave the config.
-	reconciled, _ := ReconcileRingSources(prev, rings)
+	// state so fully released entries still leave the config. Unmanaged
+	// config collisions are never granted a ring source.
+	reconciled, _ := ReconcileRingSources(prev, rings, unmanagedExisting(existing, prev))
 
 	eligible := make(map[string]bool, len(entries))
 	for name, entry := range entries {

--- a/internal/clients/syncshared/plan.go
+++ b/internal/clients/syncshared/plan.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/ankitvg/madari/internal/clients"
+	"github.com/ankitvg/madari/internal/registry"
 )
 
 // Entry describes one manifest's standing for a sync operation.
@@ -33,12 +34,18 @@ func PlanSync[T any](
 	existing map[string]T,
 	prev map[string][]string,
 	entries map[string]Entry[T],
+	rings []registry.Ring,
 	equal func(a, b T) bool,
 	conflictErr error,
 ) (clients.SyncResult, map[string][]string, map[string]T, error) {
 	if equal == nil {
 		return clients.SyncResult{}, nil, nil, fmt.Errorf("equal comparer is required")
 	}
+
+	// Ring membership edits converge here: reconciled sources drive
+	// ownership, while removal candidates are judged against the original
+	// state so fully released entries still leave the config.
+	reconciled, _ := ReconcileRingSources(prev, rings)
 
 	eligible := make(map[string]bool, len(entries))
 	for name, entry := range entries {
@@ -51,7 +58,7 @@ func PlanSync[T any](
 		existsInConfig[name] = true
 	}
 
-	next := SyncOwnership(prev, eligible, existsInConfig)
+	next := SyncOwnership(reconciled, eligible, existsInConfig)
 
 	result := clients.SyncResult{}
 	writeSet := map[string]T{}
@@ -62,6 +69,12 @@ func PlanSync[T any](
 			if entry.Refused {
 				result.Refused = append(result.Refused, name)
 			}
+			continue
+		}
+		if len(prev[name]) > 0 && len(next[name]) == 0 {
+			// Ownership fully released this pass (e.g. reconciliation
+			// dropped the last ring source): this is a removal, not a
+			// materialization candidate. A later sync may re-claim it.
 			continue
 		}
 		existingValue, exists := existing[name]

--- a/internal/clients/syncshared/plan_test.go
+++ b/internal/clients/syncshared/plan_test.go
@@ -18,7 +18,7 @@ func planSyncStrings(
 	entries map[string]Entry[string],
 ) (clients.SyncResult, map[string][]string, map[string]string) {
 	t.Helper()
-	result, next, writeSet, err := PlanSync(existing, prev, entries, func(a, b string) bool { return a == b }, errTestConflict)
+	result, next, writeSet, err := PlanSync(existing, prev, entries, nil, func(a, b string) bool { return a == b }, errTestConflict)
 	if err != nil {
 		t.Fatalf("plan sync: %v", err)
 	}
@@ -102,6 +102,7 @@ func TestPlanSyncUnmanagedMismatchConflicts(t *testing.T) {
 		map[string]string{"hand": "theirs"},
 		map[string][]string{},
 		map[string]Entry[string]{"hand": {Value: "ours", Eligible: true}},
+		nil,
 		func(a, b string) bool { return a == b },
 		errTestConflict,
 	)

--- a/internal/clients/syncshared/ringplan.go
+++ b/internal/clients/syncshared/ringplan.go
@@ -1,0 +1,108 @@
+package syncshared
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/ankitvg/madari/internal/clients"
+)
+
+// PlanAttach computes the config mutations and ownership state for attaching
+// a ring. Attach is scoped: it materializes (or refreshes) the ring's
+// eligible members and touches nothing else. Attaching onto ANY pre-existing
+// unmanaged name collision — equal values included — is a conflict: rings
+// never adopt hand-managed entries. Ineligible members (disabled, refused,
+// missing manifests) still gain the ring source — ownership persists through
+// ineligibility — but are not materialized.
+func PlanAttach[T any](
+	existing map[string]T,
+	prev map[string][]string,
+	ring string,
+	members []string,
+	entries map[string]Entry[T],
+	equal func(a, b T) bool,
+	conflictErr error,
+) (clients.SyncResult, map[string][]string, map[string]T, error) {
+	if equal == nil {
+		return clients.SyncResult{}, nil, nil, fmt.Errorf("equal comparer is required")
+	}
+
+	var conflicts []string
+	for _, member := range members {
+		member = strings.TrimSpace(member)
+		_, exists := existing[member]
+		_, owned := prev[member]
+		if exists && !owned {
+			conflicts = append(conflicts, member)
+		}
+	}
+	if len(conflicts) > 0 {
+		sort.Strings(conflicts)
+		return clients.SyncResult{}, nil, nil, fmt.Errorf(
+			"%w: unmanaged entries already exist: %s",
+			conflictErr,
+			strings.Join(conflicts, ", "),
+		)
+	}
+
+	next := AttachRingState(prev, ring, members)
+
+	result := clients.SyncResult{}
+	writeSet := map[string]T{}
+	for _, member := range members {
+		member = strings.TrimSpace(member)
+		entry, known := entries[member]
+		if !known {
+			continue // no manifest: ownership recorded, nothing materialized
+		}
+		if entry.Refused {
+			result.Refused = append(result.Refused, member)
+			continue
+		}
+		if !entry.Eligible {
+			continue // e.g. disabled: ownership recorded, not materialized
+		}
+		existingValue, exists := existing[member]
+		switch {
+		case !exists:
+			result.Added = append(result.Added, member)
+		case equal(existingValue, entry.Value):
+			result.Unchanged = append(result.Unchanged, member)
+		default:
+			result.Updated = append(result.Updated, member)
+		}
+		writeSet[member] = entry.Value
+	}
+
+	sort.Strings(result.Added)
+	sort.Strings(result.Updated)
+	sort.Strings(result.Unchanged)
+	sort.Strings(result.Refused)
+	return result, next, writeSet, nil
+}
+
+// PlanDetach computes the config mutations and ownership state for detaching
+// a ring by name (the ring file is not required — detach must always be able
+// to release sources). Only entries that lose their last source leave the
+// config; entries still owned by other sources are untouched. Detaching an
+// unattached ring yields an empty plan.
+func PlanDetach[T any](
+	existing map[string]T,
+	prev map[string][]string,
+	ring string,
+) (clients.SyncResult, map[string][]string) {
+	next := DetachRingState(prev, ring)
+
+	result := clients.SyncResult{}
+	for name := range prev {
+		if _, still := next[name]; still {
+			continue
+		}
+		if _, exists := existing[name]; exists {
+			result.Removed = append(result.Removed, name)
+		}
+	}
+	sort.Strings(result.Removed)
+	return result, next
+}

--- a/internal/clients/syncshared/ringplan.go
+++ b/internal/clients/syncshared/ringplan.go
@@ -30,7 +30,7 @@ func PlanAttach[T any](
 		return clients.SyncResult{}, nil, nil, fmt.Errorf("equal comparer is required")
 	}
 
-	reconciled, released := ReconcileRingSources(prev, rings)
+	reconciled, released := ReconcileRingSources(prev, rings, unmanagedExisting(existing, prev))
 	releasedSet := make(map[string]bool, len(released))
 	for _, name := range released {
 		releasedSet[name] = true
@@ -71,15 +71,19 @@ func PlanAttach[T any](
 	for _, member := range members {
 		member = strings.TrimSpace(member)
 		entry, known := entries[member]
-		if !known {
-			continue // no manifest: ownership recorded, nothing materialized
-		}
-		if entry.Refused {
-			result.Refused = append(result.Refused, member)
+		if !known || !entry.Eligible {
+			// Ownership is recorded but the member must be absent from the
+			// config; a previously materialized entry is scrubbed now (the
+			// conflict check above guarantees it is ours). For refused
+			// members this removes a static secret from a repo-scoped
+			// config immediately, not on some later sync.
+			if entry.Refused {
+				result.Refused = append(result.Refused, member)
+			}
+			if _, exists := existing[member]; exists {
+				result.Removed = append(result.Removed, member)
+			}
 			continue
-		}
-		if !entry.Eligible {
-			continue // e.g. disabled: ownership recorded, not materialized
 		}
 		existingValue, exists := existing[member]
 		switch {
@@ -101,6 +105,18 @@ func PlanAttach[T any](
 	return result, next, writeSet, nil
 }
 
+// unmanagedExisting lists config names madari does not own — reconciliation
+// must never grant these a ring source.
+func unmanagedExisting[T any](existing map[string]T, prev map[string][]string) map[string]bool {
+	blocked := map[string]bool{}
+	for name := range existing {
+		if _, owned := prev[name]; !owned {
+			blocked[name] = true
+		}
+	}
+	return blocked
+}
+
 // PlanDetach computes the config mutations and ownership state for detaching
 // a ring by name (the ring file is not required — detach must always be able
 // to release sources). Only entries that lose their last source leave the
@@ -112,7 +128,7 @@ func PlanDetach[T any](
 	ring string,
 	rings []registry.Ring,
 ) (clients.SyncResult, map[string][]string) {
-	reconciled, _ := ReconcileRingSources(prev, rings)
+	reconciled, _ := ReconcileRingSources(prev, rings, unmanagedExisting(existing, prev))
 	next := DetachRingState(reconciled, ring)
 
 	result := clients.SyncResult{}

--- a/internal/clients/syncshared/ringplan.go
+++ b/internal/clients/syncshared/ringplan.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/ankitvg/madari/internal/clients"
+	"github.com/ankitvg/madari/internal/registry"
 )
 
 // PlanAttach computes the config mutations and ownership state for attaching
@@ -21,6 +22,7 @@ func PlanAttach[T any](
 	ring string,
 	members []string,
 	entries map[string]Entry[T],
+	rings []registry.Ring,
 	equal func(a, b T) bool,
 	conflictErr error,
 ) (clients.SyncResult, map[string][]string, map[string]T, error) {
@@ -28,12 +30,18 @@ func PlanAttach[T any](
 		return clients.SyncResult{}, nil, nil, fmt.Errorf("equal comparer is required")
 	}
 
+	reconciled, released := ReconcileRingSources(prev, rings)
+	releasedSet := make(map[string]bool, len(released))
+	for _, name := range released {
+		releasedSet[name] = true
+	}
+
 	var conflicts []string
 	for _, member := range members {
 		member = strings.TrimSpace(member)
 		_, exists := existing[member]
-		_, owned := prev[member]
-		if exists && !owned {
+		_, owned := reconciled[member]
+		if exists && !owned && !releasedSet[member] {
 			conflicts = append(conflicts, member)
 		}
 	}
@@ -46,10 +54,20 @@ func PlanAttach[T any](
 		)
 	}
 
-	next := AttachRingState(prev, ring, members)
+	next := AttachRingState(reconciled, ring, members)
 
 	result := clients.SyncResult{}
 	writeSet := map[string]T{}
+	// Entries fully released by reconciliation leave the config unless this
+	// attach re-materializes them below.
+	for name := range prev {
+		if _, still := next[name]; still {
+			continue
+		}
+		if _, exists := existing[name]; exists {
+			result.Removed = append(result.Removed, name)
+		}
+	}
 	for _, member := range members {
 		member = strings.TrimSpace(member)
 		entry, known := entries[member]
@@ -77,6 +95,7 @@ func PlanAttach[T any](
 
 	sort.Strings(result.Added)
 	sort.Strings(result.Updated)
+	sort.Strings(result.Removed)
 	sort.Strings(result.Unchanged)
 	sort.Strings(result.Refused)
 	return result, next, writeSet, nil
@@ -91,8 +110,10 @@ func PlanDetach[T any](
 	existing map[string]T,
 	prev map[string][]string,
 	ring string,
+	rings []registry.Ring,
 ) (clients.SyncResult, map[string][]string) {
-	next := DetachRingState(prev, ring)
+	reconciled, _ := ReconcileRingSources(prev, rings)
+	next := DetachRingState(reconciled, ring)
 
 	result := clients.SyncResult{}
 	for name := range prev {

--- a/internal/clients/syncshared/ringplan_test.go
+++ b/internal/clients/syncshared/ringplan_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/ankitvg/madari/internal/registry"
 )
 
 func TestPlanAttachMaterializesMembers(t *testing.T) {
@@ -145,5 +147,89 @@ func TestPlanDetachHandlesEntryAbsentFromConfig(t *testing.T) {
 	}
 	if len(next) != 0 {
 		t.Fatalf("expected ownership released, got: %#v", next)
+	}
+}
+
+func TestPlanSyncNeverGrantsRingSourceToUnmanagedCollision(t *testing.T) {
+	// Ring r1 is attached; its membership was edited to include "weather",
+	// which already exists unmanaged in the client config. Reconciliation
+	// must not adopt it: a value mismatch is a conflict, never an overwrite.
+	_, _, _, err := PlanSync(
+		map[string]string{"weather": "theirs", "member": "v1"},
+		map[string][]string{"member": {"ring:r1"}},
+		map[string]Entry[string]{
+			"member":  {Value: "v1", Eligible: true},
+			"weather": {Value: "ours", Eligible: true},
+		},
+		[]registry.Ring{{Name: "r1", Members: []string{"member", "weather"}}},
+		func(a, b string) bool { return a == b },
+		errTestConflict,
+	)
+	if !errors.Is(err, errTestConflict) {
+		t.Fatalf("expected conflict for unmanaged collision via membership edit, got: %v", err)
+	}
+
+	// Equal values: tolerated unchanged, but never granted the ring source.
+	result, next, writeSet, err := PlanSync(
+		map[string]string{"weather": "same", "member": "v1"},
+		map[string][]string{"member": {"ring:r1"}},
+		map[string]Entry[string]{
+			"member":  {Value: "v1", Eligible: true},
+			"weather": {Value: "same", Eligible: true},
+		},
+		[]registry.Ring{{Name: "r1", Members: []string{"member", "weather"}}},
+		func(a, b string) bool { return a == b },
+		errTestConflict,
+	)
+	if err != nil {
+		t.Fatalf("plan sync: %v", err)
+	}
+	if !reflect.DeepEqual(result.Unchanged, []string{"member", "weather"}) {
+		t.Fatalf("expected equal collision tolerated, got: %+v", result)
+	}
+	if !reflect.DeepEqual(next, map[string][]string{"member": {"ring:r1"}}) {
+		t.Fatalf("expected weather to stay unowned, got: %#v", next)
+	}
+	if _, written := writeSet["weather"]; written {
+		t.Fatalf("expected unmanaged entry left unwritten, got: %#v", writeSet)
+	}
+}
+
+func TestPlanAttachScrubsIneligibleMaterializedMembers(t *testing.T) {
+	// Both members were materialized earlier; one is now secret-refused and
+	// one disabled. Re-attaching must scrub them from the config while
+	// keeping ownership — a stale secret must not linger until a later sync.
+	result, next, writeSet, err := PlanAttach(
+		map[string]string{"vault": "v-secret", "sleepy": "v1"},
+		map[string][]string{"vault": {"ring:r1"}, "sleepy": {"ring:r1"}},
+		"r1",
+		[]string{"vault", "sleepy"},
+		map[string]Entry[string]{
+			"vault":  {Refused: true},
+			"sleepy": {Eligible: false},
+		},
+		nil,
+		func(a, b string) bool { return a == b },
+		errTestConflict,
+	)
+	if err != nil {
+		t.Fatalf("plan attach: %v", err)
+	}
+
+	if !reflect.DeepEqual(result.Removed, []string{"sleepy", "vault"}) {
+		t.Fatalf("expected ineligible members scrubbed, got: %+v", result)
+	}
+	if !reflect.DeepEqual(result.Refused, []string{"vault"}) {
+		t.Fatalf("expected vault refused, got: %+v", result)
+	}
+	expectedState := map[string][]string{
+		"vault":  {"ring:r1"},
+		"sleepy": {"ring:r1"},
+	}
+	if !reflect.DeepEqual(next, expectedState) {
+		t.Fatalf("expected ownership retained, got: %#v", next)
+	}
+	if len(writeSet) != 0 {
+		t.Fatalf("expected empty write set, got: %#v", writeSet)
 	}
 }

--- a/internal/clients/syncshared/ringplan_test.go
+++ b/internal/clients/syncshared/ringplan_test.go
@@ -17,6 +17,7 @@ func TestPlanAttachMaterializesMembers(t *testing.T) {
 			"already": {Value: "v1", Eligible: true},
 			"fresh":   {Value: "v2", Eligible: true},
 		},
+		nil,
 		func(a, b string) bool { return a == b },
 		errTestConflict,
 	)
@@ -49,6 +50,7 @@ func TestPlanAttachConflictsOnAnyUnmanagedCollisionEvenEqual(t *testing.T) {
 		"r1",
 		[]string{"hand"},
 		map[string]Entry[string]{"hand": {Value: "v1", Eligible: true}},
+		nil,
 		func(a, b string) bool { return a == b },
 		errTestConflict,
 	)
@@ -70,6 +72,7 @@ func TestPlanAttachRecordsOwnershipForIneligibleMembers(t *testing.T) {
 			"disabled": {Eligible: false},
 			"secret":   {Refused: true},
 		},
+		nil,
 		func(a, b string) bool { return a == b },
 		errTestConflict,
 	)
@@ -105,6 +108,7 @@ func TestPlanDetachRemovesOnlyLastSourceEntries(t *testing.T) {
 			"standalone-too": {"ring:r1", "standalone"},
 		},
 		"r1",
+		nil,
 	)
 
 	if !reflect.DeepEqual(result.Removed, []string{"only"}) {
@@ -121,7 +125,7 @@ func TestPlanDetachRemovesOnlyLastSourceEntries(t *testing.T) {
 
 func TestPlanDetachUnattachedRingIsNoOp(t *testing.T) {
 	prev := map[string][]string{"server": {"standalone"}}
-	result, next := PlanDetach(map[string]string{"server": "v1"}, prev, "ghost")
+	result, next := PlanDetach(map[string]string{"server": "v1"}, prev, "ghost", nil)
 
 	if result.HasChanges() {
 		t.Fatalf("expected empty plan, got: %+v", result)
@@ -134,7 +138,7 @@ func TestPlanDetachUnattachedRingIsNoOp(t *testing.T) {
 func TestPlanDetachHandlesEntryAbsentFromConfig(t *testing.T) {
 	// The ring-owned entry was hand-deleted from config; detach releases
 	// ownership without reporting a removal.
-	result, next := PlanDetach(map[string]string{}, map[string][]string{"only": {"ring:r1"}}, "r1")
+	result, next := PlanDetach(map[string]string{}, map[string][]string{"only": {"ring:r1"}}, "r1", nil)
 
 	if len(result.Removed) != 0 {
 		t.Fatalf("expected no config removal, got: %+v", result)

--- a/internal/clients/syncshared/ringplan_test.go
+++ b/internal/clients/syncshared/ringplan_test.go
@@ -1,0 +1,145 @@
+package syncshared
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestPlanAttachMaterializesMembers(t *testing.T) {
+	result, next, writeSet, err := PlanAttach(
+		map[string]string{"already": "v1"},
+		map[string][]string{"already": {"standalone"}},
+		"r1",
+		[]string{"already", "fresh"},
+		map[string]Entry[string]{
+			"already": {Value: "v1", Eligible: true},
+			"fresh":   {Value: "v2", Eligible: true},
+		},
+		func(a, b string) bool { return a == b },
+		errTestConflict,
+	)
+	if err != nil {
+		t.Fatalf("plan attach: %v", err)
+	}
+
+	if !reflect.DeepEqual(result.Added, []string{"fresh"}) || !reflect.DeepEqual(result.Unchanged, []string{"already"}) {
+		t.Fatalf("unexpected plan: %+v", result)
+	}
+	expectedState := map[string][]string{
+		"already": {"ring:r1", "standalone"},
+		"fresh":   {"ring:r1"},
+	}
+	if !reflect.DeepEqual(next, expectedState) {
+		t.Fatalf("unexpected ownership: %#v", next)
+	}
+	if writeSet["fresh"] != "v2" || writeSet["already"] != "v1" {
+		t.Fatalf("unexpected write set: %#v", writeSet)
+	}
+}
+
+func TestPlanAttachConflictsOnAnyUnmanagedCollisionEvenEqual(t *testing.T) {
+	// The hand-managed entry has values IDENTICAL to the manifest. Plain
+	// sync tolerates that as unchanged; attach must refuse — rings never
+	// adopt hand-managed entries.
+	_, _, _, err := PlanAttach(
+		map[string]string{"hand": "v1"},
+		map[string][]string{},
+		"r1",
+		[]string{"hand"},
+		map[string]Entry[string]{"hand": {Value: "v1", Eligible: true}},
+		func(a, b string) bool { return a == b },
+		errTestConflict,
+	)
+	if !errors.Is(err, errTestConflict) {
+		t.Fatalf("expected conflict for equal-value unmanaged collision, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "hand") {
+		t.Fatalf("expected member name in error, got: %v", err)
+	}
+}
+
+func TestPlanAttachRecordsOwnershipForIneligibleMembers(t *testing.T) {
+	result, next, writeSet, err := PlanAttach(
+		map[string]string{},
+		map[string][]string{},
+		"r1",
+		[]string{"disabled", "secret", "missing"},
+		map[string]Entry[string]{
+			"disabled": {Eligible: false},
+			"secret":   {Refused: true},
+		},
+		func(a, b string) bool { return a == b },
+		errTestConflict,
+	)
+	if err != nil {
+		t.Fatalf("plan attach: %v", err)
+	}
+
+	if !reflect.DeepEqual(result.Refused, []string{"secret"}) {
+		t.Fatalf("expected secret member refused, got: %+v", result)
+	}
+	if len(result.Added)+len(result.Updated)+len(result.Unchanged) != 0 {
+		t.Fatalf("expected no materialization, got: %+v", result)
+	}
+	expectedState := map[string][]string{
+		"disabled": {"ring:r1"},
+		"secret":   {"ring:r1"},
+		"missing":  {"ring:r1"},
+	}
+	if !reflect.DeepEqual(next, expectedState) {
+		t.Fatalf("expected ownership recorded for all members, got: %#v", next)
+	}
+	if len(writeSet) != 0 {
+		t.Fatalf("expected empty write set, got: %#v", writeSet)
+	}
+}
+
+func TestPlanDetachRemovesOnlyLastSourceEntries(t *testing.T) {
+	result, next := PlanDetach(
+		map[string]string{"only": "v1", "shared": "v2", "standalone-too": "v3"},
+		map[string][]string{
+			"only":           {"ring:r1"},
+			"shared":         {"ring:r1", "ring:r2"},
+			"standalone-too": {"ring:r1", "standalone"},
+		},
+		"r1",
+	)
+
+	if !reflect.DeepEqual(result.Removed, []string{"only"}) {
+		t.Fatalf("expected only last-source entry removed, got: %+v", result)
+	}
+	expectedState := map[string][]string{
+		"shared":         {"ring:r2"},
+		"standalone-too": {"standalone"},
+	}
+	if !reflect.DeepEqual(next, expectedState) {
+		t.Fatalf("unexpected ownership: %#v", next)
+	}
+}
+
+func TestPlanDetachUnattachedRingIsNoOp(t *testing.T) {
+	prev := map[string][]string{"server": {"standalone"}}
+	result, next := PlanDetach(map[string]string{"server": "v1"}, prev, "ghost")
+
+	if result.HasChanges() {
+		t.Fatalf("expected empty plan, got: %+v", result)
+	}
+	if !reflect.DeepEqual(next, prev) {
+		t.Fatalf("expected unchanged ownership, got: %#v", next)
+	}
+}
+
+func TestPlanDetachHandlesEntryAbsentFromConfig(t *testing.T) {
+	// The ring-owned entry was hand-deleted from config; detach releases
+	// ownership without reporting a removal.
+	result, next := PlanDetach(map[string]string{}, map[string][]string{"only": {"ring:r1"}}, "r1")
+
+	if len(result.Removed) != 0 {
+		t.Fatalf("expected no config removal, got: %+v", result)
+	}
+	if len(next) != 0 {
+		t.Fatalf("expected ownership released, got: %#v", next)
+	}
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -113,6 +113,9 @@ type Options struct {
 	// DriftTargets enables drift detection for the listed state/config
 	// pairs.
 	DriftTargets []DriftTarget
+	// Rings carries current ring definitions so drift plans reconcile ring
+	// sources the same way sync does.
+	Rings []registry.Ring
 }
 
 func Run(store *registry.Store, opts Options) (Report, error) {
@@ -165,7 +168,7 @@ func Run(store *registry.Store, opts Options) (Report, error) {
 	// repaired.
 	report.Drift = []DriftReport{}
 	if len(manifestErrors) == 0 {
-		report.Drift = checkDrift(manifests, opts.DriftTargets)
+		report.Drift = checkDrift(manifests, opts.DriftTargets, opts.Rings)
 	}
 
 	report.Summary = summarize(report)
@@ -175,7 +178,7 @@ func Run(store *registry.Store, opts Options) (Report, error) {
 // checkDrift diffs materialized client entries against manifests by reading
 // each target's dry-run sync plan. Targets without managed entries are
 // skipped: no ownership, nothing to drift.
-func checkDrift(manifests []registry.Manifest, targets []DriftTarget) []DriftReport {
+func checkDrift(manifests []registry.Manifest, targets []DriftTarget, rings []registry.Ring) []DriftReport {
 	reports := []DriftReport{}
 	for _, target := range targets {
 		dr := DriftReport{
@@ -198,6 +201,7 @@ func checkDrift(manifests []registry.Manifest, targets []DriftTarget) []DriftRep
 		plan, err := target.Adapter.Sync(syncableForTarget(manifests, target.Adapter.Target()), clients.SyncOptions{
 			ConfigPath: target.ConfigPath,
 			StatePath:  target.StatePath,
+			Rings:      rings,
 			Scope:      target.Scope,
 			DryRun:     true,
 		})

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -22,6 +22,12 @@ func (a testAdapter) DefaultConfigPath() (string, error) { return a.configPath, 
 func (a testAdapter) Sync(_ []registry.Manifest, _ clients.SyncOptions) (clients.SyncResult, error) {
 	return clients.SyncResult{}, nil
 }
+func (a testAdapter) AttachRing(_ registry.Ring, _ []registry.Manifest, _ clients.SyncOptions) (clients.SyncResult, error) {
+	return clients.SyncResult{}, nil
+}
+func (a testAdapter) DetachRing(_ string, _ clients.SyncOptions) (clients.SyncResult, error) {
+	return clients.SyncResult{}, nil
+}
 
 func findClientConfig(report Report, target string) (ClientConfigReport, bool) {
 	for _, cc := range report.ClientConfigs {


### PR DESCRIPTION
**PR 4 of 7** in the v0.2.0 Rings plan — rings become operational. Three commits:

## Commit 1 — `clients: ring attach and detach operations`
- `PlanAttach`/`PlanDetach` extend the PR-3 engine; both adapters expose `AttachRing`/`DetachRing` through the `ClientAdapter` contract, sharing the sync apply path (backup + atomic write + raw passthrough).
- Attach is **scoped**: it materializes (or refreshes) the ring's eligible members and touches nothing else. Ineligible members — disabled, secret-refused, missing manifests — still gain the ring source (ownership persists through ineligibility) but are not materialized.
- **Attaching onto any pre-existing unmanaged entry, equal values included, refuses with `ErrConflict` before any state is written** — stricter than plain sync's tolerate-equal rule, per the artifact's no-adoption decision, with an explicit equal-value test.
- Detach releases by **name** (no ring file required, so stale sources can always be freed); only entries losing their last source leave the config; re-detach is a no-op.
- Config-level tests mirror the PR-3 ordering matrix: overlapping rings detached in both orders end clean; standalone members survive ring detach.

## Commit 2 — `sync: reconcile ring sources against current membership`
Every sync/attach/detach reconciles recorded `ring:*` sources against current ring files: new members gain the source, ex-members lose it, and fully released entries leave the config — so membership edits via snapshot import or hand-editing **converge on the next operation** (and show up in drift's dry-run plans beforehand). Reconciliation lives *inside* the planners so sync, attach, detach, and doctor drift can never diverge. Sources of missing ring files are left intact (doctor flags them in PR 5; detach-by-name cleans them). Callers pass definitions via `SyncOptions.Rings`; CLI sync and doctor drift now supply them.

## Commit 3 — `cli: madari ring attach and detach`
`ring attach/detach <ring> <client>` with `--scope`/`--dry-run`/`--config-path` mirroring sync; per-scope state for claude-code; stderr warnings for owned-but-not-materialized members (disabled/missing/untargeted); friendly no-op notice for detaching an unattached ring. Docs updated.

## Verification
- `go test -count=1 ./...` + `go vet` green at every commit.
- End-to-end CLI smoke (the plan's full matrix): overlapping rings attach → state shows `["ring:r1","ring:r2"]` → **plain sync mid-flow changes no ownership** → disable scrubs but stays ring-owned → re-enable rematerializes identically → detach r1 (no config change, r2 owns) → detach r2 → state `{}`, config `{}`.
- Membership-edit convergence covered at engine, adapter, and (via Rings plumbing) drift level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)