### PR TITLE
cli: ring render and ring status

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ go install github.com/ankitvg/madari/cmd/madari@latest
 - `madari ring show <name> [--json]`
 - `madari ring attach <ring> <client> [--scope project|user] [--dry-run] [--config-path <path>]`
 - `madari ring detach <ring> <client> [--scope project|user] [--dry-run] [--config-path <path>]`
+- `madari ring render <name> --client <target>`
+- `madari ring status [--json]`
 - `madari clients`
 - `madari doctor [--client-config target=path ...] [--json]`
 - `madari status [--client-config target=path ...] [--json]`
@@ -51,6 +53,7 @@ Notes:
 - `list`, `status`, `doctor`, `sync --dry-run`, `ring list`, and `ring show` accept `--json` for machine-readable output with a versioned schema; schemas and exit codes are documented in `docs/cli-reference.md`.
 - Rings are named capability sets of servers (`madari ring …`). Members reference registry entries by name — the server manifest stays the single source of truth for command, args, and env.
 - `ring attach` records reference-counted ownership (`ring:<name>` sources) and materializes eligible members; `ring detach` releases it, and an entry only leaves the client config when nothing owns it anymore. Overlapping rings and standalone+ring combinations resolve by refcount, in any order. Attaching onto an entry madari does not manage is refused — even when values match.
+- `ring render` prints a self-contained MCP config to stdout for ephemeral use — `claude --mcp-config <(madari ring render research --client claude-code)` — mutating nothing; secret env values are never emitted. `ring status` shows attached rings and per-server ownership for every client and scope.
 - Supported sync clients: `claude-desktop` and `claude-code`.
 - Default sync config paths:
   - `claude-desktop`: platform-specific Claude Desktop config path.

--- a/cmd/madari/json_output.go
+++ b/cmd/madari/json_output.go
@@ -67,7 +67,34 @@ type doctorJSON struct {
 	ManifestErrors []manifestErrorJSON `json:"manifest_errors"`
 	ClientConfigs  []doctorConfigJSON  `json:"client_configs"`
 	Drift          []driftJSON         `json:"drift"`
+	RingIssues     []ringIssueJSON     `json:"ring_issues"`
 	Summary        summaryJSON         `json:"summary"`
+}
+
+type ringIssueJSON struct {
+	Target   string `json:"target"`
+	Scope    string `json:"scope"`
+	Ring     string `json:"ring"`
+	Severity string `json:"severity"`
+	Message  string `json:"message"`
+}
+
+func ringIssuesToJSON(issues []doctor.RingIssue) []ringIssueJSON {
+	out := make([]ringIssueJSON, 0, len(issues))
+	for _, issue := range issues {
+		scope := issue.Scope
+		if scope == "" && issue.Target != "" {
+			scope = "default"
+		}
+		out = append(out, ringIssueJSON{
+			Target:   issue.Target,
+			Scope:    scope,
+			Ring:     issue.Ring,
+			Severity: string(issue.Severity),
+			Message:  issue.Message,
+		})
+	}
+	return out
 }
 
 type driftJSON struct {
@@ -149,6 +176,33 @@ func ringToJSON(ring registry.Ring) ringJSON {
 		Members:     nonNilStrings(members),
 		Description: ring.Description,
 	}
+}
+
+type ringStatusJSON struct {
+	SchemaVersion int                    `json:"schema_version"`
+	Command       string                 `json:"command"`
+	Targets       []ringStatusTargetJSON `json:"targets"`
+}
+
+type ringStatusTargetJSON struct {
+	Target  string               `json:"target"`
+	Scope   string               `json:"scope"`
+	Rings   []ringAttachmentJSON `json:"rings"`
+	Servers []ringServerJSON     `json:"servers"`
+}
+
+type ringAttachmentJSON struct {
+	Name           string   `json:"name"`
+	Exists         bool     `json:"exists"`
+	Members        []string `json:"members"`
+	Owned          []string `json:"owned"`
+	Pending        []string `json:"pending"`
+	MissingMembers []string `json:"missing_members"`
+}
+
+type ringServerJSON struct {
+	Name    string   `json:"name"`
+	Sources []string `json:"sources"`
 }
 
 // writeJSON emits one indented JSON document followed by a newline; --json

--- a/cmd/madari/json_output.go
+++ b/cmd/madari/json_output.go
@@ -197,6 +197,7 @@ type ringAttachmentJSON struct {
 	Members        []string `json:"members"`
 	Owned          []string `json:"owned"`
 	Pending        []string `json:"pending"`
+	Stale          []string `json:"stale"`
 	MissingMembers []string `json:"missing_members"`
 }
 

