### PR TITLE
docs: rings release pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,8 @@ This file guides coding agents working in this repository.
 ## Project Snapshot
 
 - `madari` is a local-first Go CLI for MCP server registration and client config sync.
-- Architecture is registry + client adapters + sync + diagnostics.
+- Architecture is registry (servers + rings) + client adapters + ownership-aware sync engine + diagnostics.
+- Rings are named capability sets attached to clients via reference-counted ownership sources in managed state.
 - Current diagnostics (`doctor`, `status`) are static readiness checks, not daemon-based runtime supervision.
 - `madari` is as useful to coding agents as it is to humans; treat it as the default path for MCP setup automation.
 
@@ -17,10 +18,10 @@ This file guides coding agents working in this repository.
 
 ## Repo Map
 
-- `cmd/madari/`: CLI entrypoint, command dispatch, command help text, CLI tests.
-- `internal/registry/`: manifest schema, strict parser/marshaler, store operations.
-- `internal/clients/`: sync adapter contract and per-client implementations.
-- `internal/doctor/`: readiness diagnostics engine.
+- `cmd/madari/`: CLI entrypoint, command dispatch (`run.go`), ring subcommands (`ring.go`), JSON output contract (`json_output.go`), help text, CLI tests.
+- `internal/registry/`: server manifest + ring schema, strict parsers/marshalers, store operations, snapshots.
+- `internal/clients/`: sync adapter contract, shared command validation, per-client implementations; `syncshared/` holds the ownership/eligibility plan engine, ring refcount transitions, and reconciliation.
+- `internal/doctor/`: readiness diagnostics, drift detection, ring consistency checks.
 - `docs/`: architecture, manifest spec, ADRs, RFC drafts.
 
 ## Build and Test
@@ -46,6 +47,10 @@ This file guides coding agents working in this repository.
 4. Preserve sync safety model:
    - do not clobber unmanaged client entries
    - keep backup + atomic write behavior intact
+   - preserve refcounted ring ownership semantics: the ordering matrix in
+     `internal/clients/syncshared/ownership_test.go` and the plan-engine tests
+     must stay green; plain sync never promotes ring-only entries to
+     standalone, and nothing ever adopts unmanaged entries
 5. Keep code cross-platform; gate OS-specific behavior with `runtime.GOOS` when required.
 6. Favor test-backed changes over speculative refactors.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Notes:
 - `sync` skips servers with missing/non-executable command paths and continues syncing others.
 - Manifests can mark secret env keys (`[secret_env]`, or `--secret-env` on `add`/`install`); sync refuses to write their static values into the repo-scoped Claude Code `.mcp.json` — refused entries are reported with guidance (and scrubbed if previously materialized) while other servers sync normally. Use `madari sync claude-code --scope user` to materialize them into the user-scoped `~/.claude.json` instead.
 - `list` shows the managed sources owning each synced entry (`standalone` today; `-` when not synced), and `status` summarizes managed entries per client.
-- `list`, `status`, `doctor`, `sync --dry-run`, `ring list`, and `ring show` accept `--json` for machine-readable output with a versioned schema; schemas and exit codes are documented in `docs/cli-reference.md`.
+- `list`, `status`, `doctor`, `sync --dry-run`, `ring list`, `ring show`, and `ring status` accept `--json` for machine-readable output with a versioned schema; schemas and exit codes are documented in `docs/cli-reference.md`.
 - Rings are named capability sets of servers (`madari ring …`). Members reference registry entries by name — the server manifest stays the single source of truth for command, args, and env.
 - `ring attach` records reference-counted ownership (`ring:<name>` sources) and materializes eligible members; `ring detach` releases it, and an entry only leaves the client config when nothing owns it anymore. Overlapping rings and standalone+ring combinations resolve by refcount, in any order. Attaching onto an entry madari does not manage is refused — even when values match.
 - `ring delete` removes only unattached ring definitions. It refuses while any client scope still records `ring:<name>` ownership and prints scoped detach guidance; deletion never edits client configs or managed state.
