### PR TITLE
[codex] Add Gemini sync adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,18 +49,19 @@ Notes:
 - `install --manager npm` requires `--command` because npm package names can differ from executable names.
 - `add` resolves `--command` to an absolute executable path and stores that path in the manifest.
 - `sync` skips servers with missing/non-executable command paths and continues syncing others.
-- Manifests can mark secret env keys (`[secret_env]`, or `--secret-env` on `add`/`install`); sync refuses to write their static values into the repo-scoped Claude Code `.mcp.json` — refused entries are reported with guidance (and scrubbed if previously materialized) while other servers sync normally. Use `madari sync claude-code --scope user` to materialize them into the user-scoped `~/.claude.json` instead.
+- Manifests can mark secret env keys (`[secret_env]`, or `--secret-env` on `add`/`install`); sync refuses to write their static values into repo-scoped configs such as Claude Code `.mcp.json` and Gemini `.gemini/settings.json` — refused entries are reported with guidance (and scrubbed if previously materialized) while other servers sync normally. Use `madari sync <client> --scope user` for clients that support user scope.
 - `list` shows the managed sources owning each synced entry (`standalone` today; `-` when not synced), and `status` summarizes managed entries per client.
 - `list`, `status`, `doctor`, `sync --dry-run`, `ring list`, `ring show`, and `ring status` accept `--json` for machine-readable output with a versioned schema; schemas and exit codes are documented in `docs/cli-reference.md`.
 - Rings are named capability sets of servers (`madari ring …`). Members reference registry entries by name — the server manifest stays the single source of truth for command, args, and env.
 - `ring attach` records reference-counted ownership (`ring:<name>` sources) and materializes eligible members; `ring detach` releases it, and an entry only leaves the client config when nothing owns it anymore. Overlapping rings and standalone+ring combinations resolve by refcount, in any order. Attaching onto an entry madari does not manage is refused — even when values match.
 - `ring delete` removes only unattached ring definitions. It refuses while any client scope still records `ring:<name>` ownership and prints scoped detach guidance; deletion never edits client configs or managed state.
 - `ring render` prints a self-contained MCP config to stdout for ephemeral use — `claude --mcp-config <(madari ring render research --client claude-code)` — mutating nothing; secret env values are never emitted. Render targets are independent from persistent sync support: Claude and Gemini emit JSON, while Codex and Vibe emit TOML. `ring status` shows attached rings and per-server ownership for every client and scope.
-- Supported sync clients: `claude-desktop` and `claude-code`.
+- Supported sync clients: `claude-desktop`, `claude-code`, and `gemini`.
 - Supported render targets: `claude-code`, `claude-desktop`, `gemini`, `codex`, and `vibe`.
 - Default sync config paths:
   - `claude-desktop`: platform-specific Claude Desktop config path.
   - `claude-code`: `<current working directory>/.mcp.json`.
+  - `gemini`: `<current working directory>/.gemini/settings.json`.
 - `install --config-path` can only be used when exactly one sync target is selected.
 - `export` writes a versioned JSON snapshot of server and ring manifests for backup/sharing (stdout by default).
 - `import` is dry-run by default and only adds/updates listed servers and rings (`--apply` persists). Existing servers and rings absent from the snapshot are left unchanged; imported rings are not attached or synced.
@@ -111,10 +112,12 @@ madari install stewreads-mcp
 madari install @modelcontextprotocol/server-sequential-thinking --manager npm --command mcp-server-sequential-thinking
 madari add stewreads --command /Users/me/.local/bin/stewreads-mcp --client claude-desktop
 madari add stewreads --command /Users/me/.local/bin/stewreads-mcp --client claude-code
+madari add stewreads --command /Users/me/.local/bin/stewreads-mcp --client gemini
 madari list
 madari status
 madari sync claude-desktop --dry-run
 madari sync claude-code --dry-run
+madari sync gemini --dry-run
 madari export --file madari-snapshot.json
 madari import --file madari-snapshot.json
 madari import --file madari-snapshot.json --apply
@@ -129,12 +132,14 @@ spin it up ephemerally:
 ```bash
 madari ring create research --member stewreads --member arxiv
 madari ring attach research claude-code
+madari ring attach research gemini
 madari ring status
 claude --mcp-config <(madari ring render research --client claude-code)
 madari ring render research --client gemini
 madari ring render research --client codex
 madari ring render research --client vibe
 madari ring detach research claude-code
+madari ring detach research gemini
 madari ring delete research
 ```
 
@@ -160,7 +165,7 @@ go test ./...
 - Reference-counted ring ownership: entries leave a client config only when nothing owns them
 - `doctor` and `status` for diagnostics, drift detection, and ring consistency
 - Supports `uv` and `npm` package manager installs, plus manual `add` for any runtime/framework
-- macOS, Linux, and Windows; supports Claude Desktop and Claude Code sync targets
+- macOS, Linux, and Windows; supports Claude Desktop, Claude Code, and Gemini sync targets
 
 ## Principles
 

--- a/cmd/madari/ring.go
+++ b/cmd/madari/ring.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/ankitvg/madari/internal/clients"
-	"github.com/ankitvg/madari/internal/clients/claudecode"
 	"github.com/ankitvg/madari/internal/clients/syncshared"
 	"github.com/ankitvg/madari/internal/registry"
 )