--- a/cmd/madari/ring.go
+++ b/cmd/madari/ring.go
@@ -17,7 +17,7 @@ import (
 
 func (a cliApp) cmdRing(args []string) error {
 	if len(args) == 0 {
-		return commandUsageError("ring", "madari ring <create|list|show|attach|detach|render> [options]")
+		return commandUsageError("ring", "madari ring <create|list|show|attach|detach|render|status> [options]")
 	}
 	if isHelpToken(args[0]) {
 		printRingHelp(a.stdout)
@@ -38,9 +38,199 @@ func (a cliApp) cmdRing(args []string) error {
 		return a.cmdRingDetach(rest)
 	case "render":
 		return a.cmdRingRender(rest)
+	case "status":
+		return a.cmdRingStatus(rest)
 	default:
-		return commandInputError("ring", fmt.Sprintf("unknown ring subcommand %q (supported: create, list, show, attach, detach, render)", sub))
+		return commandInputError("ring", fmt.Sprintf("unknown ring subcommand %q (supported: create, list, show, attach, detach, render, status)", sub))
 	}
+}
+
+// ringTargetStatus is the per-(target, scope) view ring status reports.
+type ringTargetStatus struct {
+	target  string
+	scope   string
+	rings   []ringAttachment
+	servers []serverSources
+}
+
+type ringAttachment struct {
+	name           string
+	exists         bool
+	members        []string
+	owned          []string
+	pending        []string
+	missingMembers []string
+}
+
+type serverSources struct {
+	name    string
+	sources []string
+}
+
+func (a cliApp) cmdRingStatus(args []string) error {
+	if len(args) == 1 && isHelpToken(args[0]) {
+		printRingStatusHelp(a.stdout)
+		return nil
+	}
+	fs := flag.NewFlagSet("ring status", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var jsonOut bool
+	fs.BoolVar(&jsonOut, "json", false, "Emit JSON instead of text")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printRingStatusHelp(a.stdout)
+			return nil
+		}
+		return commandInputError("ring status", err.Error())
+	}
+	if fs.NArg() != 0 {
+		return commandUnexpectedArgsError("ring status", fs.Args())
+	}
+
+	manifests, err := a.store.List()
+	if err != nil {
+		return err
+	}
+	manifestNames := make(map[string]bool, len(manifests))
+	for _, manifest := range manifests {
+		manifestNames[manifest.Name] = true
+	}
+
+	statuses := []ringTargetStatus{}
+	for _, ref := range a.managedStateRefs() {
+		state, err := syncshared.LoadManagedState(ref.path)
+		if err != nil {
+			return err
+		}
+		ts := ringTargetStatus{target: ref.target, scope: ref.scope}
+
+		for _, name := range syncshared.AttachedRings(state) {
+			attachment := ringAttachment{name: name}
+			ring, err := a.store.GetRing(name)
+			switch {
+			case errors.Is(err, registry.ErrRingNotFound):
+				// exists stays false; stale sources released via detach.
+			case err != nil:
+				return err
+			default:
+				attachment.exists = true
+				members := append([]string(nil), ring.Members...)
+				sort.Strings(members)
+				attachment.members = members
+				source := syncshared.RingSource(name)
+				for _, member := range members {
+					member = strings.TrimSpace(member)
+					if slices.Contains(state[member], source) {
+						attachment.owned = append(attachment.owned, member)
+					} else {
+						attachment.pending = append(attachment.pending, member)
+					}
+					if !manifestNames[member] {
+						attachment.missingMembers = append(attachment.missingMembers, member)
+					}
+				}
+			}
+			ts.rings = append(ts.rings, attachment)
+		}
+
+		serverNames := syncshared.MapKeys(state)
+		sort.Strings(serverNames)
+		for _, name := range serverNames {
+			ts.servers = append(ts.servers, serverSources{name: name, sources: state[name]})
+		}
+		statuses = append(statuses, ts)
+	}
+
+	if jsonOut {
+		payload := ringStatusJSON{
+			SchemaVersion: jsonSchemaVersion,
+			Command:       "ring status",
+			Targets:       make([]ringStatusTargetJSON, 0, len(statuses)),
+		}
+		for _, ts := range statuses {
+			scope := ts.scope
+			if scope == "" {
+				scope = "default"
+			}
+			targetJSON := ringStatusTargetJSON{
+				Target:  ts.target,
+				Scope:   scope,
+				Rings:   make([]ringAttachmentJSON, 0, len(ts.rings)),
+				Servers: make([]ringServerJSON, 0, len(ts.servers)),
+			}
+			for _, att := range ts.rings {
+				targetJSON.Rings = append(targetJSON.Rings, ringAttachmentJSON{
+					Name:           att.name,
+					Exists:         att.exists,
+					Members:        nonNilStrings(att.members),
+					Owned:          nonNilStrings(att.owned),
+					Pending:        nonNilStrings(att.pending),
+					MissingMembers: nonNilStrings(att.missingMembers),
+				})
+			}
+			for _, server := range ts.servers {
+				targetJSON.Servers = append(targetJSON.Servers, ringServerJSON{
+					Name:    server.name,
+					Sources: nonNilStrings(server.sources),
+				})
+			}
+			payload.Targets = append(payload.Targets, targetJSON)
+		}
+		return writeJSON(a.stdout, payload)
+	}
+
+	for _, ts := range statuses {
+		label := ts.target
+		if ts.scope == clients.ScopeUser {
+			label += " (user scope)"
+		}
+		if len(ts.servers) == 0 {
+			fmt.Fprintf(a.stdout, "%s: no managed entries\n", label)
+			continue
+		}
+		fmt.Fprintf(a.stdout, "%s:\n", label)
+		if len(ts.rings) == 0 {
+			fmt.Fprintln(a.stdout, "  rings: -")
+		} else {
+			fmt.Fprintln(a.stdout, "  rings:")
+			for _, att := range ts.rings {
+				if !att.exists {
+					fix := fmt.Sprintf("madari ring detach %s %s", att.name, ts.target)
+					if ts.scope == clients.ScopeUser {
+						fix += " --scope user"
+					}
+					fmt.Fprintf(a.stdout, "    %s [missing] ring file not found; release with `%s`\n", att.name, fix)
+					continue
+				}
+				line := fmt.Sprintf("    %s [ok] members=%d owned=%d", att.name, len(att.members), len(att.owned))
+				if len(att.pending) > 0 {
+					line += fmt.Sprintf(" pending=%s (run madari sync %s)", strings.Join(att.pending, ","), ts.target)
+				}
+				if len(att.missingMembers) > 0 {
+					line += fmt.Sprintf(" missing-from-registry=%s", strings.Join(att.missingMembers, ","))
+				}
+				fmt.Fprintln(a.stdout, line)
+			}
+		}
+		fmt.Fprintln(a.stdout, "  servers:")
+		for _, server := range ts.servers {
+			fmt.Fprintf(a.stdout, "    %s: %s\n", server.name, strings.Join(server.sources, ", "))
+		}
+	}
+	return nil
+}
+
+func printRingStatusHelp(out io.Writer) {
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  madari ring status [--json]")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Options:")
+	fmt.Fprintln(out, "  --json                     Emit JSON instead of text")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Description:")
+	fmt.Fprintln(out, "  Show attached rings and per-server ownership sources for every client")
+	fmt.Fprintln(out, "  and scope. Flags rings whose file is missing (release with ring detach)")
+	fmt.Fprintln(out, "  and members that are pending sync or missing from the registry.")
 }
 
 // renderedServer is the self-contained client config entry ring render emits.