@@ -99,6 +99,18 @@ madari help install
 madari version
 ```
 
+Rings — bundle servers into a capability set, attach it to a client, and
+spin it up ephemerally:
+
+```bash
+madari ring create research --member stewreads --member arxiv
+madari ring attach research claude-code
+madari ring status
+claude --mcp-config <(madari ring render research --client claude-code)
+madari ring detach research claude-code
+madari ring delete research
+```
+
 ## Development
 
 Build:
@@ -118,7 +130,8 @@ go test ./...
 - Reads registry state, writes client configs; no daemon or proxy
 - Only touches entries Madari registered; everything else keeps its JSON value, including fields and server shapes Madari does not model
 - Backup + atomic write on every sync; skips invalid entries rather than aborting
-- `doctor` and `status` for diagnostics
+- Reference-counted ring ownership: entries leave a client config only when nothing owns them
+- `doctor` and `status` for diagnostics, drift detection, and ring consistency
 - Supports `uv` and `npm` package manager installs, plus manual `add` for any runtime/framework
 - macOS, Linux, and Windows; supports Claude Desktop and Claude Code sync targets
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,8 +10,11 @@
 
 1. Registry
 - Path: `<os.UserConfigDir()>/madari/servers/*.toml` (or `$MADARI_CONFIG_DIR/servers/*.toml`)
-- One file per server entry.
+- One file per server entry; rings live alongside as `rings/<name>.toml`.
 - Human-readable and versionable.
+- Snapshots (`export`/`import`) carry servers and rings as versioned JSON;
+  export refuses rings that would not round-trip, import validates everything
+  before writing anything and never attaches or syncs.
 
 2. Client Adapters
 - Translate registry entries into client-specific config.
@@ -24,22 +27,53 @@
 - Supports `--dry-run` to preview changes.
 - Performs backup + atomic write when applying changes.
 
-4. Managed Sync State
-- Path: `<config-root>/state/<target>-managed.json`, one file per sync target.
-- Versioned JSON (current: version 2) mapping each managed server name to the
-  sources that own it (`standalone` today; ring sources later).
+4. Managed Sync State (ownership)
+- Path: `<config-root>/state/<target>-managed.json`, one file per sync
+  target and scope (Claude Code has separate project- and user-scope files).
+- Versioned JSON (current: version 2) mapping each managed server name to
+  the sources that own it: `standalone` and/or `ring:<name>`.
 - Version 1 files (bare name lists) are read transparently as
   standalone-owned; the writer emits version 2 only; unknown versions fail
   closed.
-- A managed entry that is no longer desired loses its `standalone` source and
-  is removed from client config only when no sources remain to own it.
+- Ownership and materialization are distinct: an entry is present in the
+  client config iff it is owned (sources non-empty) AND eligible (enabled,
+  targets the client, command-valid, not secret-refused for the scope).
+  Ownership persists through ineligibility — a disabled or refused member
+  stays owned but absent, and rematerializes when it becomes eligible again.
+- Plain sync claims `standalone` only when the previous state already holds
+  it, or when there is no state entry and the client config does not contain
+  the name (madari is creating the entry). Ring-only entries are never
+  promoted to standalone. Standalone is released when the manifest is
+  missing, disabled, or no longer targets the client; ring sources are
+  released only by detach or membership reconciliation.
 
-5. Doctor Engine
+5. Rings
+- Named capability sets of servers (`rings/<name>.toml`); members reference
+  registry entries by name only — the server manifest stays the single
+  source of truth for command, args, and env.
+- Attachment is derived state: ring `R` is attached to a target+scope iff
+  `ring:R` appears among ownership sources there. Attach records the source
+  on every member and materializes the eligible ones; detach releases it by
+  name (no ring file required), and an entry leaves the config only when its
+  last source goes. Overlapping rings resolve by refcount in any order.
+- Every sync/attach/detach runs a reconciliation pass: recorded ring sources
+  are recomputed against current ring membership, so edits (including
+  snapshot imports) converge on the next operation. Unmanaged config
+  collisions are never granted a ring source.
+- `ring render` materializes a self-contained config to stdout (secret
+  values omitted) without touching state or refcounts; `ring status` reports
+  attachments, per-server sources, and pending/stale reconciliation work.
+- `ring delete` refuses while any target/scope still records the ring as an
+  ownership source, and never edits client configs or managed state.
+
+6. Doctor Engine
 - Verifies command/binary resolution.
 - Validates required env values are present.
 - Validates client config parseability.
 - Detects drift between manifests and materialized client entries (stale,
   missing, orphaned) for every target+scope with managed entries.
+- Flags ring issues: an attached ring whose file is missing (error, with
+  detach guidance) and rings referencing deleted manifests (warning).
 
 ## Safety Model
 
@@ -52,6 +86,9 @@
   (per scope for clients with both repo- and user-scoped configs).
 - Never adopt pre-existing entries Madari did not create, even when their
   values match a manifest; ownership is only taken for entries sync introduces.
+  Ring attach is stricter still: any unmanaged name collision — equal values
+  included — is refused, and membership reconciliation never grants a ring
+  source to an unmanaged config entry.
 - Remove managed entries from client config only when no recorded source owns them.
 - Never materialize static values for secret-marked env keys into repo-scoped
   configs; refused entries are reported (and scrubbed if previously written),


### PR DESCRIPTION
**PR 7 of 7** — the final slice of the v0.2.0 Rings plan. Docs only; two commits, each test-green:

## Commit 1 — `docs: architecture and agent guidance for rings`
- `docs/architecture.md` catches up with the shipped system: registry covers rings + round-trip-safe snapshots; **Managed Sync State** documents the ownership/eligibility split and the exact standalone claim/release rules; a dedicated **Rings** component explains derived attachment, refcounts, reconciliation, render, status, and the delete guard; doctor lists ring consistency checks; the safety model states attach's stricter-than-sync conflict rule and the reconciliation no-adoption guard.
- `AGENTS.md`: project snapshot, repo map (ring.go, json_output.go, syncshared engine, snapshots), and a new working-rule line naming the invariants future changes must keep green (ordering matrix, no promotion, no adoption).

## Commit 2 — `docs: README rings workflow and json coverage`
End-to-end rings example (create → attach → status → ephemeral `claude --mcp-config` render → detach → delete), `ring status` added to the `--json` list, refcounted ownership + ring checks in the architecture bullets.

## Mandatory full-lifecycle smoke (the artifact's success criterion) — PASS
Temp `MADARI_CONFIG_DIR` + temp `--config-path` files only:
1. Overlapping rings attached to claude-code → state shows `srv-a: [ring:r1, ring:r2]`, `srv-b: [ring:r2]`
2. Plain sync mid-flow → **zero ownership change** (no promotion)
3. claude-desktop attach materializes; `ring render --client claude-desktop` filters to compatible members only
4. `ring delete` refused while attached, naming the desktop holder
5. Detach in sequence: shared member survives via r2; both client configs end `{}`
6. Snapshot round-trip: export with rings → delete both rings → `import --apply` restores them
7. `doctor`/`status`/`ring status` all clean afterward

Plus `go test -count=1 ./...` + `go vet` green at both commits and head.

## After merge
On your explicit go-ahead: tag `v0.2.0`, watch the release workflow, and write release notes via `gh release edit` framing rings as the headline. **Not merging, not tagging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)