### PR TITLE
v0.2.0 rings: guarded delete and snapshot v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ go install github.com/ankitvg/madari/cmd/madari@latest
 - `madari ring show <name> [--json]`
 - `madari ring attach <ring> <client> [--scope project|user] [--dry-run] [--config-path <path>]`
 - `madari ring detach <ring> <client> [--scope project|user] [--dry-run] [--config-path <path>]`
+- `madari ring delete <name>`
 - `madari ring render <name> --client <target>`
 - `madari ring status [--json]`
 - `madari clients`
@@ -53,14 +54,15 @@ Notes:
 - `list`, `status`, `doctor`, `sync --dry-run`, `ring list`, and `ring show` accept `--json` for machine-readable output with a versioned schema; schemas and exit codes are documented in `docs/cli-reference.md`.
 - Rings are named capability sets of servers (`madari ring …`). Members reference registry entries by name — the server manifest stays the single source of truth for command, args, and env.
 - `ring attach` records reference-counted ownership (`ring:<name>` sources) and materializes eligible members; `ring detach` releases it, and an entry only leaves the client config when nothing owns it anymore. Overlapping rings and standalone+ring combinations resolve by refcount, in any order. Attaching onto an entry madari does not manage is refused — even when values match.
+- `ring delete` removes only unattached ring definitions. It refuses while any client scope still records `ring:<name>` ownership and prints scoped detach guidance; deletion never edits client configs or managed state.
 - `ring render` prints a self-contained MCP config to stdout for ephemeral use — `claude --mcp-config <(madari ring render research --client claude-code)` — mutating nothing; secret env values are never emitted. `ring status` shows attached rings and per-server ownership for every client and scope.
 - Supported sync clients: `claude-desktop` and `claude-code`.
 - Default sync config paths:
   - `claude-desktop`: platform-specific Claude Desktop config path.
   - `claude-code`: `<current working directory>/.mcp.json`.
 - `install --config-path` can only be used when exactly one sync target is selected.
-- `export` writes a versioned JSON snapshot for backup/sharing (stdout by default).
-- `import` is dry-run by default and only adds/updates listed servers (`--apply` persists).
+- `export` writes a versioned JSON snapshot of server and ring manifests for backup/sharing (stdout by default).
+- `import` is dry-run by default and only adds/updates listed servers and rings (`--apply` persists). Existing servers and rings absent from the snapshot are left unchanged; imported rings are not attached or synced.
 
 Claude Code project config shape (`.mcp.json`):
 