@@ -490,6 +680,7 @@ func printRingHelp(out io.Writer) {
 	fmt.Fprintln(out, "  attach    Attach a ring to a client (materialize members)")
 	fmt.Fprintln(out, "  detach    Detach a ring from a client")
 	fmt.Fprintln(out, "  render    Print a self-contained MCP config for a ring")
+	fmt.Fprintln(out, "  status    Show attached rings and ownership per client")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Description:")
 	fmt.Fprintln(out, "  Rings are named capability sets of MCP servers. Members reference")

--- a/cmd/madari/ring.go
+++ b/cmd/madari/ring.go
@@ -17,7 +17,7 @@ import (
 
 func (a cliApp) cmdRing(args []string) error {
 	if len(args) == 0 {
-		return commandUsageError("ring", "madari ring <create|list|show|attach|detach> [options]")
+		return commandUsageError("ring", "madari ring <create|list|show|attach|detach|render> [options]")
 	}
 	if isHelpToken(args[0]) {
 		printRingHelp(a.stdout)
@@ -36,9 +36,136 @@ func (a cliApp) cmdRing(args []string) error {
 		return a.cmdRingAttach(rest)
 	case "detach":
 		return a.cmdRingDetach(rest)
+	case "render":
+		return a.cmdRingRender(rest)
 	default:
-		return commandInputError("ring", fmt.Sprintf("unknown ring subcommand %q (supported: create, list, show, attach, detach)", sub))
+		return commandInputError("ring", fmt.Sprintf("unknown ring subcommand %q (supported: create, list, show, attach, detach, render)", sub))
 	}
+}
+
+// renderedServer is the self-contained client config entry ring render emits.
+type renderedServer struct {
+	Command string            `json:"command"`
+	Args    []string          `json:"args,omitempty"`
+	Env     map[string]string `json:"env,omitempty"`
+}
+
+func (a cliApp) cmdRingRender(args []string) error {
+	if len(args) == 0 {
+		return commandUsageError("ring render", "madari ring render <name> --client <target>")
+	}
+	if isHelpToken(args[0]) {
+		printRingRenderHelp(a.stdout)
+		return nil
+	}
+	name := strings.TrimSpace(args[0])
+
+	fs := flag.NewFlagSet("ring render", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var target string
+	fs.StringVar(&target, "client", "", "Target client the rendered config is for (required)")
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printRingRenderHelp(a.stdout)
+			return nil
+		}
+		return commandInputError("ring render", err.Error())
+	}
+	if fs.NArg() != 0 {
+		return commandUnexpectedArgsError("ring render", fs.Args())
+	}
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return commandInputError("ring render", "--client is required")
+	}
+	if _, ok := syncAdapters[target]; !ok {
+		return commandInputError("ring render", fmt.Sprintf("unsupported client %q (supported: %s)", target, strings.Join(supportedSyncTargets(), ", ")))
+	}
+
+	ring, err := a.store.GetRing(name)
+	if err != nil {
+		if errors.Is(err, registry.ErrRingNotFound) {
+			return fmt.Errorf("ring %q not found", name)
+		}
+		return err
+	}
+	manifests, err := a.store.List()
+	if err != nil {
+		return err
+	}
+	byName := make(map[string]registry.Manifest, len(manifests))
+	for _, manifest := range manifests {
+		byName[manifest.Name] = manifest
+	}
+
+	// Render mutates nothing: no state, no refcounts, no config files. The
+	// output is a self-contained config for ephemeral use (for example
+	// `claude --mcp-config`); stdout carries only the JSON document.
+	servers := map[string]renderedServer{}
+	members := append([]string(nil), ring.Members...)
+	sort.Strings(members)
+	for _, member := range members {
+		member = strings.TrimSpace(member)
+		manifest, known := byName[member]
+		switch {
+		case !known:
+			fmt.Fprintf(a.stderr, "warning: ring member %s no longer exists in the registry; omitted\n", member)
+			continue
+		case !manifest.Enabled:
+			fmt.Fprintf(a.stderr, "warning: ring member %s is disabled; omitted\n", member)
+			continue
+		case !manifest.HasClient(target):
+			fmt.Fprintf(a.stderr, "warning: ring member %s does not target %s; omitted\n", member, target)
+			continue
+		}
+		if err := clients.ValidateCommandPath(manifest.Command); err != nil {
+			fmt.Fprintf(a.stderr, "warning: ring member %s omitted: %s\n", member, err.Message)
+			continue
+		}
+
+		entry := renderedServer{Command: manifest.Command}
+		if len(manifest.Args) > 0 {
+			entry.Args = append([]string(nil), manifest.Args...)
+		}
+		secret := make(map[string]bool, len(manifest.SecretEnv.Keys))
+		for _, key := range manifest.SecretEnv.Keys {
+			secret[strings.TrimSpace(key)] = true
+		}
+		var omitted []string
+		for key, value := range manifest.Env {
+			if secret[key] {
+				omitted = append(omitted, key)
+				continue
+			}
+			if entry.Env == nil {
+				entry.Env = map[string]string{}
+			}
+			entry.Env[key] = value
+		}
+		if len(omitted) > 0 {
+			sort.Strings(omitted)
+			fmt.Fprintf(a.stderr, "warning: ring member %s: secret env values omitted (%s); provide them via the runtime environment\n", member, strings.Join(omitted, ", "))
+		}
+		servers[member] = entry
+	}
+
+	return writeJSON(a.stdout, map[string]map[string]renderedServer{"mcpServers": servers})
+}
+
+func printRingRenderHelp(out io.Writer) {
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  madari ring render <name> --client <target>")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Options:")
+	fmt.Fprintln(out, "  --client <target>          Target client the rendered config is for (required)")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Description:")
+	fmt.Fprintln(out, "  Print a self-contained MCP config for the ring to stdout, for ephemeral")
+	fmt.Fprintln(out, "  use such as `claude --mcp-config <(madari ring render research --client claude-code)`.")
+	fmt.Fprintln(out, "  Members are filtered by client compatibility; disabled, missing, or")
+	fmt.Fprintln(out, "  command-invalid members are omitted with a warning. Static values for")
+	fmt.Fprintln(out, "  [secret_env] keys are never emitted — provide them via the runtime")
+	fmt.Fprintln(out, "  environment. Render mutates no state and no refcounts.")
 }
 
 // parseRingOpArgs parses `<ring> <client> [flags]` shared by attach/detach.