@@ -402,7 +401,7 @@ func (a cliApp) parseRingOpArgs(command string, args []string, usage string, pri
 	fs.SetOutput(io.Discard)
 	fs.BoolVar(&dryRun, "dry-run", false, "Preview changes without writing files")
 	fs.StringVar(&configPath, "config-path", "", "Override client config path")
-	fs.StringVar(&scope, "scope", "", "Target config scope for claude-code: project (default) or user")
+	fs.StringVar(&scope, "scope", "", "Target config scope for supported clients: project (default) or user")
 	if parseErr := fs.Parse(args[2:]); parseErr != nil {
 		if errors.Is(parseErr, flag.ErrHelp) {
 			printHelp(a.stdout)
@@ -416,8 +415,8 @@ func (a cliApp) parseRingOpArgs(command string, args []string, usage string, pri
 
 	scope = strings.TrimSpace(scope)
 	if scope != "" {
-		if target != claudecode.Target {
-			return "", "", "", "", false, commandInputError(command, fmt.Sprintf("--scope is only supported for %s", claudecode.Target))
+		if !targetSupportsUserScope(target) {
+			return "", "", "", "", false, commandInputError(command, fmt.Sprintf("--scope is only supported for %s", strings.Join(userScopedSyncTargets(), ", ")))
 		}
 		if scope != clients.ScopeProject && scope != clients.ScopeUser {
 			return "", "", "", "", false, commandInputError(command, fmt.Sprintf("unknown scope %q (supported: %s, %s)", scope, clients.ScopeProject, clients.ScopeUser))
@@ -830,7 +829,7 @@ func printRingAttachHelp(out io.Writer) {
 	fmt.Fprintln(out, "  madari ring attach <ring> <client> [--scope project|user] [--dry-run] [--config-path <path>]")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Options:")
-	fmt.Fprintln(out, "  --scope project|user       Claude Code only: target scope (default: project)")
+	fmt.Fprintf(out, "  --scope project|user       Supported by %s (default: project)\n", strings.Join(userScopedSyncTargets(), ", "))
 	fmt.Fprintln(out, "  --dry-run                  Preview changes without writing files")
 	fmt.Fprintln(out, "  --config-path <path>       Override client config path")
 	fmt.Fprintln(out)
@@ -846,7 +845,7 @@ func printRingDetachHelp(out io.Writer) {
 	fmt.Fprintln(out, "  madari ring detach <ring> <client> [--scope project|user] [--dry-run] [--config-path <path>]")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Options:")
-	fmt.Fprintln(out, "  --scope project|user       Claude Code only: target scope (default: project)")
+	fmt.Fprintf(out, "  --scope project|user       Supported by %s (default: project)\n", strings.Join(userScopedSyncTargets(), ", "))
 	fmt.Fprintln(out, "  --dry-run                  Preview changes without writing files")
 	fmt.Fprintln(out, "  --config-path <path>       Override client config path")
 	fmt.Fprintln(out)

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ankitvg/madari/internal/clients"
 	claudedesktop "github.com/ankitvg/madari/internal/clients/claude-desktop"
 	"github.com/ankitvg/madari/internal/clients/claudecode"
+	"github.com/ankitvg/madari/internal/clients/gemini"
 	"github.com/ankitvg/madari/internal/clients/syncshared"
 	"github.com/ankitvg/madari/internal/doctor"
 	"github.com/ankitvg/madari/internal/registry"
@@ -24,6 +25,7 @@ var version = "0.0.0-dev"
 var syncAdapters = map[string]clients.ClientAdapter{
 	claudedesktop.Target: claudedesktop.Adapter{},
 	claudecode.Target:    claudecode.Adapter{},
+	gemini.Target:        gemini.Adapter{},
 }
 
 func supportedSyncTargets() []string {
@@ -199,7 +201,7 @@ func (a cliApp) cmdInstall(args []string) error {
 	fs.StringVar(&command, "command", "", "Server command (defaults to package name)")
 	fs.StringVar(&description, "description", "", "Server description")
 	fs.StringVar(&manager, "manager", "uv", "Package manager used for installation")
-	fs.StringVar(&configPath, "config-path", "", "Override Claude config path for sync")
+	fs.StringVar(&configPath, "config-path", "", "Override target client config path for sync")
 	fs.BoolVar(&disabled, "disabled", false, "Create server in disabled state")
 	fs.BoolVar(&noSync, "no-sync", false, "Skip automatic sync after install")
 	fs.BoolVar(&skipInstall, "skip-install", false, "Skip package installation step")
@@ -476,8 +478,8 @@ type managedStateRef struct {
 	path   string
 }
 
-// managedStateRefs lists every managed-state file across sync targets;
-// claude-code has one per scope.
+// managedStateRefs lists every managed-state file across sync targets; clients
+// with both project- and user-scoped configs have one per scope.
 func (a cliApp) managedStateRefs() []managedStateRef {
 	refs := []managedStateRef{}
 	for _, adapter := range sortedAdapters() {
@@ -485,7 +487,7 @@ func (a cliApp) managedStateRefs() []managedStateRef {
 			target: adapter.Target(),
 			path:   a.managedStatePath(adapter.Target()),
 		})
-		if adapter.Target() == claudecode.Target {
+		if targetSupportsUserScope(adapter.Target()) {
 			refs = append(refs, managedStateRef{
 				target: adapter.Target(),
 				scope:  clients.ScopeUser,
@@ -497,7 +499,7 @@ func (a cliApp) managedStateRefs() []managedStateRef {
 }
 
 // driftTargets enumerates the managed-state/config pairs doctor and status
-// diff for drift; claude-code gets one per scope.
+// diff for drift; clients with user scope get one per scope.
 func (a cliApp) driftTargets(adapters []clients.ClientAdapter, configPathOverrides map[string]string) []doctor.DriftTarget {
 	targets := make([]doctor.DriftTarget, 0, len(adapters)+1)
 	for _, adapter := range adapters {
@@ -506,7 +508,7 @@ func (a cliApp) driftTargets(adapters []clients.ClientAdapter, configPathOverrid
 			StatePath:  a.managedStatePath(adapter.Target()),
 			ConfigPath: configPathOverrides[adapter.Target()],
 		})
-		if adapter.Target() == claudecode.Target {
+		if targetSupportsUserScope(adapter.Target()) {
 			targets = append(targets, doctor.DriftTarget{
 				Adapter:   adapter,
 				Scope:     clients.ScopeUser,
@@ -634,7 +636,7 @@ func (a cliApp) cmdSync(args []string) error {
 	fs.BoolVar(&dryRun, "dry-run", false, "Preview changes without writing files")
 	fs.StringVar(&configPath, "config-path", "", "Override client config path")
 	fs.BoolVar(&jsonOut, "json", false, "Emit JSON instead of text (requires --dry-run)")
-	fs.StringVar(&scope, "scope", "", "Target config scope for claude-code: project (default) or user")
+	fs.StringVar(&scope, "scope", "", "Target config scope for supported clients: project (default) or user")
 	if err := fs.Parse(args[1:]); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			printSyncHelp(a.stdout)
@@ -650,8 +652,8 @@ func (a cliApp) cmdSync(args []string) error {
 	}
 	scope = strings.TrimSpace(scope)
 	if scope != "" {
-		if target != claudecode.Target {
-			return commandInputError("sync", fmt.Sprintf("--scope is only supported for %s", claudecode.Target))
+		if !targetSupportsUserScope(target) {
+			return commandInputError("sync", fmt.Sprintf("--scope is only supported for %s", strings.Join(userScopedSyncTargets(), ", ")))
 		}
 		if scope != clients.ScopeProject && scope != clients.ScopeUser {
 			return commandInputError("sync", fmt.Sprintf("unknown scope %q (supported: %s, %s)", scope, clients.ScopeProject, clients.ScopeUser))
@@ -1261,6 +1263,25 @@ func sortedAdapters() []clients.ClientAdapter {
 	return adapters
 }
 
+func userScopedSyncTargets() []string {
+	targets := []string{}
+	for _, target := range supportedSyncTargets() {
+		if targetSupportsUserScope(target) {
+			targets = append(targets, target)
+		}
+	}
+	return targets
+}
+
+func targetSupportsUserScope(target string) bool {
+	switch target {
+	case claudecode.Target, gemini.Target:
+		return true
+	default:
+		return false
+	}
+}
+
 func parseClientConfigOverrides(pairs []string) (map[string]string, error) {
 	overrides := map[string]string{}
 	for _, pair := range pairs {
@@ -1653,8 +1674,8 @@ func printSyncHelp(out io.Writer) {
 	fmt.Fprintln(out, "  --dry-run                  Preview changes without writing files")
 	fmt.Fprintln(out, "  --config-path <path>       Override target client config path")
 	fmt.Fprintln(out, "  --json                     Emit JSON instead of text (requires --dry-run)")
-	fmt.Fprintln(out, "  --scope project|user       Claude Code only: target the repo-scoped .mcp.json")
-	fmt.Fprintln(out, "                             (project, default) or the user-scoped ~/.claude.json")
+	fmt.Fprintf(out, "  --scope project|user       Supported by %s; project is the default\n", strings.Join(userScopedSyncTargets(), ", "))
+	fmt.Fprintln(out, "                             and user targets the client's user config")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Description:")
 	fmt.Fprintln(out, "  Sync enabled servers from Madari registry into a target client config.")

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -914,6 +914,46 @@ func TestRunWithStoreSyncClaudeCodeApply(t *testing.T) {
 	}
 }
 
+func TestRunWithStoreSyncGeminiApply(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	addResult := runCmd(store, "add", "stewreads", "--command", commandPath, "--client", "gemini")
+	if addResult.code != 0 {
+		t.Fatalf("setup add failed: %s", addResult.stderr)
+	}
+
+	configPath := filepath.Join(t.TempDir(), ".gemini", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{"mcpServers":{"weather":{"command":"uv"}}}`), 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	result := runCmd(store, "sync", "gemini", "--config-path", configPath)
+	if result.code != 0 {
+		t.Fatalf("sync apply failed with stderr: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "mode: applied") {
+		t.Fatalf("expected applied mode output, got: %s", result.stdout)
+	}
+	if !strings.Contains(result.stdout, "sync target: gemini") {
+		t.Fatalf("expected gemini target output, got: %s", result.stdout)
+	}
+
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config after sync: %v", err)
+	}
+	if !strings.Contains(string(after), "\"stewreads\"") {
+		t.Fatalf("expected synced config to include stewreads server, got: %s", string(after))
+	}
+	if !strings.Contains(string(after), "\"weather\"") {
+		t.Fatalf("expected synced config to preserve existing weather server, got: %s", string(after))
+	}
+}
+
 func TestRunWithStoreSyncSkipsMissingExecutable(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("executable fixture handling not needed in this test environment")
@@ -1121,6 +1161,9 @@ func TestRunWithStoreClientsListsAllAdapters(t *testing.T) {
 	if !strings.Contains(result.stdout, "claude-code") {
 		t.Fatalf("expected claude-code in clients output, got: %s", result.stdout)
 	}
+	if !strings.Contains(result.stdout, "gemini") {
+		t.Fatalf("expected gemini in clients output, got: %s", result.stdout)
+	}
 }
 
 func TestRunWithStoreClientsShowsHeaderAndStatus(t *testing.T) {
@@ -1235,6 +1278,39 @@ func TestRunWithStoreDoctorReturnsErrorForInvalidClaudeCodeConfig(t *testing.T) 
 	}
 	if !strings.Contains(result.stdout, "claude-code config:") {
 		t.Fatalf("expected doctor output to include claude-code config details, got: %s", result.stdout)
+	}
+}
+
+func TestRunWithStoreDoctorAndStatusInspectGeminiConfig(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	if result := runCmd(store, "add", "stewreads", "--command", commandPath, "--client", "gemini"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+
+	configPath := filepath.Join(t.TempDir(), ".gemini", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{"mcpServers":{}}`), 0o644); err != nil {
+		t.Fatalf("write Gemini config fixture: %v", err)
+	}
+
+	result := runCmd(store, "doctor", "--client-config", "gemini="+configPath)
+	if result.code != 0 {
+		t.Fatalf("doctor expected success, got code=%d stderr=%s stdout=%s", result.code, result.stderr, result.stdout)
+	}
+	if !strings.Contains(result.stdout, "gemini config:") {
+		t.Fatalf("expected doctor output to include gemini config details, got: %s", result.stdout)
+	}
+
+	result = runCmd(store, "status", "--client-config", "gemini="+configPath)
+	if result.code != 0 {
+		t.Fatalf("status expected success, got code=%d stderr=%s stdout=%s", result.code, result.stderr, result.stdout)
+	}
+	if !strings.Contains(result.stdout, "gemini-config: ready") {
+		t.Fatalf("expected status output to include gemini config readiness, got: %s", result.stdout)
 	}
 }
 
@@ -1583,7 +1659,7 @@ func TestRunWithStoreSyncScopeValidation(t *testing.T) {
 	if result.code == 0 {
 		t.Fatalf("expected --scope on claude-desktop to fail")
 	}
-	if !strings.Contains(result.stderr, "--scope is only supported for claude-code") {
+	if !strings.Contains(result.stderr, "--scope is only supported for claude-code, gemini") {
 		t.Fatalf("expected scope support error, got: %s", result.stderr)
 	}
 
@@ -1639,7 +1715,7 @@ func TestRunWithStoreSecretEnvPlacementFlow(t *testing.T) {
 	}
 
 	// status counts user-scope managed entries (no exit-code assertion:
-	// user-scope drift inspects the machine's real ~/.claude.json).
+	// user-scope drift inspects the machine's real user config).
 	result = runCmd(store, "status", "--client-config", "claude-code="+projectConfig)
 	if !strings.Contains(result.stdout, "claude-code-user-managed: entries=1 sources=standalone") {
 		t.Fatalf("expected user-scope managed summary in status, got: %s", result.stdout)
@@ -2165,6 +2241,49 @@ func TestRunWithStoreRingAttachDetachFlow(t *testing.T) {
 	}
 }
 
+func TestRunWithStoreRingAttachDetachGemini(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	if result := runCmd(store, "add", "stewreads", "--command", commandPath, "--client", "gemini"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "ring", "create", "research", "--member", "stewreads"); result.code != 0 {
+		t.Fatalf("ring create failed: %s", result.stderr)
+	}
+
+	configPath := filepath.Join(t.TempDir(), ".gemini", "settings.json")
+	result := runCmd(store, "ring", "attach", "research", "gemini", "--config-path", configPath)
+	if result.code != 0 {
+		t.Fatalf("attach failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "sync target: gemini") || !strings.Contains(result.stdout, "added: stewreads") {
+		t.Fatalf("expected gemini attach output, got: %s", result.stdout)
+	}
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read Gemini config after attach: %v", err)
+	}
+	if !strings.Contains(string(after), "\"stewreads\"") {
+		t.Fatalf("expected attached ring member in Gemini config, got: %s", after)
+	}
+
+	result = runCmd(store, "ring", "detach", "research", "gemini", "--config-path", configPath)
+	if result.code != 0 {
+		t.Fatalf("detach failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "removed: stewreads") {
+		t.Fatalf("expected gemini detach removal, got: %s", result.stdout)
+	}
+	after, err = os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read Gemini config after detach: %v", err)
+	}
+	if strings.Contains(string(after), "\"stewreads\"") {
+		t.Fatalf("expected detached ring member removed from Gemini config, got: %s", after)
+	}
+}
+
 func TestRunWithStoreRingAttachWarnsDisabledMember(t *testing.T) {
 	store := newTestStore(t)
 	commandPath := mustCurrentExecutable(t)
@@ -2273,10 +2392,6 @@ func TestRunWithStoreRingRender(t *testing.T) {
 func TestRunWithStoreRingRenderJSONTargets(t *testing.T) {
 	store := newTestStore(t)
 	commandPath := mustCurrentExecutable(t)
-
-	if _, ok := syncAdapters["gemini"]; ok {
-		t.Fatal("gemini must not be registered as a sync adapter")
-	}
 
 	if result := runCmd(store, "add", "portable", "--command", commandPath,
 		"--client", "claude-desktop",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@
 
 2. Client Adapters
 - Translate registry entries into client-specific config.
-- Current adapters: Claude Desktop and Claude Code.
+- Current adapters: Claude Desktop, Claude Code, and Gemini.
 - Adapters own read/merge/write behavior for their client format.
 
 3. Sync Engine
@@ -29,7 +29,7 @@
 
 4. Managed Sync State (ownership)
 - Path: `<config-root>/state/<target>-managed.json`, one file per sync
-  target and scope (Claude Code has separate project- and user-scope files).
+  target and scope (project/user-scoped clients have separate state files).
 - Versioned JSON (current: version 2) mapping each managed server name to
   the sources that own it: `standalone` and/or `ring:<name>`.
 - Version 1 files (bare name lists) are read transparently as

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -28,14 +28,18 @@ madari sync claude-desktop
 madari sync claude-code --dry-run
 madari sync claude-code
 madari sync claude-code --scope user
+madari sync gemini --dry-run
+madari sync gemini
+madari sync gemini --scope user
 ```
 
-`--scope` applies to `claude-code` only: `project` (default) targets the
-repo-scoped `.mcp.json`, `user` targets the user-scoped `~/.claude.json`.
-Each scope tracks its managed entries independently. Servers carrying static
-values for `[secret_env]` keys are refused per entry at project scope (other
-servers keep syncing; a previously materialized secret entry is scrubbed)
-and must sync with `--scope user`.
+`--scope` applies to clients with project and user configs: `claude-code`
+(`.mcp.json` or `~/.claude.json`) and `gemini` (`.gemini/settings.json` or
+`~/.gemini/settings.json`). `project` is the default. Each scope tracks its
+managed entries independently. Servers carrying static values for
+`[secret_env]` keys are refused per entry at project scope (other servers
+keep syncing; a previously materialized secret entry is scrubbed) and must
+sync with `--scope user`.
 
 ## Rings
 
@@ -45,7 +49,10 @@ madari ring list
 madari ring show research
 madari ring attach research claude-code
 madari ring attach research claude-code --scope user
+madari ring attach research gemini
+madari ring attach research gemini --scope user
 madari ring detach research claude-code
+madari ring detach research gemini
 madari ring delete research
 madari ring render research --client claude-code
 madari ring render research --client gemini
@@ -174,12 +181,15 @@ summaries cover every sync target):
   "summary": {"total": 1, "ready": 1, "warning": 0, "error": 0, "skipped": 0},
   "client_configs": [
     {"target": "claude-code", "status": "skipped"},
-    {"target": "claude-desktop", "status": "ready"}
+    {"target": "claude-desktop", "status": "ready"},
+    {"target": "gemini", "status": "skipped"}
   ],
   "managed": [
     {"target": "claude-code", "scope": "default", "entries": 0, "sources": []},
     {"target": "claude-code", "scope": "user", "entries": 0, "sources": []},
-    {"target": "claude-desktop", "scope": "default", "entries": 1, "sources": ["standalone"]}
+    {"target": "claude-desktop", "scope": "default", "entries": 1, "sources": ["standalone"]},
+    {"target": "gemini", "scope": "default", "entries": 0, "sources": []},
+    {"target": "gemini", "scope": "user", "entries": 0, "sources": []}
   ],
   "manifest_errors": 0,
   "drift": [
@@ -359,3 +369,4 @@ madari version
 
 - `claude-desktop`
 - `claude-code`
+- `gemini`

--- a/docs/manifest-spec.md
+++ b/docs/manifest-spec.md
@@ -23,9 +23,9 @@ Known client IDs:
 - `codex`
 - `vibe`
 
-`claude-desktop` and `claude-code` are sync-capable today. `gemini`,
-`codex`, and `vibe` are render targets for `madari ring render`; they are
-not persistent sync targets unless adapter support is added separately.
+`claude-desktop`, `claude-code`, and `gemini` are sync-capable today.
+`codex` and `vibe` are render targets for `madari ring render`; they are not
+persistent sync targets unless adapter support is added separately.
 
 ### `[env]`
 
@@ -39,8 +39,9 @@ Key/value static environment variables.
 
 - `keys` (array of strings): env vars whose values are secrets. Sync refuses
   to materialize a static `[env]` value for a secret key into repo-scoped
-  client configs (for example the Claude Code project `.mcp.json`); secret
-  values may only land in user-scoped configs.
+  client configs (for example Claude Code `.mcp.json` or Gemini
+  `.gemini/settings.json`); secret values may only land in user-scoped
+  configs.
 
 ## Example
 

--- a/internal/clients/gemini/adapter.go
+++ b/internal/clients/gemini/adapter.go
@@ -1,0 +1,31 @@
+package gemini
+
+import (
+	"github.com/ankitvg/madari/internal/clients"
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+// Adapter implements clients.ClientAdapter for Gemini CLI.
+type Adapter struct{}
+
+var _ clients.ClientAdapter = Adapter{}
+
+func (Adapter) Target() string {
+	return Target
+}
+
+func (Adapter) DefaultConfigPath() (string, error) {
+	return DefaultProjectConfigPath()
+}
+
+func (Adapter) Sync(manifests []registry.Manifest, opts clients.SyncOptions) (clients.SyncResult, error) {
+	return Sync(manifests, opts)
+}
+
+func (Adapter) AttachRing(ring registry.Ring, manifests []registry.Manifest, opts clients.SyncOptions) (clients.SyncResult, error) {
+	return AttachRing(ring, manifests, opts)
+}
+
+func (Adapter) DetachRing(ring string, opts clients.SyncOptions) (clients.SyncResult, error) {
+	return DetachRing(ring, opts)
+}

--- a/internal/clients/gemini/sync.go
+++ b/internal/clients/gemini/sync.go
@@ -1,0 +1,374 @@
+package gemini
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ankitvg/madari/internal/clients"
+	"github.com/ankitvg/madari/internal/clients/syncshared"
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+const (
+	Target = "gemini"
+)
+
+var ErrConflict = clients.ErrConflict
+
+// SyncOptions configures sync behavior.
+type SyncOptions = clients.SyncOptions
+
+// SyncResult captures the computed or applied mutation plan.
+type SyncResult = clients.SyncResult
+
+// Sync synchronizes enabled Gemini-targeted manifests into the Gemini CLI
+// settings file. The default scope is project (.gemini/settings.json), matching
+// `gemini mcp add`; user scope targets ~/.gemini/settings.json.
+func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
+	userScope, err := resolveScope(opts.Scope)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	configPath, err := resolveConfigPath(opts.ConfigPath, userScope)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	statePath, err := resolveStatePath(opts.StatePath, userScope)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	root, rawServers, existingServers, configExists, err := loadGeminiConfig(configPath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	managedState, err := syncshared.LoadManagedState(statePath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	result, nextState, writeSet, err := syncshared.PlanSync(existingServers, managedState, entriesForTarget(manifests, userScope), opts.Rings, equalServer, ErrConflict)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	result.ConfigPath = configPath
+	result.DryRun = opts.DryRun
+
+	if opts.DryRun {
+		return result, nil
+	}
+
+	if err := applyPlan(configPath, statePath, root, rawServers, configExists, result.Removed, writeSet, nextState); err != nil {
+		return SyncResult{}, err
+	}
+	return result, nil
+}
+
+// AttachRing adds the ring's ownership source to every member and materializes
+// eligible ones into the Gemini settings file. Attaching onto any pre-existing
+// unmanaged entry, equal values included, refuses with ErrConflict.
+func AttachRing(ring registry.Ring, manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
+	userScope, err := resolveScope(opts.Scope)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	configPath, err := resolveConfigPath(opts.ConfigPath, userScope)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	statePath, err := resolveStatePath(opts.StatePath, userScope)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	root, rawServers, existingServers, configExists, err := loadGeminiConfig(configPath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	managedState, err := syncshared.LoadManagedState(statePath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	result, nextState, writeSet, err := syncshared.PlanAttach(existingServers, managedState, ring.Name, ring.Members, entriesForTarget(manifests, userScope), opts.Rings, equalServer, ErrConflict)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	result.ConfigPath = configPath
+	result.DryRun = opts.DryRun
+
+	if opts.DryRun {
+		return result, nil
+	}
+	if err := applyPlan(configPath, statePath, root, rawServers, configExists, result.Removed, writeSet, nextState); err != nil {
+		return SyncResult{}, err
+	}
+	return result, nil
+}
+
+// DetachRing removes the ring's ownership source everywhere; entries that lose
+// their last source leave the config. The ring file is not required, so stale
+// sources can always be released.
+func DetachRing(ringName string, opts SyncOptions) (SyncResult, error) {
+	userScope, err := resolveScope(opts.Scope)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	configPath, err := resolveConfigPath(opts.ConfigPath, userScope)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	statePath, err := resolveStatePath(opts.StatePath, userScope)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	root, rawServers, existingServers, configExists, err := loadGeminiConfig(configPath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	managedState, err := syncshared.LoadManagedState(statePath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	result, nextState := syncshared.PlanDetach(existingServers, managedState, ringName, opts.Rings)
+	result.ConfigPath = configPath
+	result.DryRun = opts.DryRun
+
+	if opts.DryRun {
+		return result, nil
+	}
+	if err := applyPlan(configPath, statePath, root, rawServers, configExists, result.Removed, nil, nextState); err != nil {
+		return SyncResult{}, err
+	}
+	return result, nil
+}
+
+// applyPlan writes the mutated config (backup + atomic write) and ownership
+// state. The raw entries pass through untouched except for removals and the
+// write set; pre-existing unmanaged entries are never serialized.
+func applyPlan(
+	configPath, statePath string,
+	root, rawServers map[string]json.RawMessage,
+	configExists bool,
+	removed []string,
+	writeSet map[string]serverConfig,
+	nextState map[string][]string,
+) error {
+	mutated := make(map[string]json.RawMessage, len(rawServers)+len(writeSet))
+	for name, raw := range rawServers {
+		mutated[name] = raw
+	}
+	for _, name := range removed {
+		delete(mutated, name)
+	}
+	for name, server := range writeSet {
+		entryPayload, err := json.Marshal(server)
+		if err != nil {
+			return fmt.Errorf("marshal server %q: %w", name, err)
+		}
+		mutated[name] = entryPayload
+	}
+
+	updatedRoot := make(map[string]json.RawMessage, len(root)+1)
+	for key, value := range root {
+		updatedRoot[key] = value
+	}
+	serversPayload, err := json.Marshal(mutated)
+	if err != nil {
+		return fmt.Errorf("marshal mcpServers: %w", err)
+	}
+	updatedRoot["mcpServers"] = serversPayload
+
+	payload, err := json.MarshalIndent(updatedRoot, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal Gemini config: %w", err)
+	}
+	payload = append(payload, '\n')
+
+	if configExists {
+		if _, err := syncshared.BackupFile(configPath); err != nil {
+			return fmt.Errorf("backup Gemini config: %w", err)
+		}
+	}
+	if err := syncshared.WriteFileAtomically(configPath, payload, 0o644); err != nil {
+		return fmt.Errorf("write Gemini config: %w", err)
+	}
+
+	if err := syncshared.SaveManagedState(statePath, nextState); err != nil {
+		return fmt.Errorf("write managed sync state: %w", err)
+	}
+	return nil
+}
+
+func DefaultProjectConfigPath() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("resolve current working directory: %w", err)
+	}
+	return filepath.Join(cwd, ".gemini", "settings.json"), nil
+}
+
+func DefaultUserConfigPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user home: %w", err)
+	}
+	return filepath.Join(home, ".gemini", "settings.json"), nil
+}
+
+func DefaultStatePath() (string, error) {
+	root, err := registry.DefaultRootDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, "state", Target+"-managed.json"), nil
+}
+
+func DefaultUserStatePath() (string, error) {
+	root, err := registry.DefaultRootDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, "state", Target+"-user-managed.json"), nil
+}
+
+func resolveConfigPath(configPath string, userScope bool) (string, error) {
+	if userScope {
+		return syncshared.ResolvePath(configPath, DefaultUserConfigPath)
+	}
+	return syncshared.ResolvePath(configPath, DefaultProjectConfigPath)
+}
+
+// resolveScope reports whether opts.Scope selects the user-scoped config.
+// Empty defaults to project (fail closed); unknown values are rejected.
+func resolveScope(scope string) (bool, error) {
+	switch strings.TrimSpace(scope) {
+	case "", clients.ScopeProject:
+		return false, nil
+	case clients.ScopeUser:
+		return true, nil
+	default:
+		return false, fmt.Errorf("unknown sync scope %q (supported: %s, %s)", scope, clients.ScopeProject, clients.ScopeUser)
+	}
+}
+
+func resolveStatePath(statePath string, userScope bool) (string, error) {
+	if userScope {
+		return syncshared.ResolvePath(statePath, DefaultUserStatePath)
+	}
+	return syncshared.ResolvePath(statePath, DefaultStatePath)
+}
+
+// entriesForTarget classifies every Gemini-targeted manifest for the plan
+// engine. Disabled manifests are ineligible (ownership release); secret-bearing
+// manifests at project scope are refused (scrubbed but ring ownership
+// persists); manifests for other clients are omitted entirely.
+func entriesForTarget(manifests []registry.Manifest, userScope bool) map[string]syncshared.Entry[serverConfig] {
+	entries := map[string]syncshared.Entry[serverConfig]{}
+	for _, manifest := range manifests {
+		if !manifest.HasClient(Target) {
+			continue
+		}
+		entry := syncshared.Entry[serverConfig]{}
+		switch {
+		case !manifest.Enabled:
+			// ineligible
+		case !userScope && manifest.HasSecretValue():
+			entry.Refused = true
+		default:
+			entry.Eligible = true
+			entry.Value = materializeServer(manifest)
+		}
+		entries[manifest.Name] = entry
+	}
+	return entries
+}
+
+func materializeServer(manifest registry.Manifest) serverConfig {
+	entry := serverConfig{Command: manifest.Command}
+	if len(manifest.Args) > 0 {
+		entry.Args = append([]string(nil), manifest.Args...)
+	}
+	if len(manifest.Env) > 0 {
+		entry.Env = map[string]string{}
+		for key, value := range manifest.Env {
+			entry.Env[key] = value
+		}
+	}
+	return entry
+}
+
+func equalServer(a, b serverConfig) bool {
+	if a.Command != b.Command {
+		return false
+	}
+	if len(a.Args) != len(b.Args) {
+		return false
+	}
+	for i := range a.Args {
+		if a.Args[i] != b.Args[i] {
+			return false
+		}
+	}
+	if len(a.Env) != len(b.Env) {
+		return false
+	}
+	for key, value := range a.Env {
+		if b.Env[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+// loadGeminiConfig returns the settings root plus two views of mcpServers: the
+// raw JSON per entry (preserved verbatim for entries madari does not write)
+// and the typed view used for planning.
+func loadGeminiConfig(path string) (map[string]json.RawMessage, map[string]json.RawMessage, map[string]serverConfig, bool, error) {
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]json.RawMessage{}, map[string]json.RawMessage{}, map[string]serverConfig{}, false, nil
+		}
+		return nil, nil, nil, false, fmt.Errorf("read Gemini config %q: %w", path, err)
+	}
+
+	root := map[string]json.RawMessage{}
+	if err := json.Unmarshal(payload, &root); err != nil {
+		return nil, nil, nil, true, fmt.Errorf("parse Gemini config JSON: %w", err)
+	}
+
+	rawServers := map[string]json.RawMessage{}
+	if raw, exists := root["mcpServers"]; exists {
+		if err := json.Unmarshal(raw, &rawServers); err != nil {
+			return nil, nil, nil, true, fmt.Errorf("parse mcpServers: %w", err)
+		}
+	}
+	if rawServers == nil {
+		rawServers = map[string]json.RawMessage{}
+	}
+
+	servers := make(map[string]serverConfig, len(rawServers))
+	for name, raw := range rawServers {
+		entry := serverConfig{}
+		if err := json.Unmarshal(raw, &entry); err != nil {
+			return nil, nil, nil, true, fmt.Errorf("parse mcpServers entry %q: %w", name, err)
+		}
+		servers[name] = entry
+	}
+
+	return root, rawServers, servers, true, nil
+}
+
+type serverConfig struct {
+	Command string            `json:"command"`
+	Args    []string          `json:"args,omitempty"`
+	Env     map[string]string `json:"env,omitempty"`
+}

--- a/internal/clients/gemini/sync_test.go
+++ b/internal/clients/gemini/sync_test.go
@@ -1,0 +1,629 @@
+package gemini
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/ankitvg/madari/internal/clients"
+	"github.com/ankitvg/madari/internal/clients/syncshared"
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+func TestSyncDryRunDoesNotMutateFiles(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".gemini", "settings.json")
+	statePath := filepath.Join(tmp, "state", "gemini-managed.json")
+
+	original := []byte(`{
+  "mcpServers": {
+    "weather": {
+      "command": "uv",
+      "args": ["run", "weather.py"]
+    }
+  },
+  "theme": "Default"
+}
+`)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, original, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	result, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+		DryRun:     true,
+	})
+	if err != nil {
+		t.Fatalf("sync dry-run failed: %v", err)
+	}
+	if len(result.Added) != 1 || result.Added[0] != "stewreads" {
+		t.Fatalf("expected stewreads to be planned as added, got: %+v", result)
+	}
+
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config after dry-run: %v", err)
+	}
+	if string(after) != string(original) {
+		t.Fatalf("expected dry-run to keep config unchanged")
+	}
+	if _, err := os.Stat(statePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected no state file write on dry-run, got err=%v", err)
+	}
+}
+
+func TestSyncApplyAddUpdateRemoveLifecycle(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".gemini", "settings.json")
+	statePath := filepath.Join(tmp, "state", "gemini-managed.json")
+
+	baseConfig := []byte(`{
+  "mcpServers": {
+    "weather": {
+      "command": "uv",
+      "args": ["run", "weather.py"]
+    }
+  },
+  "telemetry": {
+    "enabled": false
+  }
+}
+`)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, baseConfig, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	manifest := newStewreadsManifest()
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("initial sync failed: %v", err)
+	}
+	if len(result.Added) != 1 || result.Added[0] != "stewreads" {
+		t.Fatalf("expected add result, got: %+v", result)
+	}
+
+	servers := readServers(t, configPath)
+	if _, ok := servers["weather"]; !ok {
+		t.Fatalf("expected existing weather server to be preserved")
+	}
+	if got := servers["stewreads"].Command; got != "stewreads-mcp" {
+		t.Fatalf("expected stewreads command to be synced, got: %q", got)
+	}
+
+	managedNames := readManagedNames(t, statePath)
+	if len(managedNames) != 1 || managedNames[0] != "stewreads" {
+		t.Fatalf("expected managed state to track stewreads, got: %#v", managedNames)
+	}
+
+	result, err = Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("unchanged sync failed: %v", err)
+	}
+	if len(result.Unchanged) != 1 || result.Unchanged[0] != "stewreads" {
+		t.Fatalf("expected unchanged result, got: %+v", result)
+	}
+
+	manifest.Args = []string{"--stdio"}
+	result, err = Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("update sync failed: %v", err)
+	}
+	if len(result.Updated) != 1 || result.Updated[0] != "stewreads" {
+		t.Fatalf("expected update result, got: %+v", result)
+	}
+	servers = readServers(t, configPath)
+	if len(servers["stewreads"].Args) != 1 || servers["stewreads"].Args[0] != "--stdio" {
+		t.Fatalf("expected synced args update, got: %#v", servers["stewreads"].Args)
+	}
+
+	manifest.Enabled = false
+	result, err = Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("remove sync failed: %v", err)
+	}
+	if len(result.Removed) != 1 || result.Removed[0] != "stewreads" {
+		t.Fatalf("expected remove result, got: %+v", result)
+	}
+	servers = readServers(t, configPath)
+	if _, ok := servers["stewreads"]; ok {
+		t.Fatalf("expected stewreads to be removed from Gemini config")
+	}
+	if _, ok := servers["weather"]; !ok {
+		t.Fatalf("expected weather to remain after removal")
+	}
+
+	managedNames = readManagedNames(t, statePath)
+	if len(managedNames) != 0 {
+		t.Fatalf("expected managed state to be empty after removal, got: %#v", managedNames)
+	}
+}
+
+func TestSyncRejectsUnmanagedNameCollision(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".gemini", "settings.json")
+	statePath := filepath.Join(tmp, "state", "gemini-managed.json")
+
+	config := []byte(`{
+  "mcpServers": {
+    "stewreads": {
+      "command": "manual-custom-command"
+    }
+  }
+}
+`)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	_, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+		DryRun:     true,
+	})
+	if !errors.Is(err, clients.ErrConflict) {
+		t.Fatalf("expected clients.ErrConflict, got: %v", err)
+	}
+}
+
+func TestSyncApplyPreservesUnknownTopLevelBlocks(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".gemini", "settings.json")
+	statePath := filepath.Join(tmp, "state", "gemini-managed.json")
+
+	config := []byte(`{
+  "mcpServers": {
+    "weather": {
+      "command": "uv"
+    }
+  },
+  "theme": "Default",
+  "telemetry": {
+    "enabled": false
+  }
+}
+`)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	if _, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	}); err != nil {
+		t.Fatalf("sync apply failed: %v", err)
+	}
+
+	root := readRoot(t, configPath)
+	assertJSONEqual(t, []byte(`"Default"`), root["theme"])
+	assertJSONEqual(t, []byte(`{"enabled":false}`), root["telemetry"])
+}
+
+func TestSyncApplyFailsClosedOnInvalidJSON(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".gemini", "settings.json")
+	statePath := filepath.Join(tmp, "state", "gemini-managed.json")
+
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+	invalid := []byte("{broken")
+	if err := os.WriteFile(configPath, invalid, 0o644); err != nil {
+		t.Fatalf("write invalid config fixture: %v", err)
+	}
+
+	_, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err == nil {
+		t.Fatalf("expected sync apply to fail on invalid JSON")
+	}
+	if !strings.Contains(err.Error(), "parse Gemini config JSON") {
+		t.Fatalf("expected parse error, got: %v", err)
+	}
+
+	after, readErr := os.ReadFile(configPath)
+	if readErr != nil {
+		t.Fatalf("read config after failed sync: %v", readErr)
+	}
+	if string(after) != string(invalid) {
+		t.Fatalf("expected fail-closed behavior with unchanged config")
+	}
+	if _, statErr := os.Stat(statePath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected no state file write on failure, got err=%v", statErr)
+	}
+	backups, globErr := filepath.Glob(configPath + ".bak.*")
+	if globErr != nil {
+		t.Fatalf("glob backup files: %v", globErr)
+	}
+	if len(backups) != 0 {
+		t.Fatalf("expected no backup files on parse failure, got: %#v", backups)
+	}
+}
+
+func TestSyncApplyCreatesBackup(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".gemini", "settings.json")
+	statePath := filepath.Join(tmp, "state", "gemini-managed.json")
+
+	original := []byte(`{
+  "mcpServers": {
+    "weather": {
+      "command": "uv"
+    }
+  }
+}
+`)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, original, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	if _, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	}); err != nil {
+		t.Fatalf("sync apply failed: %v", err)
+	}
+
+	backups, err := filepath.Glob(configPath + ".bak.*")
+	if err != nil {
+		t.Fatalf("glob backup files: %v", err)
+	}
+	if len(backups) == 0 {
+		t.Fatalf("expected backup file to be created")
+	}
+	backupPayload, err := os.ReadFile(backups[0])
+	if err != nil {
+		t.Fatalf("read backup file: %v", err)
+	}
+	if string(backupPayload) != string(original) {
+		t.Fatalf("expected backup content to match original config")
+	}
+}
+
+func TestSyncDoesNotAdoptEqualUnmanagedEntry(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".gemini", "settings.json")
+	statePath := filepath.Join(tmp, "state", "gemini-managed.json")
+
+	config := []byte(`{
+  "mcpServers": {
+    "stewreads": {
+      "command": "stewreads-mcp",
+      "env": {
+        "STEWREADS_CONFIG_PATH": "~/.config/stewreads/config.toml"
+      }
+    }
+  }
+}
+`)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	manifest := newStewreadsManifest()
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync apply failed: %v", err)
+	}
+	if len(result.Unchanged) != 1 || result.Unchanged[0] != "stewreads" {
+		t.Fatalf("expected equal unmanaged entry to be unchanged, got: %+v", result)
+	}
+	if managedNames := readManagedNames(t, statePath); len(managedNames) != 0 {
+		t.Fatalf("expected no adoption of unmanaged entry, got managed: %#v", managedNames)
+	}
+
+	manifest.Enabled = false
+	result, err = Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync after disable failed: %v", err)
+	}
+	if len(result.Removed) != 0 {
+		t.Fatalf("expected no removal of never-owned entry, got: %#v", result.Removed)
+	}
+	servers := readServers(t, configPath)
+	if _, ok := servers["stewreads"]; !ok {
+		t.Fatalf("expected hand-managed stewreads entry to survive disable")
+	}
+}
+
+func TestSyncRefusesSecretEnvAtProjectScope(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".gemini", "settings.json")
+	statePath := filepath.Join(tmp, "state", "gemini-managed.json")
+
+	plain := newStewreadsManifest()
+	plain.Name = "plain"
+	result, err := Sync([]registry.Manifest{newSecretManifest(), plain}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("expected per-entry refusal without sync error, got: %v", err)
+	}
+	if len(result.Refused) != 1 || result.Refused[0] != "stewreads" {
+		t.Fatalf("expected stewreads refused at project scope, got: %+v", result)
+	}
+	if len(result.Added) != 1 || result.Added[0] != "plain" {
+		t.Fatalf("expected plain server to sync alongside refusal, got: %+v", result)
+	}
+
+	servers := readServers(t, configPath)
+	if _, ok := servers["stewreads"]; ok {
+		t.Fatalf("expected secret-bearing entry to stay out of repo-scoped config")
+	}
+	if _, ok := servers["plain"]; !ok {
+		t.Fatalf("expected plain entry in repo-scoped config")
+	}
+}
+
+func TestSyncAllowsSecretEnvAtUserScope(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".gemini", "settings.json")
+	statePath := filepath.Join(tmp, "state", "gemini-user-managed.json")
+
+	result, err := Sync([]registry.Manifest{newSecretManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+		Scope:      clients.ScopeUser,
+	})
+	if err != nil {
+		t.Fatalf("expected user-scope sync to succeed, got: %v", err)
+	}
+	if len(result.Added) != 1 || result.Added[0] != "stewreads" {
+		t.Fatalf("expected stewreads add, got: %+v", result)
+	}
+	servers := readServers(t, configPath)
+	if servers["stewreads"].Env["STEWREADS_API_KEY"] != "shhh" {
+		t.Fatalf("expected secret env value in user-scoped config, got: %#v", servers["stewreads"].Env)
+	}
+}
+
+func TestSyncUserScopeDefaultsToUserStateFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("MADARI_CONFIG_DIR", tmp)
+	configPath := filepath.Join(tmp, ".gemini", "settings.json")
+
+	_, err := Sync([]registry.Manifest{newSecretManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		Scope:      clients.ScopeUser,
+	})
+	if err != nil {
+		t.Fatalf("user-scope sync failed: %v", err)
+	}
+
+	userStatePath := filepath.Join(tmp, "state", Target+"-user-managed.json")
+	if _, err := os.Stat(userStatePath); err != nil {
+		t.Fatalf("expected user-scope state file at %s: %v", userStatePath, err)
+	}
+	projectStatePath := filepath.Join(tmp, "state", Target+"-managed.json")
+	if _, err := os.Stat(projectStatePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected no project state write for user-scope sync, err=%v", err)
+	}
+}
+
+func TestSyncRejectsUnknownScope(t *testing.T) {
+	tmp := t.TempDir()
+
+	_, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: filepath.Join(tmp, ".gemini", "settings.json"),
+		StatePath:  filepath.Join(tmp, "state", "gemini-managed.json"),
+		Scope:      "global",
+	})
+	if err == nil {
+		t.Fatalf("expected error for unknown scope")
+	}
+	if !strings.Contains(err.Error(), "unknown sync scope") {
+		t.Fatalf("expected unknown-scope error, got: %v", err)
+	}
+}
+
+func TestAttachDetachOverlappingRingsAtConfigLevel(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".gemini", "settings.json")
+	statePath := filepath.Join(tmp, "state", "gemini-managed.json")
+	opts := SyncOptions{ConfigPath: configPath, StatePath: statePath}
+
+	shared := newStewreadsManifest()
+	only2 := newStewreadsManifest()
+	only2.Name = "arxiv"
+	manifests := []registry.Manifest{shared, only2}
+
+	r1 := registry.Ring{Name: "r1", Members: []string{"stewreads"}}
+	r2 := registry.Ring{Name: "r2", Members: []string{"stewreads", "arxiv"}}
+
+	if _, err := AttachRing(r1, manifests, opts); err != nil {
+		t.Fatalf("attach r1: %v", err)
+	}
+	result, err := AttachRing(r2, manifests, opts)
+	if err != nil {
+		t.Fatalf("attach r2: %v", err)
+	}
+	if len(result.Added) != 1 || result.Added[0] != "arxiv" {
+		t.Fatalf("expected arxiv added on r2 attach, got: %+v", result)
+	}
+
+	state, err := syncshared.LoadManagedState(statePath)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	expected := map[string][]string{
+		"stewreads": {"ring:r1", "ring:r2"},
+		"arxiv":     {"ring:r2"},
+	}
+	if !reflect.DeepEqual(state, expected) {
+		t.Fatalf("expected overlapping refcounts, got: %#v", state)
+	}
+
+	result, err = DetachRing("r1", opts)
+	if err != nil {
+		t.Fatalf("detach r1: %v", err)
+	}
+	if len(result.Removed) != 0 {
+		t.Fatalf("expected no removals while r2 owns shared member, got: %+v", result)
+	}
+	servers := readServers(t, configPath)
+	if _, ok := servers["stewreads"]; !ok {
+		t.Fatalf("expected shared member to survive r1 detach")
+	}
+
+	result, err = DetachRing("r2", opts)
+	if err != nil {
+		t.Fatalf("detach r2: %v", err)
+	}
+	if !reflect.DeepEqual(result.Removed, []string{"arxiv", "stewreads"}) {
+		t.Fatalf("expected both members removed, got: %+v", result)
+	}
+	servers = readServers(t, configPath)
+	if len(servers) != 0 {
+		t.Fatalf("expected clean config, got: %#v", servers)
+	}
+}
+
+func TestAttachRingConflictsOnEqualUnmanagedEntry(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".gemini", "settings.json")
+	statePath := filepath.Join(tmp, "state", "gemini-managed.json")
+
+	config := []byte(`{
+  "mcpServers": {
+    "stewreads": {
+      "command": "stewreads-mcp",
+      "env": {
+        "STEWREADS_CONFIG_PATH": "~/.config/stewreads/config.toml"
+      }
+    }
+  }
+}
+`)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	_, err := AttachRing(
+		registry.Ring{Name: "r1", Members: []string{"stewreads"}},
+		[]registry.Manifest{newStewreadsManifest()},
+		SyncOptions{ConfigPath: configPath, StatePath: statePath},
+	)
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected ErrConflict for equal-value unmanaged collision, got: %v", err)
+	}
+	if _, statErr := os.Stat(statePath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected no state write after conflict, got: %v", statErr)
+	}
+}
+
+func newStewreadsManifest() registry.Manifest {
+	return registry.Manifest{
+		Name:    "stewreads",
+		Command: "stewreads-mcp",
+		Enabled: true,
+		Clients: []string{Target},
+		Env: map[string]string{
+			"STEWREADS_CONFIG_PATH": "~/.config/stewreads/config.toml",
+		},
+	}
+}
+
+func newSecretManifest() registry.Manifest {
+	manifest := newStewreadsManifest()
+	manifest.Env["STEWREADS_API_KEY"] = "shhh"
+	manifest.SecretEnv = registry.SecretEnv{Keys: []string{"STEWREADS_API_KEY"}}
+	return manifest
+}
+
+func readRoot(t *testing.T, path string) map[string]json.RawMessage {
+	t.Helper()
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	root := map[string]json.RawMessage{}
+	if err := json.Unmarshal(payload, &root); err != nil {
+		t.Fatalf("parse config root: %v", err)
+	}
+	return root
+}
+
+func readServers(t *testing.T, path string) map[string]serverConfig {
+	t.Helper()
+	root := readRoot(t, path)
+	raw, ok := root["mcpServers"]
+	if !ok {
+		return map[string]serverConfig{}
+	}
+	servers := map[string]serverConfig{}
+	if err := json.Unmarshal(raw, &servers); err != nil {
+		t.Fatalf("parse mcpServers: %v", err)
+	}
+	return servers
+}
+
+func readManagedNames(t *testing.T, path string) []string {
+	t.Helper()
+	state, err := syncshared.LoadManagedState(path)
+	if err != nil {
+		t.Fatalf("load managed state: %v", err)
+	}
+	names := syncshared.MapKeys(state)
+	return names
+}
+
+func assertJSONEqual(t *testing.T, want, got []byte) {
+	t.Helper()
+	var wantValue any
+	var gotValue any
+	if err := json.Unmarshal(want, &wantValue); err != nil {
+		t.Fatalf("parse expected JSON: %v", err)
+	}
+	if err := json.Unmarshal(got, &gotValue); err != nil {
+		t.Fatalf("parse actual JSON: %v", err)
+	}
+	if !reflect.DeepEqual(wantValue, gotValue) {
+		t.Fatalf("JSON mismatch: want %#v got %#v", wantValue, gotValue)
+	}
+}


### PR DESCRIPTION
## Summary
- Add a first-class Gemini sync adapter for `.gemini/settings.json` / `~/.gemini/settings.json` using the existing ownership-aware sync planner.
- Wire `gemini` into persistent sync, clients listing, doctor/status drift checks, and ring attach/detach while keeping ring render targets separate.
- Update README and docs to describe Gemini as sync-capable and document project/user scope behavior.

## Verification
- Verified installed Gemini CLI behavior: `gemini --version` -> `0.46.0`; `gemini mcp add --scope project ...` writes `.gemini/settings.json` with top-level `mcpServers`.
- `go test ./internal/clients/gemini`
- `go test ./cmd/madari`
- `go test ./internal/doctor`
- `go test ./...`
- `make build`
- Native Gemini smoke with isolated temp project/home/config: `bin/madari add smoke --command /bin/echo --client gemini --arg hello --env FOO=bar`, `bin/madari sync gemini --config-path <tmp>/.gemini/settings.json`, then `gemini mcp list` saw `smoke: /bin/echo hello (stdio)` (disabled only because the temp folder was untrusted).

## Gemini Ring Smoke
Ran an isolated ring attach smoke using a throwaway Madari registry, temp project, and temp home. The server used `/bin/echo ring-smoke` as a simple stdio entry.

Commands exercised:
- `madari add echo-ring --command /bin/echo --client gemini --arg ring-smoke`
- `madari ring create smoke-ring --member echo-ring --description "Gemini ring attach smoke"`
- `madari ring attach smoke-ring gemini --config-path <tmp>/.gemini/settings.json`
- `madari ring status`
- `madari doctor --client-config gemini=<tmp>/.gemini/settings.json`
- `HOME=<tmp> gemini mcp list`

Observed results:
- Generated `.gemini/settings.json` contained top-level `mcpServers.echo-ring` with `command = /bin/echo` and `args = ["ring-smoke"]`.
- `madari ring status` reported `smoke-ring [ok] members=1 owned=1` under `gemini` and `echo-ring: ring:smoke-ring`.
- `madari doctor` reported `gemini config ... [ready]`, `gemini drift: [ready] in sync`, and summary `total=1 ready=1 warn=0 error=0 skipped=0`.
- `gemini mcp list` detected `echo-ring: /bin/echo ring-smoke (stdio)`. Gemini marked it disabled because the temp folder was untrusted, which is expected for an untrusted throwaway directory and still confirms Gemini accepted the ring-attached config.