--- a/cmd/madari/ring.go
+++ b/cmd/madari/ring.go
@@ -17,7 +17,7 @@ import (
 
 func (a cliApp) cmdRing(args []string) error {
 	if len(args) == 0 {
-		return commandUsageError("ring", "madari ring <create|list|show|attach|detach|render|status> [options]")
+		return commandUsageError("ring", "madari ring <create|list|show|attach|detach|delete|render|status> [options]")
 	}
 	if isHelpToken(args[0]) {
 		printRingHelp(a.stdout)
@@ -36,12 +36,14 @@ func (a cliApp) cmdRing(args []string) error {
 		return a.cmdRingAttach(rest)
 	case "detach":
 		return a.cmdRingDetach(rest)
+	case "delete":
+		return a.cmdRingDelete(rest)
 	case "render":
 		return a.cmdRingRender(rest)
 	case "status":
 		return a.cmdRingStatus(rest)
 	default:
-		return commandInputError("ring", fmt.Sprintf("unknown ring subcommand %q (supported: create, list, show, attach, detach, render, status)", sub))
+		return commandInputError("ring", fmt.Sprintf("unknown ring subcommand %q (supported: create, list, show, attach, detach, delete, render, status)", sub))
 	}
 }
 
@@ -533,6 +535,99 @@ func (a cliApp) cmdRingDetach(args []string) error {
 	return nil
 }
 
+type ringDeleteHolder struct {
+	target string
+	scope  string
+}
+
+func (h ringDeleteHolder) label() string {
+	if h.scope == clients.ScopeUser {
+		return h.target + " (user scope)"
+	}
+	return h.target
+}
+
+func (h ringDeleteHolder) detachCommand(ring string) string {
+	command := fmt.Sprintf("madari ring detach %s %s", ring, h.target)
+	if h.scope == clients.ScopeUser {
+		command += " --scope user"
+	}
+	return command
+}
+
+func (a cliApp) cmdRingDelete(args []string) error {
+	if len(args) == 0 {
+		return commandUsageError("ring delete", "madari ring delete <name>")
+	}
+	if isHelpToken(args[0]) {
+		printRingDeleteHelp(a.stdout)
+		return nil
+	}
+
+	fs := flag.NewFlagSet("ring delete", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printRingDeleteHelp(a.stdout)
+			return nil
+		}
+		return commandInputError("ring delete", err.Error())
+	}
+	if fs.NArg() != 0 {
+		return commandUnexpectedArgsError("ring delete", fs.Args())
+	}
+
+	name := strings.TrimSpace(args[0])
+	if _, err := a.store.GetRing(name); err != nil {
+		if errors.Is(err, registry.ErrRingNotFound) {
+			return fmt.Errorf("ring %q not found", name)
+		}
+		return err
+	}
+
+	holders, err := a.ringDeleteHolders(name)
+	if err != nil {
+		return err
+	}
+	if len(holders) > 0 {
+		var b strings.Builder
+		fmt.Fprintf(&b, "ring %q is attached and cannot be deleted; detach it first:\n", name)
+		for _, holder := range holders {
+			fmt.Fprintf(&b, "  - %s: `%s`\n", holder.label(), holder.detachCommand(name))
+		}
+		b.WriteString("pass --config-path if the ring was attached to a custom config")
+		return fmt.Errorf("%s", b.String())
+	}
+
+	if err := a.store.RemoveRing(name); err != nil {
+		if errors.Is(err, registry.ErrRingNotFound) {
+			return fmt.Errorf("ring %q not found", name)
+		}
+		return err
+	}
+	fmt.Fprintf(a.stdout, "deleted ring %s\n", name)
+	return nil
+}
+
+func (a cliApp) ringDeleteHolders(name string) ([]ringDeleteHolder, error) {
+	source := syncshared.RingSource(name)
+	var holders []ringDeleteHolder
+	for _, ref := range a.managedStateRefs() {
+		state, err := syncshared.LoadManagedState(ref.path)
+		if err != nil {
+			return nil, err
+		}
+		for _, sources := range state {
+			if !slices.Contains(sources, source) {
+				continue
+			}
+			holders = append(holders, ringDeleteHolder{target: ref.target, scope: ref.scope})
+			break
+		}
+	}
+	return holders, nil
+}
+
 // warnRingMembers reports members that will be owned but not materialized.
 func (a cliApp) warnRingMembers(ring registry.Ring, manifests []registry.Manifest, target string) {
 	byName := make(map[string]registry.Manifest, len(manifests))
@@ -705,6 +800,7 @@ func printRingHelp(out io.Writer) {
 	fmt.Fprintln(out, "  show      Show one ring's members")
 	fmt.Fprintln(out, "  attach    Attach a ring to a client (materialize members)")
 	fmt.Fprintln(out, "  detach    Detach a ring from a client")
+	fmt.Fprintln(out, "  delete    Delete an unattached ring")
 	fmt.Fprintln(out, "  render    Print a self-contained MCP config for a ring")
 	fmt.Fprintln(out, "  status    Show attached rings and ownership per client")
 	fmt.Fprintln(out)
@@ -761,6 +857,16 @@ func printRingDetachHelp(out io.Writer) {
 	fmt.Fprintln(out, "  Release the ring's ownership; entries owned by nothing else leave the")
 	fmt.Fprintln(out, "  client config. Works by name even if the ring file no longer exists.")
 	fmt.Fprintln(out, "  Detaching a ring that is not attached is a no-op.")
+}
+
+func printRingDeleteHelp(out io.Writer) {
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  madari ring delete <name>")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Description:")
+	fmt.Fprintln(out, "  Delete an unattached ring from the registry. Deletion is refused while")
+	fmt.Fprintln(out, "  any client scope still records the ring as an ownership source; detach")
+	fmt.Fprintln(out, "  it first, passing --config-path if it was attached to a custom config.")
 }
 
 func printRingListHelp(out io.Writer) {

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -1156,7 +1156,7 @@ func (a cliApp) cmdExport(args []string) error {
 	if err := os.WriteFile(cleanPath, payload, 0o644); err != nil {
 		return fmt.Errorf("write snapshot file %q: %w", cleanPath, err)
 	}
-	fmt.Fprintf(a.stdout, "exported %d server(s) to %s\n", len(snapshot.Servers), cleanPath)
+	fmt.Fprintf(a.stdout, "exported %d server(s), %d ring(s) to %s\n", len(snapshot.Servers), len(snapshot.Rings), cleanPath)
 	return nil
 }
 
@@ -1211,6 +1211,9 @@ func (a cliApp) cmdImport(args []string) error {
 	fmt.Fprintf(a.stdout, "added: %s\n", formatNameList(result.Added))
 	fmt.Fprintf(a.stdout, "updated: %s\n", formatNameList(result.Updated))
 	fmt.Fprintf(a.stdout, "unchanged: %s\n", formatNameList(result.Unchanged))
+	fmt.Fprintf(a.stdout, "rings added: %s\n", formatNameList(result.RingsAdded))
+	fmt.Fprintf(a.stdout, "rings updated: %s\n", formatNameList(result.RingsUpdated))
+	fmt.Fprintf(a.stdout, "rings unchanged: %s\n", formatNameList(result.RingsUnchanged))
 	if !result.HasChanges() {
 		fmt.Fprintln(a.stdout, "no changes")
 	}
@@ -1692,7 +1695,7 @@ func printExportHelp(out io.Writer) {
 	fmt.Fprintln(out, "  --file <path>              Write snapshot JSON to file (default: stdout)")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Description:")
-	fmt.Fprintln(out, "  Export all server manifests as a versioned JSON snapshot.")
+	fmt.Fprintln(out, "  Export all server and ring manifests as a versioned JSON snapshot.")
 }
 
 func printImportHelp(out io.Writer) {
@@ -1704,8 +1707,9 @@ func printImportHelp(out io.Writer) {
 	fmt.Fprintln(out, "  --apply                    Apply changes to registry (default: dry-run)")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Description:")
-	fmt.Fprintln(out, "  Import a snapshot into the registry by adding/updating listed servers.")
-	fmt.Fprintln(out, "  Existing servers not present in the snapshot are left unchanged.")
+	fmt.Fprintln(out, "  Import a snapshot into the registry by adding/updating listed servers")
+	fmt.Fprintln(out, "  and rings. Existing servers and rings absent from the snapshot are")
+	fmt.Fprintln(out, "  left unchanged; importing rings never attaches or syncs them.")
 }
 
 func printHelp(out io.Writer) {

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -978,6 +978,9 @@ func TestRunWithStoreExportStdout(t *testing.T) {
 	if len(snapshot.Servers) != 1 || snapshot.Servers[0].Name != "stewreads" {
 		t.Fatalf("unexpected snapshot servers: %+v", snapshot.Servers)
 	}
+	if len(snapshot.Rings) != 0 {
+		t.Fatalf("unexpected snapshot rings: %+v", snapshot.Rings)
+	}
 }
 
 func TestRunWithStoreExportFile(t *testing.T) {
@@ -987,13 +990,16 @@ func TestRunWithStoreExportFile(t *testing.T) {
 	if result := runCmd(store, "add", "stewreads", "--command", commandPath, "--client", "claude-desktop"); result.code != 0 {
 		t.Fatalf("setup add failed: %s", result.stderr)
 	}
+	if result := runCmd(store, "ring", "create", "research", "--member", "stewreads"); result.code != 0 {
+		t.Fatalf("setup ring failed: %s", result.stderr)
+	}
 
 	path := filepath.Join(t.TempDir(), "snapshot.json")
 	result := runCmd(store, "export", "--file", path)
 	if result.code != 0 {
 		t.Fatalf("export --file failed: %s", result.stderr)
 	}
-	if !strings.Contains(result.stdout, "exported 1 server(s)") {
+	if !strings.Contains(result.stdout, "exported 1 server(s), 1 ring(s)") {
 		t.Fatalf("expected export summary output, got: %s", result.stdout)
 	}
 
@@ -1007,6 +1013,9 @@ func TestRunWithStoreExportFile(t *testing.T) {
 	}
 	if len(snapshot.Servers) != 1 || snapshot.Servers[0].Name != "stewreads" {
 		t.Fatalf("unexpected snapshot servers: %+v", snapshot.Servers)
+	}
+	if len(snapshot.Rings) != 1 || snapshot.Rings[0].Name != "research" {
+		t.Fatalf("unexpected snapshot rings: %+v", snapshot.Rings)
 	}
 }
 
@@ -1034,6 +1043,12 @@ func TestRunWithStoreImportDryRunAndApply(t *testing.T) {
 				Clients: []string{"claude-desktop"},
 			},
 		},
+		Rings: []registry.Ring{
+			{
+				Name:    "research",
+				Members: []string{"alpha", "beta"},
+			},
+		},
 	}
 	payload, err := registry.MarshalSnapshotJSON(snapshot)
 	if err != nil {
@@ -1054,6 +1069,9 @@ func TestRunWithStoreImportDryRunAndApply(t *testing.T) {
 	if !strings.Contains(dryRun.stdout, "added: beta") || !strings.Contains(dryRun.stdout, "updated: alpha") {
 		t.Fatalf("expected dry-run diff output, got: %s", dryRun.stdout)
 	}
+	if !strings.Contains(dryRun.stdout, "rings added: research") {
+		t.Fatalf("expected dry-run ring diff output, got: %s", dryRun.stdout)
+	}
 	alphaAfterDryRun, err := store.Get("alpha")
 	if err != nil {
 		t.Fatalf("load alpha after dry-run: %v", err)
@@ -1063,6 +1081,9 @@ func TestRunWithStoreImportDryRunAndApply(t *testing.T) {
 	}
 	if _, err := store.Get("beta"); err == nil {
 		t.Fatalf("expected dry-run not to create beta")
+	}
+	if _, err := store.GetRing("research"); !errors.Is(err, registry.ErrRingNotFound) {
+		t.Fatalf("expected dry-run not to create research ring, got: %v", err)
 	}
 
 	apply := runCmd(store, "import", "--file", path, "--apply")
@@ -1081,6 +1102,9 @@ func TestRunWithStoreImportDryRunAndApply(t *testing.T) {
 	}
 	if _, err := store.Get("beta"); err != nil {
 		t.Fatalf("expected beta after apply: %v", err)
+	}
+	if _, err := store.GetRing("research"); err != nil {
+		t.Fatalf("expected research ring after apply: %v", err)
 	}
 }
 

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1899,6 +1900,88 @@ func TestRunWithStoreRingListAndShow(t *testing.T) {
 	result = runCmd(store, "ring", "show", "ghost")
 	if result.code == 0 || !strings.Contains(result.stderr, `ring "ghost" not found`) {
 		t.Fatalf("expected not-found error, got code=%d stderr=%s", result.code, result.stderr)
+	}
+}
+
+func TestRunWithStoreRingDelete(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	if result := runCmd(store, "add", "stewreads", "--command", commandPath, "--client", "claude-code"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "ring", "create", "research", "--member", "stewreads"); result.code != 0 {
+		t.Fatalf("ring create failed: %s", result.stderr)
+	}
+
+	result := runCmd(store, "ring", "delete", "research", "--bogus")
+	if result.code == 0 || !strings.Contains(result.stderr, "flag provided but not defined") {
+		t.Fatalf("expected unknown-flag error, got code=%d stderr=%s", result.code, result.stderr)
+	}
+
+	result = runCmd(store, "ring", "delete")
+	if result.code == 0 || !strings.Contains(result.stderr, "usage: madari ring delete <name>") {
+		t.Fatalf("expected usage error, got code=%d stderr=%s", result.code, result.stderr)
+	}
+
+	result = runCmd(store, "ring", "delete", "--help")
+	if result.code != 0 || !strings.Contains(result.stdout, "madari ring delete <name>") {
+		t.Fatalf("expected delete help, got code=%d stdout=%s stderr=%s", result.code, result.stdout, result.stderr)
+	}
+
+	result = runCmd(store, "ring", "delete", "ghost")
+	if result.code == 0 || !strings.Contains(result.stderr, `ring "ghost" not found`) {
+		t.Fatalf("expected not-found error, got code=%d stderr=%s", result.code, result.stderr)
+	}
+
+	result = runCmd(store, "ring", "delete", "research")
+	if result.code != 0 {
+		t.Fatalf("delete failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "deleted ring research") {
+		t.Fatalf("expected delete confirmation, got: %s", result.stdout)
+	}
+	if _, err := store.GetRing("research"); !errors.Is(err, registry.ErrRingNotFound) {
+		t.Fatalf("expected ring removed from registry, got: %v", err)
+	}
+}
+
+func TestRunWithStoreRingDeleteRefusesAttachedScopes(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	if result := runCmd(store, "add", "stewreads", "--command", commandPath, "--client", "claude-code"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "ring", "create", "research", "--member", "stewreads"); result.code != 0 {
+		t.Fatalf("ring create failed: %s", result.stderr)
+	}
+
+	projectConfig := filepath.Join(t.TempDir(), ".mcp.json")
+	userConfig := filepath.Join(t.TempDir(), "claude.json")
+	if result := runCmd(store, "ring", "attach", "research", "claude-code", "--config-path", projectConfig); result.code != 0 {
+		t.Fatalf("project attach failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "ring", "attach", "research", "claude-code", "--scope", "user", "--config-path", userConfig); result.code != 0 {
+		t.Fatalf("user attach failed: %s", result.stderr)
+	}
+
+	result := runCmd(store, "ring", "delete", "research")
+	if result.code == 0 {
+		t.Fatalf("expected attached delete to fail")
+	}
+	for _, want := range []string{
+		`ring "research" is attached and cannot be deleted; detach it first:`,
+		"claude-code: `madari ring detach research claude-code`",
+		"claude-code (user scope): `madari ring detach research claude-code --scope user`",
+		"pass --config-path if the ring was attached to a custom config",
+	} {
+		if !strings.Contains(result.stderr, want) {
+			t.Fatalf("expected %q in refusal, got: %s", want, result.stderr)
+		}
+	}
+	if _, err := store.GetRing("research"); err != nil {
+		t.Fatalf("delete refusal should leave ring file untouched: %v", err)
 	}
 }
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -46,6 +46,7 @@ madari ring show research
 madari ring attach research claude-code
 madari ring attach research claude-code --scope user
 madari ring detach research claude-code
+madari ring delete research
 madari ring render research --client claude-code
 madari ring status
 ```
@@ -62,6 +63,11 @@ in any attach/detach order. Disabled, secret-refused, or missing members stay
 owned but absent until they become eligible. Ring membership edits (including
 snapshot imports) reconcile on the next sync, attach, or detach. Attaching
 onto an entry madari does not manage is refused, even when values match.
+
+`ring delete` removes the ring definition only after every target/scope has
+released its `ring:<name>` ownership source. If the ring is still attached,
+the command exits non-zero and prints scoped `ring detach` guidance. Deleting
+a ring never edits client configs or managed state.
 
 `ring render` prints a self-contained MCP config to stdout and mutates
 nothing — no state, no refcounts. Members are filtered by client
@@ -99,6 +105,13 @@ madari export --file madari-snapshot.json
 madari import --file madari-snapshot.json
 madari import --file madari-snapshot.json --apply
 ```
+
+Snapshots are versioned JSON documents containing server manifests and ring
+definitions. Export writes the current snapshot version with both `servers`
+and `rings`. Import is a dry-run by default; `--apply` adds or updates listed
+servers and rings, never deletes entries absent from the snapshot, and never
+attaches or syncs imported rings. Ring membership changes converge through
+the normal reconciliation pass on the next sync, attach, or detach.
 
 ## JSON Output
 

--- a/internal/registry/snapshot.go
+++ b/internal/registry/snapshot.go
@@ -8,21 +8,28 @@ import (
 	"strings"
 )
 
-const SnapshotVersion = 1
+const (
+	snapshotVersionV1 = 1
+	SnapshotVersion   = 2
+)
 
 type Snapshot struct {
 	Version int        `json:"version"`
 	Servers []Manifest `json:"servers"`
+	Rings   []Ring     `json:"rings"`
 }
 
 type ImportResult struct {
-	Added     []string
-	Updated   []string
-	Unchanged []string
+	Added          []string
+	Updated        []string
+	Unchanged      []string
+	RingsAdded     []string
+	RingsUpdated   []string
+	RingsUnchanged []string
 }
 
 func (r ImportResult) HasChanges() bool {
-	return len(r.Added)+len(r.Updated) > 0
+	return len(r.Added)+len(r.Updated)+len(r.RingsAdded)+len(r.RingsUpdated) > 0
 }
 
 func ExportSnapshot(store *Store) (Snapshot, error) {
@@ -33,15 +40,26 @@ func ExportSnapshot(store *Store) (Snapshot, error) {
 	if err != nil {
 		return Snapshot{}, err
 	}
+	rings, err := store.ListRings()
+	if err != nil {
+		return Snapshot{}, err
+	}
 	return Snapshot{
 		Version: SnapshotVersion,
 		Servers: servers,
+		Rings:   rings,
 	}, nil
 }
 
 func MarshalSnapshotJSON(snapshot Snapshot) ([]byte, error) {
-	if snapshot.Version == 0 {
+	if snapshot.Version == 0 || snapshot.Version == snapshotVersionV1 {
 		snapshot.Version = SnapshotVersion
+	}
+	if snapshot.Servers == nil {
+		snapshot.Servers = []Manifest{}
+	}
+	if snapshot.Rings == nil {
+		snapshot.Rings = []Ring{}
 	}
 	if err := snapshot.Validate(); err != nil {
 		return nil, err
@@ -65,6 +83,12 @@ func ParseSnapshotJSON(payload []byte) (Snapshot, error) {
 	if snapshot.Version == 0 {
 		snapshot.Version = SnapshotVersion
 	}
+	if snapshot.Servers == nil {
+		snapshot.Servers = []Manifest{}
+	}
+	if snapshot.Rings == nil {
+		snapshot.Rings = []Ring{}
+	}
 	if err := snapshot.Validate(); err != nil {
 		return Snapshot{}, err
 	}
@@ -86,6 +110,14 @@ func ImportSnapshot(store *Store, snapshot Snapshot, apply bool) (ImportResult, 
 	existingByName := make(map[string]Manifest, len(existing))
 	for _, manifest := range existing {
 		existingByName[manifest.Name] = manifest
+	}
+	existingRings, err := store.ListRings()
+	if err != nil {
+		return ImportResult{}, err
+	}
+	existingRingsByName := make(map[string]Ring, len(existingRings))
+	for _, ring := range existingRings {
+		existingRingsByName[ring.Name] = ring
 	}
 
 	servers := append([]Manifest(nil), snapshot.Servers...)
@@ -119,12 +151,56 @@ func ImportSnapshot(store *Store, snapshot Snapshot, apply bool) (ImportResult, 
 		}
 	}
 
+	allowedMembers := make(map[string]struct{}, len(existingByName)+len(snapshot.Servers))
+	for name := range existingByName {
+		allowedMembers[name] = struct{}{}
+	}
+	for _, server := range snapshot.Servers {
+		allowedMembers[server.Name] = struct{}{}
+	}
+
+	rings := append([]Ring(nil), snapshot.Rings...)
+	sort.Slice(rings, func(i, j int) bool {
+		return rings[i].Name < rings[j].Name
+	})
+	for _, incoming := range rings {
+		if err := validateRingMembersAgainst(incoming, allowedMembers); err != nil {
+			return ImportResult{}, err
+		}
+
+		existingRing, exists := existingRingsByName[incoming.Name]
+		if !exists {
+			result.RingsAdded = append(result.RingsAdded, incoming.Name)
+			if apply {
+				if err := store.SaveRing(incoming); err != nil {
+					return ImportResult{}, fmt.Errorf("save imported ring %q: %w", incoming.Name, err)
+				}
+			}
+			continue
+		}
+
+		if ringsEqual(existingRing, incoming) {
+			result.RingsUnchanged = append(result.RingsUnchanged, incoming.Name)
+			continue
+		}
+
+		result.RingsUpdated = append(result.RingsUpdated, incoming.Name)
+		if apply {
+			if err := store.SaveRing(incoming); err != nil {
+				return ImportResult{}, fmt.Errorf("update imported ring %q: %w", incoming.Name, err)
+			}
+		}
+	}
+
 	return result, nil
 }
 
 func (s Snapshot) Validate() error {
-	if s.Version != SnapshotVersion {
+	if s.Version != snapshotVersionV1 && s.Version != SnapshotVersion {
 		return fmt.Errorf("unsupported snapshot version %d (supported: %d)", s.Version, SnapshotVersion)
+	}
+	if s.Version == snapshotVersionV1 && len(s.Rings) > 0 {
+		return fmt.Errorf("snapshot version %d does not support rings", snapshotVersionV1)
 	}
 
 	seen := map[string]struct{}{}
@@ -138,7 +214,34 @@ func (s Snapshot) Validate() error {
 		seen[server.Name] = struct{}{}
 	}
 
+	seenRings := map[string]struct{}{}
+	for _, ring := range s.Rings {
+		if err := ring.Validate(); err != nil {
+			return fmt.Errorf("invalid ring %q: %w", ring.Name, err)
+		}
+		if _, exists := seenRings[ring.Name]; exists {
+			return fmt.Errorf("duplicate ring name %q in snapshot", ring.Name)
+		}
+		seenRings[ring.Name] = struct{}{}
+	}
+
 	return nil
+}
+
+func validateRingMembersAgainst(ring Ring, allowed map[string]struct{}) error {
+	var missing []string
+	for _, member := range ring.Members {
+		member = strings.TrimSpace(member)
+		if _, ok := allowed[member]; ok {
+			continue
+		}
+		missing = append(missing, member)
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	sort.Strings(missing)
+	return fmt.Errorf("ring %q references unknown servers: %s", ring.Name, strings.Join(missing, ", "))
 }
 
 func manifestsEqual(a, b Manifest) bool {
@@ -180,4 +283,22 @@ func manifestsEqual(a, b Manifest) bool {
 	sort.Strings(aSecret)
 	sort.Strings(bSecret)
 	return slices.Equal(aSecret, bSecret)
+}
+
+func ringsEqual(a, b Ring) bool {
+	if a.Name != b.Name || a.Description != b.Description {
+		return false
+	}
+	aMembers := normalizedRingMembers(a)
+	bMembers := normalizedRingMembers(b)
+	return slices.Equal(aMembers, bMembers)
+}
+
+func normalizedRingMembers(r Ring) []string {
+	members := make([]string, 0, len(r.Members))
+	for _, member := range r.Members {
+		members = append(members, strings.TrimSpace(member))
+	}
+	sort.Strings(members)
+	return members
 }

--- a/internal/registry/snapshot.go
+++ b/internal/registry/snapshot.go
@@ -44,6 +44,20 @@ func ExportSnapshot(store *Store) (Snapshot, error) {
 	if err != nil {
 		return Snapshot{}, err
 	}
+
+	// A snapshot must round-trip: every exported ring member has to exist in
+	// the exported server set, or the fresh import of this backup would be
+	// refused. Fail loudly instead of writing a broken artifact.
+	exportable := make(map[string]struct{}, len(servers))
+	for _, server := range servers {
+		exportable[server.Name] = struct{}{}
+	}
+	for _, ring := range rings {
+		if err := validateRingMembersAgainst(ring, exportable); err != nil {
+			return Snapshot{}, fmt.Errorf("%w; update or delete the ring before exporting", err)
+		}
+	}
+
 	return Snapshot{
 		Version: SnapshotVersion,
 		Servers: servers,
@@ -120,6 +134,21 @@ func ImportSnapshot(store *Store, snapshot Snapshot, apply bool) (ImportResult, 
 		existingRingsByName[ring.Name] = ring
 	}
 
+	// Validate every ring before any write: a rejected snapshot must not
+	// partially mutate the registry.
+	allowedMembers := make(map[string]struct{}, len(existingByName)+len(snapshot.Servers))
+	for name := range existingByName {
+		allowedMembers[name] = struct{}{}
+	}
+	for _, server := range snapshot.Servers {
+		allowedMembers[server.Name] = struct{}{}
+	}
+	for _, ring := range snapshot.Rings {
+		if err := validateRingMembersAgainst(ring, allowedMembers); err != nil {
+			return ImportResult{}, err
+		}
+	}
+
 	servers := append([]Manifest(nil), snapshot.Servers...)
 	sort.Slice(servers, func(i, j int) bool {
 		return servers[i].Name < servers[j].Name
@@ -151,23 +180,11 @@ func ImportSnapshot(store *Store, snapshot Snapshot, apply bool) (ImportResult, 
 		}
 	}
 
-	allowedMembers := make(map[string]struct{}, len(existingByName)+len(snapshot.Servers))
-	for name := range existingByName {
-		allowedMembers[name] = struct{}{}
-	}
-	for _, server := range snapshot.Servers {
-		allowedMembers[server.Name] = struct{}{}
-	}
-
 	rings := append([]Ring(nil), snapshot.Rings...)
 	sort.Slice(rings, func(i, j int) bool {
 		return rings[i].Name < rings[j].Name
 	})
 	for _, incoming := range rings {
-		if err := validateRingMembersAgainst(incoming, allowedMembers); err != nil {
-			return ImportResult{}, err
-		}
-
 		existingRing, exists := existingRingsByName[incoming.Name]
 		if !exists {
 			result.RingsAdded = append(result.RingsAdded, incoming.Name)

--- a/internal/registry/snapshot_test.go
+++ b/internal/registry/snapshot_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,6 +25,13 @@ func TestSnapshotExportParseRoundTrip(t *testing.T) {
 		Clients: []string{"claude-desktop"},
 	}); err != nil {
 		t.Fatalf("save beta manifest: %v", err)
+	}
+	if err := store.SaveRing(Ring{
+		Name:        "research",
+		Members:     []string{"beta", "alpha"},
+		Description: "Research helpers",
+	}); err != nil {
+		t.Fatalf("save ring: %v", err)
 	}
 
 	snapshot, err := ExportSnapshot(store)
@@ -49,6 +57,12 @@ func TestSnapshotExportParseRoundTrip(t *testing.T) {
 	if parsed.Servers[0].Name != "alpha" && parsed.Servers[1].Name != "alpha" {
 		t.Fatalf("expected alpha in parsed servers: %#v", parsed.Servers)
 	}
+	if len(parsed.Rings) != 1 || parsed.Rings[0].Name != "research" {
+		t.Fatalf("expected research ring in parsed snapshot, got: %#v", parsed.Rings)
+	}
+	if got := strings.Join(parsed.Rings[0].Members, ","); got != "alpha,beta" {
+		t.Fatalf("expected deterministic ring members, got: %s", got)
+	}
 }
 
 func TestMarshalSnapshotUsesSnakeCaseKeys(t *testing.T) {
@@ -66,6 +80,13 @@ func TestMarshalSnapshotUsesSnakeCaseKeys(t *testing.T) {
 				},
 			},
 		},
+		Rings: []Ring{
+			{
+				Name:        "research",
+				Members:     []string{"alpha"},
+				Description: "Research helpers",
+			},
+		},
 	}
 
 	payload, err := MarshalSnapshotJSON(snapshot)
@@ -73,7 +94,7 @@ func TestMarshalSnapshotUsesSnakeCaseKeys(t *testing.T) {
 		t.Fatalf("marshal snapshot failed: %v", err)
 	}
 	text := string(payload)
-	for _, key := range []string{`"name"`, `"command"`, `"args"`, `"enabled"`, `"clients"`, `"required_env"`, `"keys"`} {
+	for _, key := range []string{`"name"`, `"command"`, `"args"`, `"enabled"`, `"clients"`, `"required_env"`, `"keys"`, `"rings"`, `"members"`, `"description"`} {
 		if !strings.Contains(text, key) {
 			t.Fatalf("expected payload to contain key %s, payload=%s", key, text)
 		}
@@ -82,6 +103,20 @@ func TestMarshalSnapshotUsesSnakeCaseKeys(t *testing.T) {
 		if strings.Contains(text, legacy) {
 			t.Fatalf("expected payload to omit legacy key %s, payload=%s", legacy, text)
 		}
+	}
+}
+
+func TestParseSnapshotV1TreatsMissingRingsAsEmpty(t *testing.T) {
+	payload := []byte(`{"version":1,"servers":[{"name":"alpha","command":"/usr/bin/env","enabled":true,"clients":["claude-desktop"]}]}`)
+	snapshot, err := ParseSnapshotJSON(payload)
+	if err != nil {
+		t.Fatalf("parse v1 snapshot: %v", err)
+	}
+	if snapshot.Version != 1 {
+		t.Fatalf("expected v1 snapshot to keep version 1, got %d", snapshot.Version)
+	}
+	if len(snapshot.Rings) != 0 {
+		t.Fatalf("expected missing v1 rings to parse as empty, got: %#v", snapshot.Rings)
 	}
 }
 
@@ -159,6 +194,110 @@ func TestImportSnapshotDryRunAndApply(t *testing.T) {
 	}
 }
 
+func TestImportSnapshotRingsDryRunAndApply(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "servers"))
+	for _, manifest := range []Manifest{
+		{Name: "alpha", Command: "/usr/bin/env", Enabled: true, Clients: []string{"claude-desktop"}},
+		{Name: "beta", Command: "/usr/bin/env", Enabled: true, Clients: []string{"claude-desktop"}},
+	} {
+		if err := store.Save(manifest); err != nil {
+			t.Fatalf("save manifest %s: %v", manifest.Name, err)
+		}
+	}
+	for _, ring := range []Ring{
+		{Name: "research", Members: []string{"alpha"}, Description: "old"},
+		{Name: "stable", Members: []string{"alpha"}, Description: "same"},
+		{Name: "local", Members: []string{"alpha"}, Description: "preserved"},
+	} {
+		if err := store.SaveRing(ring); err != nil {
+			t.Fatalf("save ring %s: %v", ring.Name, err)
+		}
+	}
+
+	snapshot := Snapshot{
+		Version: SnapshotVersion,
+		Servers: []Manifest{
+			{Name: "gamma", Command: "/usr/bin/env", Enabled: true, Clients: []string{"claude-desktop"}},
+		},
+		Rings: []Ring{
+			{Name: "portable", Members: []string{"gamma", "alpha"}, Description: "new"},
+			{Name: "research", Members: []string{"beta", "alpha"}, Description: "new"},
+			{Name: "stable", Members: []string{"alpha"}, Description: "same"},
+		},
+	}
+
+	dryRunResult, err := ImportSnapshot(store, snapshot, false)
+	if err != nil {
+		t.Fatalf("dry-run import failed: %v", err)
+	}
+	if len(dryRunResult.RingsAdded) != 1 || dryRunResult.RingsAdded[0] != "portable" {
+		t.Fatalf("expected portable ring added in dry-run, got: %+v", dryRunResult)
+	}
+	if len(dryRunResult.RingsUpdated) != 1 || dryRunResult.RingsUpdated[0] != "research" {
+		t.Fatalf("expected research ring updated in dry-run, got: %+v", dryRunResult)
+	}
+	if len(dryRunResult.RingsUnchanged) != 1 || dryRunResult.RingsUnchanged[0] != "stable" {
+		t.Fatalf("expected stable ring unchanged in dry-run, got: %+v", dryRunResult)
+	}
+	researchAfterDryRun, err := store.GetRing("research")
+	if err != nil {
+		t.Fatalf("load research after dry-run: %v", err)
+	}
+	if researchAfterDryRun.Description != "old" {
+		t.Fatalf("expected dry-run not to change ring, got: %#v", researchAfterDryRun)
+	}
+	if _, err := store.GetRing("portable"); !errors.Is(err, ErrRingNotFound) {
+		t.Fatalf("expected dry-run not to create portable, got: %v", err)
+	}
+
+	applyResult, err := ImportSnapshot(store, snapshot, true)
+	if err != nil {
+		t.Fatalf("apply import failed: %v", err)
+	}
+	if len(applyResult.RingsAdded) != 1 || applyResult.RingsAdded[0] != "portable" {
+		t.Fatalf("expected portable ring added in apply, got: %+v", applyResult)
+	}
+	if len(applyResult.RingsUpdated) != 1 || applyResult.RingsUpdated[0] != "research" {
+		t.Fatalf("expected research ring updated in apply, got: %+v", applyResult)
+	}
+	researchAfterApply, err := store.GetRing("research")
+	if err != nil {
+		t.Fatalf("load research after apply: %v", err)
+	}
+	if researchAfterApply.Description != "new" || strings.Join(researchAfterApply.Members, ",") != "alpha,beta" {
+		t.Fatalf("expected research ring updated, got: %#v", researchAfterApply)
+	}
+	if _, err := store.GetRing("portable"); err != nil {
+		t.Fatalf("expected portable ring to exist after apply: %v", err)
+	}
+	if _, err := store.GetRing("local"); err != nil {
+		t.Fatalf("existing ring absent from snapshot should be preserved: %v", err)
+	}
+}
+
+func TestImportSnapshotRejectsUnknownRingMembers(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "servers"))
+	if err := store.Save(Manifest{Name: "alpha", Command: "/usr/bin/env", Enabled: true, Clients: []string{"claude-desktop"}}); err != nil {
+		t.Fatalf("save alpha: %v", err)
+	}
+
+	snapshot := Snapshot{
+		Version: SnapshotVersion,
+		Servers: []Manifest{
+			{Name: "beta", Command: "/usr/bin/env", Enabled: true, Clients: []string{"claude-desktop"}},
+		},
+		Rings: []Ring{
+			{Name: "good", Members: []string{"alpha", "beta"}},
+			{Name: "bad", Members: []string{"ghost"}},
+		},
+	}
+
+	_, err := ImportSnapshot(store, snapshot, false)
+	if err == nil || !strings.Contains(err.Error(), `ring "bad" references unknown servers: ghost`) {
+		t.Fatalf("expected unknown ring member error, got: %v", err)
+	}
+}
+
 func TestParseSnapshotRejectsInvalidPayloads(t *testing.T) {
 	_, err := ParseSnapshotJSON([]byte(""))
 	if err == nil || !strings.Contains(err.Error(), "empty") {
@@ -173,6 +312,16 @@ func TestParseSnapshotRejectsInvalidPayloads(t *testing.T) {
 	_, err = ParseSnapshotJSON([]byte(`{"version":99,"servers":[]}`))
 	if err == nil || !strings.Contains(err.Error(), "unsupported snapshot version") {
 		t.Fatalf("expected unsupported version error, got: %v", err)
+	}
+
+	_, err = ParseSnapshotJSON([]byte(`{"version":1,"servers":[],"rings":[{"name":"research","members":["alpha"]}]}`))
+	if err == nil || !strings.Contains(err.Error(), "does not support rings") {
+		t.Fatalf("expected v1 rings error, got: %v", err)
+	}
+
+	_, err = ParseSnapshotJSON([]byte(`{"version":2,"servers":[],"rings":[{"name":"research","members":["alpha"]},{"name":"research","members":["beta"]}]}`))
+	if err == nil || !strings.Contains(err.Error(), "duplicate ring name") {
+		t.Fatalf("expected duplicate ring error, got: %v", err)
 	}
 }
 

--- a/internal/registry/snapshot_test.go
+++ b/internal/registry/snapshot_test.go
@@ -382,3 +382,53 @@ func TestParseSnapshotFromFilePayload(t *testing.T) {
 		t.Fatalf("unexpected parsed snapshot: %+v", parsed)
 	}
 }
+
+func TestImportSnapshotApplyRejectsInvalidRingsWithoutPartialWrites(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "servers"))
+
+	// "zz-bad" sorts after the valid ring; before the fix, servers (and
+	// earlier rings) were already saved when its validation failed.
+	snapshot := Snapshot{
+		Version: SnapshotVersion,
+		Servers: []Manifest{
+			{Name: "beta", Command: "/usr/bin/env", Enabled: true, Clients: []string{"claude-desktop"}},
+		},
+		Rings: []Ring{
+			{Name: "good", Members: []string{"beta"}},
+			{Name: "zz-bad", Members: []string{"ghost"}},
+		},
+	}
+
+	_, err := ImportSnapshot(store, snapshot, true)
+	if err == nil || !strings.Contains(err.Error(), `ring "zz-bad" references unknown servers: ghost`) {
+		t.Fatalf("expected unknown ring member error, got: %v", err)
+	}
+	if _, err := store.Get("beta"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("rejected snapshot must not partially import servers, got: %v", err)
+	}
+	if _, err := store.GetRing("good"); !errors.Is(err, ErrRingNotFound) {
+		t.Fatalf("rejected snapshot must not partially import rings, got: %v", err)
+	}
+}
+
+func TestExportSnapshotRejectsStaleRings(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "servers"))
+	if err := store.Save(Manifest{Name: "alpha", Command: "/usr/bin/env", Enabled: true, Clients: []string{"claude-desktop"}}); err != nil {
+		t.Fatalf("save alpha: %v", err)
+	}
+	if err := store.SaveRing(Ring{Name: "research", Members: []string{"alpha"}}); err != nil {
+		t.Fatalf("save ring: %v", err)
+	}
+	// The member disappears after ring creation: export must refuse to
+	// write a snapshot the importer would reject.
+	if err := store.Remove("alpha"); err != nil {
+		t.Fatalf("remove alpha: %v", err)
+	}
+
+	_, err := ExportSnapshot(store)
+	if err == nil ||
+		!strings.Contains(err.Error(), `ring "research" references unknown servers: alpha`) ||
+		!strings.Contains(err.Error(), "update or delete the ring before exporting") {
+		t.Fatalf("expected stale-ring export refusal, got: %v", err)
+	}
+}


### PR DESCRIPTION
## What

- Adds `madari ring delete <name>` with a guard across every managed state target/scope.
- Extends registry snapshots to v2 with `rings` import/export while still accepting v1 server-only snapshots.
- Updates CLI export/import output plus README and CLI reference for guarded delete and snapshot rings.

## Why

This completes PR 6 of the v0.2.0 Rings plan. Ring delete must be registry-only and refuse while any `ring:<name>` ownership source remains. Snapshot v2 makes rings portable without attaching or syncing them on import.

## Commit breakdown

1. `cli: add guarded ring delete`
   - dispatch/help for `ring delete`
   - refusal scans `managedStateRefs()` including Claude Code project and user scopes
   - scoped detach hints include `--scope user` and the custom `--config-path` caveat

2. `registry: add snapshot v2 rings import export`
   - v2 snapshots carry `servers` and `rings`
   - v1 snapshots parse with empty rings
   - import validates ring members against snapshot servers union registry, adds/updates only, never deletes/attaches/syncs

3. `docs: document ring delete and snapshot rings`
   - CLI export/import ring counts
   - README and CLI reference updates

## Validation

Per commit:
- `make build`
- `go test ./...`
- `go vet ./...`

Final branch head:
- `make build`
- `go test -count=1 ./...`
- `go vet ./...`

Manual smoke used only temp `MADARI_CONFIG_DIR` and explicit temp `--config-path` files:
- create two servers and one ring
- attach the ring to `claude-code` project scope, `claude-code --scope user`, and `claude-desktop`
- verify `ring delete` exits non-zero and prints scoped detach hints plus the custom config caveat
- export snapshot and verify `2 server(s), 1 ring(s)`
- import into a fresh temp registry and verify `rings added: research` plus `ring show research`
- detach all scopes and verify `ring delete` succeeds only when unattached

## Handoff

Stopping here per the PR 6 handoff gate. PR 7 docs/release pass starts only after user review/merge and explicit approval.