@@ -362,6 +489,7 @@ func printRingHelp(out io.Writer) {
 	fmt.Fprintln(out, "  show      Show one ring's members")
 	fmt.Fprintln(out, "  attach    Attach a ring to a client (materialize members)")
 	fmt.Fprintln(out, "  detach    Detach a ring from a client")
+	fmt.Fprintln(out, "  render    Print a self-contained MCP config for a ring")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Description:")
 	fmt.Fprintln(out, "  Rings are named capability sets of MCP servers. Members reference")

--- a/cmd/madari/ring.go
+++ b/cmd/madari/ring.go
@@ -59,6 +59,7 @@ type ringAttachment struct {
 	members        []string
 	owned          []string
 	pending        []string
+	stale          []string
 	missingMembers []string
 }
 
@@ -118,8 +119,10 @@ func (a cliApp) cmdRingStatus(args []string) error {
 				sort.Strings(members)
 				attachment.members = members
 				source := syncshared.RingSource(name)
+				memberSet := make(map[string]bool, len(members))
 				for _, member := range members {
 					member = strings.TrimSpace(member)
+					memberSet[member] = true
 					if slices.Contains(state[member], source) {
 						attachment.owned = append(attachment.owned, member)
 					} else {
@@ -129,6 +132,14 @@ func (a cliApp) cmdRingStatus(args []string) error {
 						attachment.missingMembers = append(attachment.missingMembers, member)
 					}
 				}
+				// Stale owners: state entries still carrying the source
+				// after a membership edit removed them from the ring.
+				for owner, sources := range state {
+					if !memberSet[owner] && slices.Contains(sources, source) {
+						attachment.stale = append(attachment.stale, owner)
+					}
+				}
+				sort.Strings(attachment.stale)
 			}
 			ts.rings = append(ts.rings, attachment)
 		}
@@ -165,6 +176,7 @@ func (a cliApp) cmdRingStatus(args []string) error {
 					Members:        nonNilStrings(att.members),
 					Owned:          nonNilStrings(att.owned),
 					Pending:        nonNilStrings(att.pending),
+					Stale:          nonNilStrings(att.stale),
 					MissingMembers: nonNilStrings(att.missingMembers),
 				})
 			}
@@ -188,6 +200,10 @@ func (a cliApp) cmdRingStatus(args []string) error {
 			fmt.Fprintf(a.stdout, "%s: no managed entries\n", label)
 			continue
 		}
+		syncHint := "madari sync " + ts.target
+		if ts.scope == clients.ScopeUser {
+			syncHint += " --scope user"
+		}
 		fmt.Fprintf(a.stdout, "%s:\n", label)
 		if len(ts.rings) == 0 {
 			fmt.Fprintln(a.stdout, "  rings: -")
@@ -199,12 +215,22 @@ func (a cliApp) cmdRingStatus(args []string) error {
 					if ts.scope == clients.ScopeUser {
 						fix += " --scope user"
 					}
-					fmt.Fprintf(a.stdout, "    %s [missing] ring file not found; release with `%s`\n", att.name, fix)
+					fmt.Fprintf(a.stdout, "    %s [missing] ring file not found; release with `%s` (pass --config-path if it was attached to a custom config)\n", att.name, fix)
 					continue
 				}
-				line := fmt.Sprintf("    %s [ok] members=%d owned=%d", att.name, len(att.members), len(att.owned))
+				marker := "ok"
+				if len(att.pending)+len(att.stale) > 0 {
+					marker = "out-of-sync"
+				}
+				line := fmt.Sprintf("    %s [%s] members=%d owned=%d", att.name, marker, len(att.members), len(att.owned))
 				if len(att.pending) > 0 {
-					line += fmt.Sprintf(" pending=%s (run madari sync %s)", strings.Join(att.pending, ","), ts.target)
+					line += fmt.Sprintf(" pending=%s", strings.Join(att.pending, ","))
+				}
+				if len(att.stale) > 0 {
+					line += fmt.Sprintf(" stale=%s", strings.Join(att.stale, ","))
+				}
+				if len(att.pending)+len(att.stale) > 0 {
+					line += fmt.Sprintf(" (run %s)", syncHint)
 				}
 				if len(att.missingMembers) > 0 {
 					line += fmt.Sprintf(" missing-from-registry=%s", strings.Join(att.missingMembers, ","))

--- a/cmd/madari/ring.go
+++ b/cmd/madari/ring.go
@@ -230,7 +230,7 @@ func (a cliApp) cmdRingStatus(args []string) error {
 					line += fmt.Sprintf(" stale=%s", strings.Join(att.stale, ","))
 				}
 				if len(att.pending)+len(att.stale) > 0 {
-					line += fmt.Sprintf(" (run %s)", syncHint)
+					line += fmt.Sprintf(" (run `%s`; pass --config-path if attached to a custom config)", syncHint)
 				}
 				if len(att.missingMembers) > 0 {
 					line += fmt.Sprintf(" missing-from-registry=%s", strings.Join(att.missingMembers, ","))

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -846,6 +846,7 @@ func (a cliApp) cmdDoctor(args []string) error {
 			})
 		}
 		payload.Drift = driftToJSON(report.Drift)
+		payload.RingIssues = ringIssuesToJSON(report.RingIssues)
 		if err := writeJSON(a.stdout, payload); err != nil {
 			return err
 		}
@@ -891,6 +892,18 @@ func (a cliApp) cmdDoctor(args []string) error {
 			formatNameList(dr.Orphaned),
 			fix,
 		)
+	}
+
+	for _, issue := range report.RingIssues {
+		label := "ring " + issue.Ring
+		if issue.Target != "" {
+			scope := ""
+			if issue.Scope == clients.ScopeUser {
+				scope = ", user scope"
+			}
+			label = fmt.Sprintf("ring %s (%s%s)", issue.Ring, issue.Target, scope)
+		}
+		fmt.Fprintf(a.stdout, "%s: [%s] %s\n", label, issue.Severity, issue.Message)
 	}
 
 	if len(report.ManifestErrors) > 0 {

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -2062,3 +2062,77 @@ func TestRunWithStoreRingAttachWarnsDisabledMember(t *testing.T) {
 		t.Fatalf("expected no materialization, got: %s", result.stdout)
 	}
 }
+
+func TestRunWithStoreRingRender(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	if result := runCmd(store, "add", "stewreads", "--command", commandPath, "--client", "claude-code",
+		"--arg", "--stdio",
+		"--env", "STEWREADS_CONFIG_PATH=~/.config/stewreads/config.toml",
+		"--env", "STEWREADS_API_KEY=shhh",
+		"--secret-env", "STEWREADS_API_KEY"); result.code != 0 {
+		t.Fatalf("setup add stewreads failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "add", "desktop-only", "--command", commandPath, "--client", "claude-desktop"); result.code != 0 {
+		t.Fatalf("setup add desktop-only failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "add", "sleepy", "--command", commandPath, "--client", "claude-code"); result.code != 0 {
+		t.Fatalf("setup add sleepy failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "disable", "sleepy"); result.code != 0 {
+		t.Fatalf("disable failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "ring", "create", "research",
+		"--member", "stewreads", "--member", "desktop-only", "--member", "sleepy"); result.code != 0 {
+		t.Fatalf("ring create failed: %s", result.stderr)
+	}
+
+	result := runCmd(store, "ring", "render", "research", "--client", "claude-code")
+	if result.code != 0 {
+		t.Fatalf("ring render failed: %s", result.stderr)
+	}
+
+	expected := fmt.Sprintf(`{
+  "mcpServers": {
+    "stewreads": {
+      "command": %q,
+      "args": [
+        "--stdio"
+      ],
+      "env": {
+        "STEWREADS_CONFIG_PATH": "~/.config/stewreads/config.toml"
+      }
+    }
+  }
+}
+`, commandPath)
+	if result.stdout != expected {
+		t.Fatalf("render output drift:\nwant:\n%s\ngot:\n%s", expected, result.stdout)
+	}
+
+	for _, want := range []string{
+		"secret env values omitted (STEWREADS_API_KEY)",
+		"sleepy is disabled; omitted",
+		"desktop-only does not target claude-code; omitted",
+	} {
+		if !strings.Contains(result.stderr, want) {
+			t.Fatalf("expected warning %q, got stderr: %s", want, result.stderr)
+		}
+	}
+
+	// Render mutates nothing: no state directory appears.
+	if _, err := os.Stat(filepath.Join(filepath.Dir(store.ServersDir()), "state")); !os.IsNotExist(err) {
+		t.Fatalf("expected render to write no state, err=%v", err)
+	}
+
+	// Unknown ring and missing --client fail loudly.
+	result = runCmd(store, "ring", "render", "ghost", "--client", "claude-code")
+	if result.code == 0 || !strings.Contains(result.stderr, `ring "ghost" not found`) {
+		t.Fatalf("expected not-found error, got code=%d stderr=%s", result.code, result.stderr)
+	}
+	result = runCmd(store, "ring", "render", "research")
+	if result.code == 0 || !strings.Contains(result.stderr, "--client is required") {
+		t.Fatalf("expected required-client error, got code=%d stderr=%s", result.code, result.stderr)
+	}
+}

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -1506,7 +1506,7 @@ func TestRunWithStoreDoctorJSONReportsErrorsAndExitCode(t *testing.T) {
 	}
 
 	payload := decodeJSONObject(t, result.stdout)
-	assertJSONKeys(t, payload, "schema_version", "command", "servers_dir", "servers", "manifest_errors", "client_configs", "drift", "summary")
+	assertJSONKeys(t, payload, "schema_version", "command", "servers_dir", "servers", "manifest_errors", "client_configs", "drift", "ring_issues", "summary")
 	if payload["command"].(string) != "doctor" {
 		t.Fatalf("unexpected command: %v", payload["command"])
 	}
@@ -2134,5 +2134,140 @@ func TestRunWithStoreRingRender(t *testing.T) {
 	result = runCmd(store, "ring", "render", "research")
 	if result.code == 0 || !strings.Contains(result.stderr, "--client is required") {
 		t.Fatalf("expected required-client error, got code=%d stderr=%s", result.code, result.stderr)
+	}
+}
+
+func TestRunWithStoreRingStatus(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	for _, name := range []string{"stewreads", "arxiv"} {
+		if result := runCmd(store, "add", name, "--command", commandPath, "--client", "claude-code"); result.code != 0 {
+			t.Fatalf("setup add %s failed: %s", name, result.stderr)
+		}
+	}
+	if result := runCmd(store, "ring", "create", "research", "--member", "stewreads", "--member", "arxiv"); result.code != 0 {
+		t.Fatalf("ring create failed: %s", result.stderr)
+	}
+
+	// Nothing attached yet.
+	result := runCmd(store, "ring", "status")
+	if result.code != 0 || !strings.Contains(result.stdout, "claude-code: no managed entries") {
+		t.Fatalf("expected empty status, got code=%d stdout=%s", result.code, result.stdout)
+	}
+
+	configPath := filepath.Join(t.TempDir(), ".mcp.json")
+	if result := runCmd(store, "ring", "attach", "research", "claude-code", "--config-path", configPath); result.code != 0 {
+		t.Fatalf("attach failed: %s", result.stderr)
+	}
+
+	result = runCmd(store, "ring", "status")
+	if result.code != 0 {
+		t.Fatalf("ring status failed: %s", result.stderr)
+	}
+	for _, want := range []string{
+		"claude-code:",
+		"research [ok] members=2 owned=2",
+		"arxiv: ring:research",
+		"stewreads: ring:research",
+	} {
+		if !strings.Contains(result.stdout, want) {
+			t.Fatalf("expected %q in status output, got: %s", want, result.stdout)
+		}
+	}
+
+	// JSON shape.
+	result = runCmd(store, "ring", "status", "--json")
+	if result.code != 0 {
+		t.Fatalf("ring status --json failed: %s", result.stderr)
+	}
+	payload := decodeJSONObject(t, result.stdout)
+	assertJSONKeys(t, payload, "schema_version", "command", "targets")
+	if payload["command"] != "ring status" {
+		t.Fatalf("unexpected command: %v", payload["command"])
+	}
+	targets := payload["targets"].([]any)
+	var ccode map[string]any
+	for _, item := range targets {
+		entry := item.(map[string]any)
+		assertJSONKeys(t, entry, "target", "scope", "rings", "servers")
+		if entry["target"] == "claude-code" && entry["scope"] == "default" {
+			ccode = entry
+		}
+	}
+	if ccode == nil {
+		t.Fatalf("expected claude-code default target, got: %v", targets)
+	}
+	rings := ccode["rings"].([]any)
+	if len(rings) != 1 {
+		t.Fatalf("expected one attached ring, got: %v", rings)
+	}
+	ring := rings[0].(map[string]any)
+	assertJSONKeys(t, ring, "name", "exists", "members", "owned", "pending", "missing_members")
+	if ring["name"] != "research" || ring["exists"] != true {
+		t.Fatalf("unexpected ring attachment: %v", ring)
+	}
+
+	// Delete the ring file out from under the attachment: status flags it,
+	// doctor reports an error-level ring issue.
+	if err := os.Remove(filepath.Join(store.RingsDir(), "research.toml")); err != nil {
+		t.Fatalf("remove ring file: %v", err)
+	}
+
+	result = runCmd(store, "ring", "status")
+	if result.code != 0 {
+		t.Fatalf("ring status failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "research [missing] ring file not found; release with `madari ring detach research claude-code`") {
+		t.Fatalf("expected missing-ring flag with detach guidance, got: %s", result.stdout)
+	}
+
+	result = runCmd(store, "doctor", "--json", "--client-config", "claude-code="+configPath)
+	if result.code == 0 {
+		t.Fatalf("expected doctor to exit non-zero for missing ring file")
+	}
+	payload = decodeJSONObject(t, result.stdout)
+	issues := payload["ring_issues"].([]any)
+	if len(issues) != 1 {
+		t.Fatalf("expected one ring issue, got: %v", issues)
+	}
+	issue := issues[0].(map[string]any)
+	assertJSONKeys(t, issue, "target", "scope", "ring", "severity", "message")
+	if issue["ring"] != "research" || issue["severity"] != "error" {
+		t.Fatalf("unexpected ring issue: %v", issue)
+	}
+
+	// Detach by name still works and clears the issue.
+	if result := runCmd(store, "ring", "detach", "research", "claude-code", "--config-path", configPath); result.code != 0 {
+		t.Fatalf("detach failed: %s", result.stderr)
+	}
+	result = runCmd(store, "ring", "status")
+	if !strings.Contains(result.stdout, "claude-code: no managed entries") {
+		t.Fatalf("expected clean status after detach, got: %s", result.stdout)
+	}
+}
+
+func TestRunWithStoreDoctorFlagsDanglingRingMember(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	if result := runCmd(store, "add", "stewreads", "--command", commandPath, "--client", "claude-code"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "ring", "create", "research", "--member", "stewreads"); result.code != 0 {
+		t.Fatalf("ring create failed: %s", result.stderr)
+	}
+	// Remove the member manifest after ring creation.
+	if result := runCmd(store, "remove", "stewreads"); result.code != 0 {
+		t.Fatalf("remove failed: %s", result.stderr)
+	}
+
+	configPath := filepath.Join(t.TempDir(), ".mcp.json")
+	if err := os.WriteFile(configPath, []byte(`{"mcpServers":{}}`), 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+	result := runCmd(store, "doctor", "--client-config", "claude-code="+configPath)
+	if !strings.Contains(result.stdout, "ring research: [warn] member stewreads no longer exists in the registry") {
+		t.Fatalf("expected dangling-member warning, got: %s", result.stdout)
 	}
 }

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -2203,7 +2203,7 @@ func TestRunWithStoreRingStatus(t *testing.T) {
 		t.Fatalf("expected one attached ring, got: %v", rings)
 	}
 	ring := rings[0].(map[string]any)
-	assertJSONKeys(t, ring, "name", "exists", "members", "owned", "pending", "missing_members")
+	assertJSONKeys(t, ring, "name", "exists", "members", "owned", "pending", "stale", "missing_members")
 	if ring["name"] != "research" || ring["exists"] != true {
 		t.Fatalf("unexpected ring attachment: %v", ring)
 	}
@@ -2270,4 +2270,67 @@ func TestRunWithStoreDoctorFlagsDanglingRingMember(t *testing.T) {
 	if !strings.Contains(result.stdout, "ring research: [warn] member stewreads no longer exists in the registry") {
 		t.Fatalf("expected dangling-member warning, got: %s", result.stdout)
 	}
+}
+
+func TestRunWithStoreRingStatusFlagsStaleAndScopedPending(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	for _, name := range []string{"stewreads", "arxiv"} {
+		if result := runCmd(store, "add", name, "--command", commandPath, "--client", "claude-code"); result.code != 0 {
+			t.Fatalf("setup add %s failed: %s", name, result.stderr)
+		}
+	}
+	if result := runCmd(store, "ring", "create", "research", "--member", "stewreads"); result.code != 0 {
+		t.Fatalf("ring create failed: %s", result.stderr)
+	}
+
+	// Attach in USER scope with a custom config path.
+	configPath := filepath.Join(t.TempDir(), "claude.json")
+	if result := runCmd(store, "ring", "attach", "research", "claude-code", "--scope", "user", "--config-path", configPath); result.code != 0 {
+		t.Fatalf("attach failed: %s", result.stderr)
+	}
+
+	// Edit the ring: stewreads removed (becomes a stale owner), arxiv added
+	// (becomes pending until the next sync).
+	edited := []byte("name = \"research\"\nmembers = [\"arxiv\"]\n")
+	if err := os.WriteFile(filepath.Join(store.RingsDir(), "research.toml"), edited, 0o644); err != nil {
+		t.Fatalf("rewrite ring file: %v", err)
+	}
+
+	result := runCmd(store, "ring", "status")
+	if result.code != 0 {
+		t.Fatalf("ring status failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "research [out-of-sync] members=1 owned=0 pending=arxiv stale=stewreads (run madari sync claude-code --scope user)") {
+		t.Fatalf("expected out-of-sync line with scoped hint, got: %s", result.stdout)
+	}
+
+	// JSON carries the stale owners too.
+	result = runCmd(store, "ring", "status", "--json")
+	if result.code != 0 {
+		t.Fatalf("ring status --json failed: %s", result.stderr)
+	}
+	payload := decodeJSONObject(t, result.stdout)
+	for _, item := range payload["targets"].([]any) {
+		entry := item.(map[string]any)
+		if entry["target"] != "claude-code" || entry["scope"] != "user" {
+			continue
+		}
+		rings := entry["rings"].([]any)
+		if len(rings) != 1 {
+			t.Fatalf("expected one ring, got: %v", rings)
+		}
+		ring := rings[0].(map[string]any)
+		stale := ring["stale"].([]any)
+		if len(stale) != 1 || stale[0] != "stewreads" {
+			t.Fatalf("expected stewreads stale, got: %v", ring)
+		}
+		pending := ring["pending"].([]any)
+		if len(pending) != 1 || pending[0] != "arxiv" {
+			t.Fatalf("expected arxiv pending, got: %v", ring)
+		}
+		return
+	}
+	t.Fatalf("expected claude-code user target in: %s", result.stdout)
 }

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -2302,7 +2302,7 @@ func TestRunWithStoreRingStatusFlagsStaleAndScopedPending(t *testing.T) {
 	if result.code != 0 {
 		t.Fatalf("ring status failed: %s", result.stderr)
 	}
-	if !strings.Contains(result.stdout, "research [out-of-sync] members=1 owned=0 pending=arxiv stale=stewreads (run madari sync claude-code --scope user)") {
+	if !strings.Contains(result.stdout, "research [out-of-sync] members=1 owned=0 pending=arxiv stale=stewreads (run `madari sync claude-code --scope user`; pass --config-path if attached to a custom config)") {
 		t.Fatalf("expected out-of-sync line with scoped hint, got: %s", result.stdout)
 	}
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -75,9 +75,11 @@ claude --mcp-config <(madari ring render research --client claude-code)
 ```
 
 `ring status` shows attached rings and per-server ownership sources for
-every client and scope, flags rings whose file is missing (with the exact
+every client and scope, flags rings whose file is missing (with the
 `ring detach` command that releases the stale sources), and calls out
-members pending sync or missing from the registry. `madari doctor` reports
+members pending sync, stale owners left by membership edits (`stale`), and
+members missing from the registry. Remediation hints assume default config
+paths — pass `--config-path` when the ring was attached to a custom config. `madari doctor` reports
 the same conditions as `ring_issues` (missing ring file = error, dangling
 member = warning).
 
@@ -295,6 +297,7 @@ itself.
           "members": ["arxiv", "stewreads"],
           "owned": ["arxiv", "stewreads"],
           "pending": [],
+          "stale": [],
           "missing_members": []
         }
       ],

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -46,6 +46,8 @@ madari ring show research
 madari ring attach research claude-code
 madari ring attach research claude-code --scope user
 madari ring detach research claude-code
+madari ring render research --client claude-code
+madari ring status
 ```
 
 Rings are named capability sets of servers stored at
@@ -60,6 +62,24 @@ in any attach/detach order. Disabled, secret-refused, or missing members stay
 owned but absent until they become eligible. Ring membership edits (including
 snapshot imports) reconcile on the next sync, attach, or detach. Attaching
 onto an entry madari does not manage is refused, even when values match.
+
+`ring render` prints a self-contained MCP config to stdout and mutates
+nothing — no state, no refcounts. Members are filtered by client
+compatibility; disabled, missing, or command-invalid members are omitted
+with stderr warnings, and static values for `[secret_env]` keys are never
+emitted (the warning names the keys to provide via the runtime environment).
+Ephemeral-session recipe:
+
+```bash
+claude --mcp-config <(madari ring render research --client claude-code)
+```
+
+`ring status` shows attached rings and per-server ownership sources for
+every client and scope, flags rings whose file is missing (with the exact
+`ring detach` command that releases the stale sources), and calls out
+members pending sync or missing from the registry. `madari doctor` reports
+the same conditions as `ring_issues` (missing ring file = error, dangling
+member = warning).
 
 ## Diagnostics
 
@@ -80,8 +100,8 @@ madari import --file madari-snapshot.json --apply
 
 ## JSON Output
 
-`list`, `status`, `doctor`, `sync --dry-run`, `ring list`, and `ring show`
-accept `--json` and emit a single JSON document on stdout with nothing else.
+`list`, `status`, `doctor`, `sync --dry-run`, `ring list`, `ring show`, and
+`ring status` accept `--json` and emit a single JSON document on stdout with nothing else.
 Every payload carries the envelope fields `schema_version` (currently `1`)
 and `command`. Field additions are backward-compatible; renames or removals
 bump `schema_version`. List-valued fields are always present (empty arrays,
@@ -94,6 +114,7 @@ madari doctor --json
 madari sync claude-code --dry-run --json
 madari ring list --json
 madari ring show research --json
+madari ring status --json
 ```
 
 `sync --json` requires `--dry-run`; the apply-mode output contract is not yet
@@ -256,6 +277,39 @@ itself.
   }
 }
 ```
+
+`madari ring status --json` reports per target+scope:
+
+```json
+{
+  "schema_version": 1,
+  "command": "ring status",
+  "targets": [
+    {
+      "target": "claude-code",
+      "scope": "default",
+      "rings": [
+        {
+          "name": "research",
+          "exists": true,
+          "members": ["arxiv", "stewreads"],
+          "owned": ["arxiv", "stewreads"],
+          "pending": [],
+          "missing_members": []
+        }
+      ],
+      "servers": [
+        {"name": "arxiv", "sources": ["ring:research"]},
+        {"name": "stewreads", "sources": ["ring:research", "standalone"]}
+      ]
+    }
+  ]
+}
+```
+
+`madari doctor --json` additionally carries a `ring_issues` array
+(`{target, scope, ring, severity, message}`): an attached ring whose file is
+missing is error-level; a ring referencing a deleted manifest is a warning.
 
 ### Exit Codes
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -72,7 +72,20 @@ type Report struct {
 	ManifestErrors []ManifestError
 	ClientConfigs  []ClientConfigReport
 	Drift          []DriftReport
+	RingIssues     []RingIssue
 	Summary        Summary
+}
+
+// RingIssue reports a ring consistency problem: an attached ring whose file
+// no longer exists (error; ownership sources are never auto-removed, detach
+// releases them), or a ring referencing a deleted manifest (warning).
+// Registry-level issues carry no target/scope.
+type RingIssue struct {
+	Target   string
+	Scope    string
+	Ring     string
+	Severity IssueSeverity
+	Message  string
 }
 
 // DriftTarget names one managed-state/config pair to diff against manifests.
@@ -171,8 +184,68 @@ func Run(store *registry.Store, opts Options) (Report, error) {
 		report.Drift = checkDrift(manifests, opts.DriftTargets, opts.Rings)
 	}
 
+	report.RingIssues = checkRingIssues(manifests, opts.DriftTargets, opts.Rings)
+
 	report.Summary = summarize(report)
 	return report, nil
+}
+
+// checkRingIssues flags attached rings whose file is gone (per target+scope)
+// and ring members whose manifest no longer exists (registry-level). It runs
+// regardless of manifest errors: a stale ring source must never hide.
+func checkRingIssues(manifests []registry.Manifest, targets []DriftTarget, rings []registry.Ring) []RingIssue {
+	issues := []RingIssue{}
+
+	known := make(map[string]registry.Ring, len(rings))
+	for _, ring := range rings {
+		known[ring.Name] = ring
+	}
+	for _, target := range targets {
+		state, err := syncshared.LoadManagedState(target.StatePath)
+		if err != nil {
+			continue // drift already reports unreadable state
+		}
+		for _, ring := range syncshared.AttachedRings(state) {
+			if _, exists := known[ring]; exists {
+				continue
+			}
+			fix := fmt.Sprintf("madari ring detach %s %s", ring, target.Adapter.Target())
+			if target.Scope == clients.ScopeUser {
+				fix += " --scope user"
+			}
+			issues = append(issues, RingIssue{
+				Target:   target.Adapter.Target(),
+				Scope:    target.Scope,
+				Ring:     ring,
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("ring file missing; release the stale sources with `%s`", fix),
+			})
+		}
+	}
+
+	manifestNames := make(map[string]bool, len(manifests))
+	for _, manifest := range manifests {
+		manifestNames[manifest.Name] = true
+	}
+	for _, ring := range rings {
+		for _, member := range ring.Members {
+			if !manifestNames[strings.TrimSpace(member)] {
+				issues = append(issues, RingIssue{
+					Ring:     ring.Name,
+					Severity: SeverityWarning,
+					Message:  fmt.Sprintf("member %s no longer exists in the registry", member),
+				})
+			}
+		}
+	}
+
+	sort.Slice(issues, func(i, j int) bool {
+		if issues[i].Ring != issues[j].Ring {
+			return issues[i].Ring < issues[j].Ring
+		}
+		return issues[i].Target < issues[j].Target
+	})
+	return issues
 }
 
 // checkDrift diffs materialized client entries against manifests by reading
@@ -271,6 +344,13 @@ func summarize(report Report) Summary {
 		if dr.Status == StatusError {
 			summary.Error++
 		} else if dr.Status == StatusWarning {
+			summary.Warning++
+		}
+	}
+	for _, issue := range report.RingIssues {
+		if issue.Severity == SeverityError {
+			summary.Error++
+		} else {
 			summary.Warning++
 		}
 	}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -218,7 +218,7 @@ func checkRingIssues(manifests []registry.Manifest, targets []DriftTarget, rings
 				Scope:    target.Scope,
 				Ring:     ring,
 				Severity: SeverityError,
-				Message:  fmt.Sprintf("ring file missing; release the stale sources with `%s`", fix),
+				Message:  fmt.Sprintf("ring file missing; release the stale sources with `%s` (pass --config-path if it was attached to a custom config)", fix),
 			})
 		}
 	}


### PR DESCRIPTION
**PR 5 of 7** in the v0.2.0 Rings plan — the read/inspection surface. Three commits:

## Commit 1 — `cli: ring render`
`madari ring render <name> --client <target>` prints a self-contained `{"mcpServers": …}` to stdout for ephemeral use (`claude --mcp-config <(…)`):
- **Target explicit** (per plan review): members filtered by client compatibility; disabled, missing, or command-invalid members omitted with stderr warnings.
- **"Materialized env minus secrets"** (artifact decision): static values for `[secret_env]` keys are never emitted — the warning names the keys to provide via runtime env.
- Mutates nothing: no state, no refcounts, no config files; stdout carries only the JSON document (warnings on stderr keep pipes clean). Golden test pins the output.

## Commit 2 — `cli+doctor: ring status and ring consistency checks`
- `madari ring status [--json]`: per (target, scope) — attached rings (derived from `ring:*` sources), per-server ownership sources, members pending sync, members missing from the registry.
- **Missing ring files flagged** (deferred from PR 4): status prints the exact `ring detach` command that releases stale sources; doctor reports the same as an **error-level** `RingIssue` (the schema-stability test caught the JSON addition, updated deliberately). A ring referencing a deleted manifest is a **warning-level** issue, checked registry-wide and independent of manifest-error gating.
- Detach-by-name still releases sources after the file is gone — covered end-to-end in tests.

## Commit 3 — `docs: ring render and status reference`
README + cli-reference incl. the `claude --mcp-config` recipe, `ring status` JSON schema, and doctor's `ring_issues`.

## Verification
- `go test -count=1 ./...` + `go vet` green at every commit.
- Manual smoke: render omits the secret with a named-key warning and parses clean through `json.tool`; status shows refcounts per scope; deleting the ring file flips status + doctor to the flagged state; `ring detach` by name cleans up — with the nice detail that the secret-bearing member was never in the project config to begin with (refused at attach), so detach removed only the eligible member.

🤖 Generated with [Claude Code](https://claude.com/claude-code)