### PR TITLE
[codex] Add Codex sync adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,14 @@ Notes:
 - `ring attach` records reference-counted ownership (`ring:<name>` sources) and materializes eligible members; `ring detach` releases it, and an entry only leaves the client config when nothing owns it anymore. Overlapping rings and standalone+ring combinations resolve by refcount, in any order. Attaching onto an entry madari does not manage is refused — even when values match.
 - `ring delete` removes only unattached ring definitions. It refuses while any client scope still records `ring:<name>` ownership and prints scoped detach guidance; deletion never edits client configs or managed state.
 - `ring render` prints a self-contained MCP config to stdout for ephemeral use — `claude --mcp-config <(madari ring render research --client claude-code)` — mutating nothing; secret env values are never emitted. Render targets are independent from persistent sync support: Claude and Gemini emit JSON, while Codex and Vibe emit TOML. `ring status` shows attached rings and per-server ownership for every client and scope.
-- Supported sync clients: `claude-desktop`, `claude-code`, and `gemini`.
+- Codex sync writes static non-secret `[env]` values under `[mcp_servers.<name>.env]` and forwards `[required_env]` plus `[secret_env]` keys through `env_vars`; static secret values are not written into Codex config.
+- Supported sync clients: `claude-desktop`, `claude-code`, `gemini`, and `codex`.
 - Supported render targets: `claude-code`, `claude-desktop`, `gemini`, `codex`, and `vibe`.
 - Default sync config paths:
   - `claude-desktop`: platform-specific Claude Desktop config path.
   - `claude-code`: `<current working directory>/.mcp.json`.
   - `gemini`: `<current working directory>/.gemini/settings.json`.
+  - `codex`: `$CODEX_HOME/config.toml` or `~/.codex/config.toml`.
 - `install --config-path` can only be used when exactly one sync target is selected.
 - `export` writes a versioned JSON snapshot of server and ring manifests for backup/sharing (stdout by default).
 - `import` is dry-run by default and only adds/updates listed servers and rings (`--apply` persists). Existing servers and rings absent from the snapshot are left unchanged; imported rings are not attached or synced.
@@ -82,7 +84,7 @@ Claude and Gemini config shape:
 }
 ```
 
-Codex render output uses TOML tables:
+Codex sync/render output uses TOML tables:
 
 ```toml
 [mcp_servers.stewreads]
@@ -113,11 +115,13 @@ madari install @modelcontextprotocol/server-sequential-thinking --manager npm --
 madari add stewreads --command /Users/me/.local/bin/stewreads-mcp --client claude-desktop
 madari add stewreads --command /Users/me/.local/bin/stewreads-mcp --client claude-code
 madari add stewreads --command /Users/me/.local/bin/stewreads-mcp --client gemini
+madari add stewreads --command /Users/me/.local/bin/stewreads-mcp --client codex
 madari list
 madari status
 madari sync claude-desktop --dry-run
 madari sync claude-code --dry-run
 madari sync gemini --dry-run
+madari sync codex --dry-run
 madari export --file madari-snapshot.json
 madari import --file madari-snapshot.json
 madari import --file madari-snapshot.json --apply
@@ -133,6 +137,7 @@ spin it up ephemerally:
 madari ring create research --member stewreads --member arxiv
 madari ring attach research claude-code
 madari ring attach research gemini
+madari ring attach research codex
 madari ring status
 claude --mcp-config <(madari ring render research --client claude-code)
 madari ring render research --client gemini
@@ -140,6 +145,7 @@ madari ring render research --client codex
 madari ring render research --client vibe
 madari ring detach research claude-code
 madari ring detach research gemini
+madari ring detach research codex
 madari ring delete research
 ```
 
@@ -165,7 +171,7 @@ go test ./...
 - Reference-counted ring ownership: entries leave a client config only when nothing owns them
 - `doctor` and `status` for diagnostics, drift detection, and ring consistency
 - Supports `uv` and `npm` package manager installs, plus manual `add` for any runtime/framework
-- macOS, Linux, and Windows; supports Claude Desktop, Claude Code, and Gemini sync targets
+- macOS, Linux, and Windows; supports Claude Desktop, Claude Code, Gemini, and Codex sync targets
 
 ## Principles
 

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ankitvg/madari/internal/clients"
 	claudedesktop "github.com/ankitvg/madari/internal/clients/claude-desktop"
 	"github.com/ankitvg/madari/internal/clients/claudecode"
+	"github.com/ankitvg/madari/internal/clients/codex"
 	"github.com/ankitvg/madari/internal/clients/gemini"
 	"github.com/ankitvg/madari/internal/clients/syncshared"
 	"github.com/ankitvg/madari/internal/doctor"
@@ -25,6 +26,7 @@ var version = "0.0.0-dev"
 var syncAdapters = map[string]clients.ClientAdapter{
 	claudedesktop.Target: claudedesktop.Adapter{},
 	claudecode.Target:    claudecode.Adapter{},
+	codex.Target:         codex.Adapter{},
 	gemini.Target:        gemini.Adapter{},
 }
 

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -750,7 +750,7 @@ func (a cliApp) cmdClients(args []string) error {
 			})
 			continue
 		}
-		cr := doctor.InspectConfigPath(path)
+		cr := doctor.InspectClientConfigPath(adapter.Target(), path)
 		cr.Target = adapter.Target()
 		rows = append(rows, clientRow{target: adapter.Target(), path: path, cr: cr})
 	}

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -954,6 +954,48 @@ func TestRunWithStoreSyncGeminiApply(t *testing.T) {
 	}
 }
 
+func TestRunWithStoreSyncCodexApply(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	addResult := runCmd(store, "add", "stewreads", "--command", commandPath, "--client", "codex")
+	if addResult.code != 0 {
+		t.Fatalf("setup add failed: %s", addResult.stderr)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(configPath, []byte("model = \"gpt-5\"\n\n[mcp_servers.weather]\ncommand = \"uv\"\n"), 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	result := runCmd(store, "sync", "codex", "--config-path", configPath)
+	if result.code != 0 {
+		t.Fatalf("sync apply failed with stderr: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "mode: applied") {
+		t.Fatalf("expected applied mode output, got: %s", result.stdout)
+	}
+	if !strings.Contains(result.stdout, "sync target: codex") {
+		t.Fatalf("expected codex target output, got: %s", result.stdout)
+	}
+
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config after sync: %v", err)
+	}
+	for _, want := range []string{
+		"model = ",
+		"gpt-5",
+		"[mcp_servers.weather]",
+		"[mcp_servers.stewreads]",
+		commandPath,
+	} {
+		if !strings.Contains(string(after), want) {
+			t.Fatalf("expected synced Codex config to contain %q, got: %s", want, after)
+		}
+	}
+}
+
 func TestRunWithStoreSyncSkipsMissingExecutable(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("executable fixture handling not needed in this test environment")
@@ -1161,6 +1203,9 @@ func TestRunWithStoreClientsListsAllAdapters(t *testing.T) {
 	if !strings.Contains(result.stdout, "claude-code") {
 		t.Fatalf("expected claude-code in clients output, got: %s", result.stdout)
 	}
+	if !strings.Contains(result.stdout, "codex") {
+		t.Fatalf("expected codex in clients output, got: %s", result.stdout)
+	}
 	if !strings.Contains(result.stdout, "gemini") {
 		t.Fatalf("expected gemini in clients output, got: %s", result.stdout)
 	}
@@ -1314,12 +1359,42 @@ func TestRunWithStoreDoctorAndStatusInspectGeminiConfig(t *testing.T) {
 	}
 }
 
+func TestRunWithStoreDoctorAndStatusInspectCodexConfig(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	if result := runCmd(store, "add", "stewreads", "--command", commandPath, "--client", "codex"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(configPath, []byte("[mcp_servers]\n"), 0o644); err != nil {
+		t.Fatalf("write Codex config fixture: %v", err)
+	}
+
+	result := runCmd(store, "doctor", "--client-config", "codex="+configPath)
+	if result.code != 0 {
+		t.Fatalf("doctor expected success, got code=%d stderr=%s stdout=%s", result.code, result.stderr, result.stdout)
+	}
+	if !strings.Contains(result.stdout, "codex config:") {
+		t.Fatalf("expected doctor output to include codex config details, got: %s", result.stdout)
+	}
+
+	result = runCmd(store, "status", "--client-config", "codex="+configPath)
+	if result.code != 0 {
+		t.Fatalf("status expected success, got code=%d stderr=%s stdout=%s", result.code, result.stderr, result.stdout)
+	}
+	if !strings.Contains(result.stdout, "codex-config: ready") {
+		t.Fatalf("expected status output to include codex config readiness, got: %s", result.stdout)
+	}
+}
+
 func TestRunWithStoreDoctorChecksRenderOnlyTargets(t *testing.T) {
 	store := newTestStore(t)
 	commandPath := mustCurrentExecutable(t)
 
 	if result := runCmd(store, "add", "portable", "--command", commandPath,
-		"--client", "codex",
+		"--client", "vibe",
 		"--required-env", "PORTABLE_TOKEN"); result.code != 0 {
 		t.Fatalf("setup add failed: %s", result.stderr)
 	}
@@ -2284,6 +2359,49 @@ func TestRunWithStoreRingAttachDetachGemini(t *testing.T) {
 	}
 }
 
+func TestRunWithStoreRingAttachDetachCodex(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	if result := runCmd(store, "add", "stewreads", "--command", commandPath, "--client", "codex"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "ring", "create", "research", "--member", "stewreads"); result.code != 0 {
+		t.Fatalf("ring create failed: %s", result.stderr)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	result := runCmd(store, "ring", "attach", "research", "codex", "--config-path", configPath)
+	if result.code != 0 {
+		t.Fatalf("attach failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "sync target: codex") || !strings.Contains(result.stdout, "added: stewreads") {
+		t.Fatalf("expected codex attach output, got: %s", result.stdout)
+	}
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read Codex config after attach: %v", err)
+	}
+	if !strings.Contains(string(after), "[mcp_servers.stewreads]") {
+		t.Fatalf("expected attached ring member in Codex config, got: %s", after)
+	}
+
+	result = runCmd(store, "ring", "detach", "research", "codex", "--config-path", configPath)
+	if result.code != 0 {
+		t.Fatalf("detach failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "removed: stewreads") {
+		t.Fatalf("expected codex detach removal, got: %s", result.stdout)
+	}
+	after, err = os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read Codex config after detach: %v", err)
+	}
+	if strings.Contains(string(after), "[mcp_servers.stewreads]") {
+		t.Fatalf("expected detached ring member removed from Codex config, got: %s", after)
+	}
+}
+
 func TestRunWithStoreRingAttachWarnsDisabledMember(t *testing.T) {
 	store := newTestStore(t)
 	commandPath := mustCurrentExecutable(t)
@@ -2435,10 +2553,8 @@ func TestRunWithStoreRingRenderTOMLTargets(t *testing.T) {
 	store := newTestStore(t)
 	commandPath := mustCurrentExecutable(t)
 
-	for _, target := range []string{"codex", "vibe"} {
-		if _, ok := syncAdapters[target]; ok {
-			t.Fatalf("%s must not be registered as a sync adapter", target)
-		}
+	if _, ok := syncAdapters["vibe"]; ok {
+		t.Fatal("vibe must not be registered as a sync adapter")
 	}
 
 	if result := runCmd(store, "add", "portable", "--command", commandPath,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@
 
 2. Client Adapters
 - Translate registry entries into client-specific config.
-- Current adapters: Claude Desktop, Claude Code, and Gemini.
+- Current adapters: Claude Desktop, Claude Code, Gemini, and Codex.
 - Adapters own read/merge/write behavior for their client format.
 
 3. Sync Engine

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -31,6 +31,8 @@ madari sync claude-code --scope user
 madari sync gemini --dry-run
 madari sync gemini
 madari sync gemini --scope user
+madari sync codex --dry-run
+madari sync codex
 ```
 
 `--scope` applies to clients with project and user configs: `claude-code`
@@ -40,6 +42,12 @@ managed entries independently. Servers carrying static values for
 `[secret_env]` keys are refused per entry at project scope (other servers
 keep syncing; a previously materialized secret entry is scrubbed) and must
 sync with `--scope user`.
+
+`codex` sync targets Codex's user config (`$CODEX_HOME/config.toml`, or
+`~/.codex/config.toml` when `CODEX_HOME` is unset). Static non-secret `[env]`
+values are written under `[mcp_servers.<name>.env]`; `[required_env]` and
+`[secret_env]` keys are forwarded through `env_vars`, and static secret
+values are not written into Codex config.
 
 ## Rings
 
@@ -51,8 +59,10 @@ madari ring attach research claude-code
 madari ring attach research claude-code --scope user
 madari ring attach research gemini
 madari ring attach research gemini --scope user
+madari ring attach research codex
 madari ring detach research claude-code
 madari ring detach research gemini
+madari ring detach research codex
 madari ring delete research
 madari ring render research --client claude-code
 madari ring render research --client gemini
@@ -181,12 +191,14 @@ summaries cover every sync target):
   "summary": {"total": 1, "ready": 1, "warning": 0, "error": 0, "skipped": 0},
   "client_configs": [
     {"target": "claude-code", "status": "skipped"},
+    {"target": "codex", "status": "skipped"},
     {"target": "claude-desktop", "status": "ready"},
     {"target": "gemini", "status": "skipped"}
   ],
   "managed": [
     {"target": "claude-code", "scope": "default", "entries": 0, "sources": []},
     {"target": "claude-code", "scope": "user", "entries": 0, "sources": []},
+    {"target": "codex", "scope": "default", "entries": 0, "sources": []},
     {"target": "claude-desktop", "scope": "default", "entries": 1, "sources": ["standalone"]},
     {"target": "gemini", "scope": "default", "entries": 0, "sources": []},
     {"target": "gemini", "scope": "user", "entries": 0, "sources": []}
@@ -369,4 +381,5 @@ madari version
 
 - `claude-desktop`
 - `claude-code`
+- `codex`
 - `gemini`

--- a/docs/manifest-spec.md
+++ b/docs/manifest-spec.md
@@ -23,9 +23,9 @@ Known client IDs:
 - `codex`
 - `vibe`
 
-`claude-desktop`, `claude-code`, and `gemini` are sync-capable today.
-`codex` and `vibe` are render targets for `madari ring render`; they are not
-persistent sync targets unless adapter support is added separately.
+`claude-desktop`, `claude-code`, `gemini`, and `codex` are sync-capable
+today. `vibe` is a render target for `madari ring render`; it is not a
+persistent sync target unless adapter support is added separately.
 
 ### `[env]`
 
@@ -41,7 +41,8 @@ Key/value static environment variables.
   to materialize a static `[env]` value for a secret key into repo-scoped
   client configs (for example Claude Code `.mcp.json` or Gemini
   `.gemini/settings.json`); secret values may only land in user-scoped
-  configs.
+  configs. Codex sync forwards secret keys through `env_vars` and does not
+  write static secret values into Codex config.
 
 ## Example
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/ankitvg/madari
 
 go 1.26
+
+require github.com/pelletier/go-toml/v2 v2.3.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
+github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=

--- a/internal/clients/codex/adapter.go
+++ b/internal/clients/codex/adapter.go
@@ -1,0 +1,31 @@
+package codex
+
+import (
+	"github.com/ankitvg/madari/internal/clients"
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+// Adapter implements clients.ClientAdapter for Codex.
+type Adapter struct{}
+
+var _ clients.ClientAdapter = Adapter{}
+
+func (Adapter) Target() string {
+	return Target
+}
+
+func (Adapter) DefaultConfigPath() (string, error) {
+	return DefaultConfigPath()
+}
+
+func (Adapter) Sync(manifests []registry.Manifest, opts clients.SyncOptions) (clients.SyncResult, error) {
+	return Sync(manifests, opts)
+}
+
+func (Adapter) AttachRing(ring registry.Ring, manifests []registry.Manifest, opts clients.SyncOptions) (clients.SyncResult, error) {
+	return AttachRing(ring, manifests, opts)
+}
+
+func (Adapter) DetachRing(ring string, opts clients.SyncOptions) (clients.SyncResult, error) {
+	return DetachRing(ring, opts)
+}

--- a/internal/clients/codex/sync.go
+++ b/internal/clients/codex/sync.go
@@ -1,0 +1,429 @@
+package codex
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/ankitvg/madari/internal/clients"
+	"github.com/ankitvg/madari/internal/clients/syncshared"
+	"github.com/ankitvg/madari/internal/registry"
+	"github.com/pelletier/go-toml/v2"
+)
+
+const (
+	Target = "codex"
+)
+
+var ErrConflict = clients.ErrConflict
+
+// SyncOptions configures sync behavior.
+type SyncOptions = clients.SyncOptions
+
+// SyncResult captures the computed or applied mutation plan.
+type SyncResult = clients.SyncResult
+
+// Sync synchronizes enabled Codex-targeted manifests into the Codex user
+// config file. Codex's native `codex mcp add` command writes global MCP
+// servers to $CODEX_HOME/config.toml, defaulting to ~/.codex/config.toml.
+func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
+	if err := validateScope(opts.Scope); err != nil {
+		return SyncResult{}, err
+	}
+	configPath, err := resolveConfigPath(opts.ConfigPath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	statePath, err := resolveStatePath(opts.StatePath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	root, rawServers, existingServers, configExists, err := loadCodexConfig(configPath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	managedState, err := syncshared.LoadManagedState(statePath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	result, nextState, writeSet, err := syncshared.PlanSync(existingServers, managedState, entriesForTarget(manifests), opts.Rings, equalServer, ErrConflict)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	result.ConfigPath = configPath
+	result.DryRun = opts.DryRun
+
+	if opts.DryRun {
+		return result, nil
+	}
+
+	if err := applyPlan(configPath, statePath, root, rawServers, configExists, result.Removed, writeSet, nextState); err != nil {
+		return SyncResult{}, err
+	}
+	return result, nil
+}
+
+// AttachRing adds the ring's ownership source to every member and materializes
+// eligible ones into Codex config. Attaching onto any pre-existing unmanaged
+// entry, equal values included, refuses with ErrConflict.
+func AttachRing(ring registry.Ring, manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
+	if err := validateScope(opts.Scope); err != nil {
+		return SyncResult{}, err
+	}
+	configPath, err := resolveConfigPath(opts.ConfigPath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	statePath, err := resolveStatePath(opts.StatePath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	root, rawServers, existingServers, configExists, err := loadCodexConfig(configPath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	managedState, err := syncshared.LoadManagedState(statePath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	result, nextState, writeSet, err := syncshared.PlanAttach(existingServers, managedState, ring.Name, ring.Members, entriesForTarget(manifests), opts.Rings, equalServer, ErrConflict)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	result.ConfigPath = configPath
+	result.DryRun = opts.DryRun
+
+	if opts.DryRun {
+		return result, nil
+	}
+	if err := applyPlan(configPath, statePath, root, rawServers, configExists, result.Removed, writeSet, nextState); err != nil {
+		return SyncResult{}, err
+	}
+	return result, nil
+}
+
+// DetachRing removes the ring's ownership source everywhere; entries that lose
+// their last source leave the config. The ring file is not required, so stale
+// sources can always be released.
+func DetachRing(ringName string, opts SyncOptions) (SyncResult, error) {
+	if err := validateScope(opts.Scope); err != nil {
+		return SyncResult{}, err
+	}
+	configPath, err := resolveConfigPath(opts.ConfigPath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	statePath, err := resolveStatePath(opts.StatePath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	root, rawServers, existingServers, configExists, err := loadCodexConfig(configPath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	managedState, err := syncshared.LoadManagedState(statePath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	result, nextState := syncshared.PlanDetach(existingServers, managedState, ringName, opts.Rings)
+	result.ConfigPath = configPath
+	result.DryRun = opts.DryRun
+
+	if opts.DryRun {
+		return result, nil
+	}
+	if err := applyPlan(configPath, statePath, root, rawServers, configExists, result.Removed, nil, nextState); err != nil {
+		return SyncResult{}, err
+	}
+	return result, nil
+}
+
+func applyPlan(
+	configPath, statePath string,
+	root, rawServers map[string]any,
+	configExists bool,
+	removed []string,
+	writeSet map[string]serverConfig,
+	nextState map[string][]string,
+) error {
+	mutated := make(map[string]any, len(rawServers)+len(writeSet))
+	for name, raw := range rawServers {
+		mutated[name] = raw
+	}
+	for _, name := range removed {
+		delete(mutated, name)
+	}
+	for name, server := range writeSet {
+		mutated[name] = server
+	}
+
+	updatedRoot := make(map[string]any, len(root)+1)
+	for key, value := range root {
+		updatedRoot[key] = value
+	}
+	updatedRoot["mcp_servers"] = mutated
+
+	payload, err := toml.Marshal(updatedRoot)
+	if err != nil {
+		return fmt.Errorf("marshal Codex config: %w", err)
+	}
+
+	if configExists {
+		if _, err := syncshared.BackupFile(configPath); err != nil {
+			return fmt.Errorf("backup Codex config: %w", err)
+		}
+	}
+	if err := syncshared.WriteFileAtomically(configPath, payload, 0o644); err != nil {
+		return fmt.Errorf("write Codex config: %w", err)
+	}
+
+	if err := syncshared.SaveManagedState(statePath, nextState); err != nil {
+		return fmt.Errorf("write managed sync state: %w", err)
+	}
+	return nil
+}
+
+func DefaultConfigPath() (string, error) {
+	if codexHome := strings.TrimSpace(os.Getenv("CODEX_HOME")); codexHome != "" {
+		resolved, err := syncshared.ExpandHome(codexHome)
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(filepath.Clean(resolved), "config.toml"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user home: %w", err)
+	}
+	return filepath.Join(home, ".codex", "config.toml"), nil
+}
+
+func DefaultStatePath() (string, error) {
+	root, err := registry.DefaultRootDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, "state", Target+"-managed.json"), nil
+}
+
+func resolveConfigPath(configPath string) (string, error) {
+	return syncshared.ResolvePath(configPath, DefaultConfigPath)
+}
+
+func resolveStatePath(statePath string) (string, error) {
+	return syncshared.ResolvePath(statePath, DefaultStatePath)
+}
+
+func validateScope(scope string) error {
+	switch strings.TrimSpace(scope) {
+	case "", clients.ScopeUser:
+		return nil
+	default:
+		return fmt.Errorf("%s sync supports the user-scoped config only", Target)
+	}
+}
+
+func entriesForTarget(manifests []registry.Manifest) map[string]syncshared.Entry[serverConfig] {
+	entries := map[string]syncshared.Entry[serverConfig]{}
+	for _, manifest := range manifests {
+		if !manifest.HasClient(Target) {
+			continue
+		}
+		entry := syncshared.Entry[serverConfig]{}
+		if manifest.Enabled {
+			entry.Eligible = true
+			entry.Value = materializeServer(manifest)
+		}
+		entries[manifest.Name] = entry
+	}
+	return entries
+}
+
+func materializeServer(manifest registry.Manifest) serverConfig {
+	entry := serverConfig{
+		Command: manifest.Command,
+		EnvVars: runtimeEnvKeys(
+			manifest.RequiredEnv.Keys,
+			manifest.SecretEnv.Keys,
+		),
+	}
+	if len(manifest.Args) > 0 {
+		entry.Args = append([]string(nil), manifest.Args...)
+	}
+
+	secret := map[string]bool{}
+	for _, key := range manifest.SecretEnv.Keys {
+		secret[strings.TrimSpace(key)] = true
+	}
+	for key, value := range manifest.Env {
+		if secret[key] {
+			continue
+		}
+		if entry.Env == nil {
+			entry.Env = map[string]string{}
+		}
+		entry.Env[key] = value
+	}
+	return entry
+}
+
+func runtimeEnvKeys(keyGroups ...[]string) []string {
+	seen := map[string]bool{}
+	for _, keys := range keyGroups {
+		for _, key := range keys {
+			key = strings.TrimSpace(key)
+			if key == "" {
+				continue
+			}
+			seen[key] = true
+		}
+	}
+	keys := make([]string, 0, len(seen))
+	for key := range seen {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func equalServer(a, b serverConfig) bool {
+	if a.Command != b.Command {
+		return false
+	}
+	if !equalStringSlices(a.Args, b.Args) {
+		return false
+	}
+	if len(a.Env) != len(b.Env) {
+		return false
+	}
+	for key, value := range a.Env {
+		if b.Env[key] != value {
+			return false
+		}
+	}
+	return equalStringSlices(a.EnvVars, b.EnvVars)
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func loadCodexConfig(path string) (map[string]any, map[string]any, map[string]serverConfig, bool, error) {
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]any{}, map[string]any{}, map[string]serverConfig{}, false, nil
+		}
+		return nil, nil, nil, false, fmt.Errorf("read Codex config %q: %w", path, err)
+	}
+
+	root := map[string]any{}
+	if err := toml.Unmarshal(payload, &root); err != nil {
+		return nil, nil, nil, true, fmt.Errorf("parse Codex config TOML: %w", err)
+	}
+	if root == nil {
+		root = map[string]any{}
+	}
+
+	rawServers := map[string]any{}
+	if raw, exists := root["mcp_servers"]; exists {
+		servers, ok := raw.(map[string]any)
+		if !ok {
+			return nil, nil, nil, true, fmt.Errorf("parse mcp_servers: expected table")
+		}
+		for name, server := range servers {
+			rawServers[name] = server
+		}
+	}
+
+	servers := make(map[string]serverConfig, len(rawServers))
+	for name, raw := range rawServers {
+		servers[name] = parseServer(raw)
+	}
+
+	return root, rawServers, servers, true, nil
+}
+
+func parseServer(raw any) serverConfig {
+	table, ok := raw.(map[string]any)
+	if !ok {
+		return serverConfig{}
+	}
+
+	entry := serverConfig{}
+	if command, ok := table["command"].(string); ok {
+		entry.Command = command
+	}
+	if args, ok := stringSlice(table["args"]); ok {
+		entry.Args = args
+	}
+	if env, ok := stringMap(table["env"]); ok {
+		entry.Env = env
+	}
+	if envVars, ok := stringSlice(table["env_vars"]); ok {
+		entry.EnvVars = envVars
+	}
+	return entry
+}
+
+func stringSlice(raw any) ([]string, bool) {
+	if raw == nil {
+		return nil, false
+	}
+	values, ok := raw.([]any)
+	if !ok {
+		return nil, false
+	}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		str, ok := value.(string)
+		if !ok {
+			return nil, false
+		}
+		out = append(out, str)
+	}
+	return out, true
+}
+
+func stringMap(raw any) (map[string]string, bool) {
+	if raw == nil {
+		return nil, false
+	}
+	values, ok := raw.(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		str, ok := value.(string)
+		if !ok {
+			return nil, false
+		}
+		out[key] = str
+	}
+	return out, true
+}
+
+type serverConfig struct {
+	Command string            `toml:"command"`
+	Args    []string          `toml:"args,omitempty"`
+	EnvVars []string          `toml:"env_vars,omitempty"`
+	Env     map[string]string `toml:"env,omitempty"`
+}

--- a/internal/clients/codex/sync.go
+++ b/internal/clients/codex/sync.go
@@ -15,7 +15,8 @@ import (
 )
 
 const (
-	Target = "codex"
+	Target            = "codex"
+	defaultConfigMode = 0o600
 )
 
 var ErrConflict = clients.ErrConflict
@@ -42,7 +43,7 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 		return SyncResult{}, err
 	}
 
-	root, rawServers, existingServers, configExists, err := loadCodexConfig(configPath)
+	root, rawServers, existingServers, configExists, configMode, err := loadCodexConfig(configPath)
 	if err != nil {
 		return SyncResult{}, err
 	}
@@ -62,7 +63,7 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 		return result, nil
 	}
 
-	if err := applyPlan(configPath, statePath, root, rawServers, configExists, result.Removed, writeSet, nextState); err != nil {
+	if err := applyPlan(configPath, statePath, root, rawServers, configExists, configMode, result.Removed, writeSet, nextState); err != nil {
 		return SyncResult{}, err
 	}
 	return result, nil
@@ -84,7 +85,7 @@ func AttachRing(ring registry.Ring, manifests []registry.Manifest, opts SyncOpti
 		return SyncResult{}, err
 	}
 
-	root, rawServers, existingServers, configExists, err := loadCodexConfig(configPath)
+	root, rawServers, existingServers, configExists, configMode, err := loadCodexConfig(configPath)
 	if err != nil {
 		return SyncResult{}, err
 	}
@@ -103,7 +104,7 @@ func AttachRing(ring registry.Ring, manifests []registry.Manifest, opts SyncOpti
 	if opts.DryRun {
 		return result, nil
 	}
-	if err := applyPlan(configPath, statePath, root, rawServers, configExists, result.Removed, writeSet, nextState); err != nil {
+	if err := applyPlan(configPath, statePath, root, rawServers, configExists, configMode, result.Removed, writeSet, nextState); err != nil {
 		return SyncResult{}, err
 	}
 	return result, nil
@@ -125,7 +126,7 @@ func DetachRing(ringName string, opts SyncOptions) (SyncResult, error) {
 		return SyncResult{}, err
 	}
 
-	root, rawServers, existingServers, configExists, err := loadCodexConfig(configPath)
+	root, rawServers, existingServers, configExists, configMode, err := loadCodexConfig(configPath)
 	if err != nil {
 		return SyncResult{}, err
 	}
@@ -141,7 +142,7 @@ func DetachRing(ringName string, opts SyncOptions) (SyncResult, error) {
 	if opts.DryRun {
 		return result, nil
 	}
-	if err := applyPlan(configPath, statePath, root, rawServers, configExists, result.Removed, nil, nextState); err != nil {
+	if err := applyPlan(configPath, statePath, root, rawServers, configExists, configMode, result.Removed, nil, nextState); err != nil {
 		return SyncResult{}, err
 	}
 	return result, nil
@@ -151,6 +152,7 @@ func applyPlan(
 	configPath, statePath string,
 	root, rawServers map[string]any,
 	configExists bool,
+	configMode os.FileMode,
 	removed []string,
 	writeSet map[string]serverConfig,
 	nextState map[string][]string,
@@ -182,7 +184,7 @@ func applyPlan(
 			return fmt.Errorf("backup Codex config: %w", err)
 		}
 	}
-	if err := syncshared.WriteFileAtomically(configPath, payload, 0o644); err != nil {
+	if err := syncshared.WriteFileAtomically(configPath, payload, configMode); err != nil {
 		return fmt.Errorf("write Codex config: %w", err)
 	}
 
@@ -299,6 +301,9 @@ func equalServer(a, b serverConfig) bool {
 	if a.Command != b.Command {
 		return false
 	}
+	if effectiveEnabled(a) != effectiveEnabled(b) {
+		return false
+	}
 	if !equalStringSlices(a.Args, b.Args) {
 		return false
 	}
@@ -313,6 +318,10 @@ func equalServer(a, b serverConfig) bool {
 	return equalStringSlices(a.EnvVars, b.EnvVars)
 }
 
+func effectiveEnabled(server serverConfig) bool {
+	return server.Enabled == nil || *server.Enabled
+}
+
 func equalStringSlices(a, b []string) bool {
 	if len(a) != len(b) {
 		return false
@@ -325,18 +334,27 @@ func equalStringSlices(a, b []string) bool {
 	return true
 }
 
-func loadCodexConfig(path string) (map[string]any, map[string]any, map[string]serverConfig, bool, error) {
-	payload, err := os.ReadFile(path)
+func loadCodexConfig(path string) (map[string]any, map[string]any, map[string]serverConfig, bool, os.FileMode, error) {
+	info, err := os.Stat(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return map[string]any{}, map[string]any{}, map[string]serverConfig{}, false, nil
+			return map[string]any{}, map[string]any{}, map[string]serverConfig{}, false, defaultConfigMode, nil
 		}
-		return nil, nil, nil, false, fmt.Errorf("read Codex config %q: %w", path, err)
+		return nil, nil, nil, false, 0, fmt.Errorf("stat Codex config %q: %w", path, err)
+	}
+	configMode := info.Mode().Perm()
+	if configMode == 0 {
+		configMode = defaultConfigMode
+	}
+
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, nil, false, 0, fmt.Errorf("read Codex config %q: %w", path, err)
 	}
 
 	root := map[string]any{}
 	if err := toml.Unmarshal(payload, &root); err != nil {
-		return nil, nil, nil, true, fmt.Errorf("parse Codex config TOML: %w", err)
+		return nil, nil, nil, true, configMode, fmt.Errorf("parse Codex config TOML: %w", err)
 	}
 	if root == nil {
 		root = map[string]any{}
@@ -346,7 +364,7 @@ func loadCodexConfig(path string) (map[string]any, map[string]any, map[string]se
 	if raw, exists := root["mcp_servers"]; exists {
 		servers, ok := raw.(map[string]any)
 		if !ok {
-			return nil, nil, nil, true, fmt.Errorf("parse mcp_servers: expected table")
+			return nil, nil, nil, true, configMode, fmt.Errorf("parse mcp_servers: expected table")
 		}
 		for name, server := range servers {
 			rawServers[name] = server
@@ -355,74 +373,118 @@ func loadCodexConfig(path string) (map[string]any, map[string]any, map[string]se
 
 	servers := make(map[string]serverConfig, len(rawServers))
 	for name, raw := range rawServers {
-		servers[name] = parseServer(raw)
+		server, err := parseServer(name, raw)
+		if err != nil {
+			return nil, nil, nil, true, configMode, err
+		}
+		servers[name] = server
 	}
 
-	return root, rawServers, servers, true, nil
+	return root, rawServers, servers, true, configMode, nil
 }
 
-func parseServer(raw any) serverConfig {
+func parseServer(name string, raw any) (serverConfig, error) {
 	table, ok := raw.(map[string]any)
 	if !ok {
-		return serverConfig{}
+		return serverConfig{}, fmt.Errorf("parse mcp_servers.%s: expected table", name)
 	}
 
 	entry := serverConfig{}
-	if command, ok := table["command"].(string); ok {
+	if rawCommand, exists := table["command"]; exists {
+		command, ok := rawCommand.(string)
+		if !ok {
+			return serverConfig{}, fmt.Errorf("parse mcp_servers.%s.command: expected string", name)
+		}
 		entry.Command = command
 	}
-	if args, ok := stringSlice(table["args"]); ok {
+	if enabled, ok, err := optionalBool(table, "enabled"); err != nil {
+		return serverConfig{}, fmt.Errorf("parse mcp_servers.%s.enabled: %w", name, err)
+	} else if ok {
+		entry.Enabled = &enabled
+	}
+	if args, ok, err := optionalStringSlice(table, "args"); err != nil {
+		return serverConfig{}, fmt.Errorf("parse mcp_servers.%s.args: %w", name, err)
+	} else if ok {
 		entry.Args = args
 	}
-	if env, ok := stringMap(table["env"]); ok {
+	if env, ok, err := optionalStringMap(table, "env"); err != nil {
+		return serverConfig{}, fmt.Errorf("parse mcp_servers.%s.env: %w", name, err)
+	} else if ok {
 		entry.Env = env
 	}
-	if envVars, ok := stringSlice(table["env_vars"]); ok {
+	if envVars, ok, err := optionalStringSlice(table, "env_vars"); err != nil {
+		return serverConfig{}, fmt.Errorf("parse mcp_servers.%s.env_vars: %w", name, err)
+	} else if ok {
 		entry.EnvVars = envVars
 	}
-	return entry
+	return entry, nil
 }
 
-func stringSlice(raw any) ([]string, bool) {
-	if raw == nil {
-		return nil, false
+func optionalBool(table map[string]any, key string) (bool, bool, error) {
+	raw, exists := table[key]
+	if !exists {
+		return false, false, nil
+	}
+	value, ok := raw.(bool)
+	if !ok {
+		return false, true, fmt.Errorf("expected bool")
+	}
+	return value, true, nil
+}
+
+func optionalStringSlice(table map[string]any, key string) ([]string, bool, error) {
+	raw, exists := table[key]
+	if !exists {
+		return nil, false, nil
 	}
 	values, ok := raw.([]any)
 	if !ok {
-		return nil, false
+		if strings, ok := raw.([]string); ok {
+			return append([]string(nil), strings...), true, nil
+		}
+		return nil, true, fmt.Errorf("expected array of strings")
 	}
 	out := make([]string, 0, len(values))
 	for _, value := range values {
 		str, ok := value.(string)
 		if !ok {
-			return nil, false
+			return nil, true, fmt.Errorf("expected array of strings")
 		}
 		out = append(out, str)
 	}
-	return out, true
+	return out, true, nil
 }
 
-func stringMap(raw any) (map[string]string, bool) {
-	if raw == nil {
-		return nil, false
+func optionalStringMap(table map[string]any, key string) (map[string]string, bool, error) {
+	raw, exists := table[key]
+	if !exists {
+		return nil, false, nil
 	}
 	values, ok := raw.(map[string]any)
 	if !ok {
-		return nil, false
+		if strings, ok := raw.(map[string]string); ok {
+			out := make(map[string]string, len(strings))
+			for key, value := range strings {
+				out[key] = value
+			}
+			return out, true, nil
+		}
+		return nil, true, fmt.Errorf("expected table of strings")
 	}
 	out := make(map[string]string, len(values))
 	for key, value := range values {
 		str, ok := value.(string)
 		if !ok {
-			return nil, false
+			return nil, true, fmt.Errorf("expected table of strings")
 		}
 		out[key] = str
 	}
-	return out, true
+	return out, true, nil
 }
 
 type serverConfig struct {
 	Command string            `toml:"command"`
+	Enabled *bool             `toml:"enabled,omitempty"`
 	Args    []string          `toml:"args,omitempty"`
 	EnvVars []string          `toml:"env_vars,omitempty"`
 	Env     map[string]string `toml:"env,omitempty"`

--- a/internal/clients/codex/sync_test.go
+++ b/internal/clients/codex/sync_test.go
@@ -1,0 +1,464 @@
+package codex
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/ankitvg/madari/internal/clients"
+	"github.com/ankitvg/madari/internal/clients/syncshared"
+	"github.com/ankitvg/madari/internal/registry"
+	"github.com/pelletier/go-toml/v2"
+)
+
+func TestSyncDryRunDoesNotMutateFiles(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "codex-managed.json")
+	original := []byte(`model = "gpt-5"
+
+[mcp_servers.weather]
+command = "uv"
+args = ["run", "weather.py"]
+`)
+	if err := os.WriteFile(configPath, original, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	result, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+		DryRun:     true,
+	})
+	if err != nil {
+		t.Fatalf("sync dry-run failed: %v", err)
+	}
+	if len(result.Added) != 1 || result.Added[0] != "stewreads" {
+		t.Fatalf("expected stewreads to be planned as added, got: %+v", result)
+	}
+
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config after dry-run: %v", err)
+	}
+	if string(after) != string(original) {
+		t.Fatalf("expected dry-run to keep config unchanged")
+	}
+	if _, err := os.Stat(statePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected no state file write on dry-run, got err=%v", err)
+	}
+}
+
+func TestSyncApplyAddUpdateRemoveLifecycle(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "codex-managed.json")
+	baseConfig := []byte(`model = "gpt-5"
+
+[mcp_servers.weather]
+command = "uv"
+args = ["run", "weather.py"]
+`)
+	if err := os.WriteFile(configPath, baseConfig, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	manifest := newStewreadsManifest()
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("initial sync failed: %v", err)
+	}
+	if len(result.Added) != 1 || result.Added[0] != "stewreads" {
+		t.Fatalf("expected add result, got: %+v", result)
+	}
+
+	root := readRoot(t, configPath)
+	if root["model"] != "gpt-5" {
+		t.Fatalf("expected unrelated top-level model preserved, got: %#v", root["model"])
+	}
+	servers := readServers(t, configPath)
+	if _, ok := servers["weather"]; !ok {
+		t.Fatalf("expected existing weather server to be preserved")
+	}
+	if got := servers["stewreads"].Command; got != "stewreads-mcp" {
+		t.Fatalf("expected stewreads command to be synced, got: %q", got)
+	}
+
+	managedNames := readManagedNames(t, statePath)
+	if len(managedNames) != 1 || managedNames[0] != "stewreads" {
+		t.Fatalf("expected managed state to track stewreads, got: %#v", managedNames)
+	}
+
+	result, err = Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("unchanged sync failed: %v", err)
+	}
+	if len(result.Unchanged) != 1 || result.Unchanged[0] != "stewreads" {
+		t.Fatalf("expected unchanged result, got: %+v", result)
+	}
+
+	manifest.Args = []string{"--stdio"}
+	result, err = Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("update sync failed: %v", err)
+	}
+	if len(result.Updated) != 1 || result.Updated[0] != "stewreads" {
+		t.Fatalf("expected update result, got: %+v", result)
+	}
+	servers = readServers(t, configPath)
+	if !reflect.DeepEqual(servers["stewreads"].Args, []string{"--stdio"}) {
+		t.Fatalf("expected synced args update, got: %#v", servers["stewreads"].Args)
+	}
+
+	manifest.Enabled = false
+	result, err = Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("remove sync failed: %v", err)
+	}
+	if len(result.Removed) != 1 || result.Removed[0] != "stewreads" {
+		t.Fatalf("expected remove result, got: %+v", result)
+	}
+	servers = readServers(t, configPath)
+	if _, ok := servers["stewreads"]; ok {
+		t.Fatalf("expected stewreads to be removed from Codex config")
+	}
+	if _, ok := servers["weather"]; !ok {
+		t.Fatalf("expected weather to remain after removal")
+	}
+}
+
+func TestSyncRejectsUnmanagedNameCollision(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "codex-managed.json")
+	config := []byte(`[mcp_servers.stewreads]
+command = "manual-custom-command"
+`)
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	_, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+		DryRun:     true,
+	})
+	if !errors.Is(err, clients.ErrConflict) {
+		t.Fatalf("expected clients.ErrConflict, got: %v", err)
+	}
+}
+
+func TestSyncDoesNotAdoptEqualUnmanagedEntry(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "codex-managed.json")
+	config := []byte(`[mcp_servers.stewreads]
+command = "stewreads-mcp"
+
+[mcp_servers.stewreads.env]
+STEWREADS_CONFIG_PATH = "~/.config/stewreads/config.toml"
+`)
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	manifest := newStewreadsManifest()
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync apply failed: %v", err)
+	}
+	if len(result.Unchanged) != 1 || result.Unchanged[0] != "stewreads" {
+		t.Fatalf("expected equal unmanaged entry to be unchanged, got: %+v", result)
+	}
+	if managedNames := readManagedNames(t, statePath); len(managedNames) != 0 {
+		t.Fatalf("expected no adoption of unmanaged entry, got managed: %#v", managedNames)
+	}
+
+	manifest.Enabled = false
+	result, err = Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync after disable failed: %v", err)
+	}
+	if len(result.Removed) != 0 {
+		t.Fatalf("expected no removal of never-owned entry, got: %#v", result.Removed)
+	}
+	servers := readServers(t, configPath)
+	if _, ok := servers["stewreads"]; !ok {
+		t.Fatalf("expected hand-managed stewreads entry to survive disable")
+	}
+}
+
+func TestSyncApplyFailsClosedOnInvalidTOML(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "codex-managed.json")
+	invalid := []byte("[broken")
+	if err := os.WriteFile(configPath, invalid, 0o644); err != nil {
+		t.Fatalf("write invalid config fixture: %v", err)
+	}
+
+	_, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err == nil {
+		t.Fatalf("expected sync apply to fail on invalid TOML")
+	}
+	if !strings.Contains(err.Error(), "parse Codex config TOML") {
+		t.Fatalf("expected parse error, got: %v", err)
+	}
+
+	after, readErr := os.ReadFile(configPath)
+	if readErr != nil {
+		t.Fatalf("read config after failed sync: %v", readErr)
+	}
+	if string(after) != string(invalid) {
+		t.Fatalf("expected fail-closed behavior with unchanged config")
+	}
+	if _, statErr := os.Stat(statePath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected no state file write on failure, got err=%v", statErr)
+	}
+	backups, globErr := filepath.Glob(configPath + ".bak.*")
+	if globErr != nil {
+		t.Fatalf("glob backup files: %v", globErr)
+	}
+	if len(backups) != 0 {
+		t.Fatalf("expected no backup files on parse failure, got: %#v", backups)
+	}
+}
+
+func TestSyncApplyCreatesBackup(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "codex-managed.json")
+	original := []byte(`[mcp_servers.weather]
+command = "uv"
+`)
+	if err := os.WriteFile(configPath, original, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	if _, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	}); err != nil {
+		t.Fatalf("sync apply failed: %v", err)
+	}
+
+	backups, err := filepath.Glob(configPath + ".bak.*")
+	if err != nil {
+		t.Fatalf("glob backup files: %v", err)
+	}
+	if len(backups) == 0 {
+		t.Fatalf("expected backup file to be created")
+	}
+	backupPayload, err := os.ReadFile(backups[0])
+	if err != nil {
+		t.Fatalf("read backup file: %v", err)
+	}
+	if string(backupPayload) != string(original) {
+		t.Fatalf("expected backup content to match original config")
+	}
+}
+
+func TestSyncMapsStaticEnvAndRuntimeEnvVars(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "codex-managed.json")
+
+	manifest := newStewreadsManifest()
+	manifest.Env["STEWREADS_API_KEY"] = "shhh"
+	manifest.RequiredEnv = registry.RequiredEnv{Keys: []string{"STEWREADS_PROFILE"}}
+	manifest.SecretEnv = registry.SecretEnv{Keys: []string{"STEWREADS_API_KEY"}}
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	if len(result.Added) != 1 || result.Added[0] != "stewreads" {
+		t.Fatalf("expected add result, got: %+v", result)
+	}
+
+	server := readServers(t, configPath)["stewreads"]
+	if server.Env["STEWREADS_CONFIG_PATH"] == "" {
+		t.Fatalf("expected non-secret static env to be written, got: %#v", server.Env)
+	}
+	if _, ok := server.Env["STEWREADS_API_KEY"]; ok {
+		t.Fatalf("expected secret static value omitted from Codex config, got: %#v", server.Env)
+	}
+	if !reflect.DeepEqual(server.EnvVars, []string{"STEWREADS_API_KEY", "STEWREADS_PROFILE"}) {
+		t.Fatalf("expected required and secret keys forwarded via env_vars, got: %#v", server.EnvVars)
+	}
+}
+
+func TestSyncDefaultPathHonorsCodexHome(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("CODEX_HOME", tmp)
+	t.Setenv("MADARI_CONFIG_DIR", filepath.Join(tmp, "madari"))
+
+	result, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{})
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	expectedPath := filepath.Join(tmp, "config.toml")
+	if result.ConfigPath != expectedPath {
+		t.Fatalf("expected default config path %q, got %q", expectedPath, result.ConfigPath)
+	}
+	if _, err := os.Stat(expectedPath); err != nil {
+		t.Fatalf("expected config at default CODEX_HOME path: %v", err)
+	}
+}
+
+func TestAttachDetachOverlappingRingsAtConfigLevel(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "codex-managed.json")
+	opts := SyncOptions{ConfigPath: configPath, StatePath: statePath}
+
+	shared := newStewreadsManifest()
+	only2 := newStewreadsManifest()
+	only2.Name = "arxiv"
+	manifests := []registry.Manifest{shared, only2}
+
+	r1 := registry.Ring{Name: "r1", Members: []string{"stewreads"}}
+	r2 := registry.Ring{Name: "r2", Members: []string{"stewreads", "arxiv"}}
+
+	if _, err := AttachRing(r1, manifests, opts); err != nil {
+		t.Fatalf("attach r1: %v", err)
+	}
+	result, err := AttachRing(r2, manifests, opts)
+	if err != nil {
+		t.Fatalf("attach r2: %v", err)
+	}
+	if len(result.Added) != 1 || result.Added[0] != "arxiv" {
+		t.Fatalf("expected arxiv added on r2 attach, got: %+v", result)
+	}
+
+	state, err := syncshared.LoadManagedState(statePath)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	expected := map[string][]string{
+		"stewreads": {"ring:r1", "ring:r2"},
+		"arxiv":     {"ring:r2"},
+	}
+	if !reflect.DeepEqual(state, expected) {
+		t.Fatalf("expected overlapping refcounts, got: %#v", state)
+	}
+
+	result, err = DetachRing("r1", opts)
+	if err != nil {
+		t.Fatalf("detach r1: %v", err)
+	}
+	if len(result.Removed) != 0 {
+		t.Fatalf("expected no removals while r2 owns shared member, got: %+v", result)
+	}
+
+	result, err = DetachRing("r2", opts)
+	if err != nil {
+		t.Fatalf("detach r2: %v", err)
+	}
+	if !reflect.DeepEqual(result.Removed, []string{"arxiv", "stewreads"}) {
+		t.Fatalf("expected both members removed, got: %+v", result)
+	}
+	servers := readServers(t, configPath)
+	if len(servers) != 0 {
+		t.Fatalf("expected clean config, got: %#v", servers)
+	}
+}
+
+func TestAttachRingConflictsOnEqualUnmanagedEntry(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "codex-managed.json")
+	config := []byte(`[mcp_servers.stewreads]
+command = "stewreads-mcp"
+
+[mcp_servers.stewreads.env]
+STEWREADS_CONFIG_PATH = "~/.config/stewreads/config.toml"
+`)
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	_, err := AttachRing(
+		registry.Ring{Name: "r1", Members: []string{"stewreads"}},
+		[]registry.Manifest{newStewreadsManifest()},
+		SyncOptions{ConfigPath: configPath, StatePath: statePath},
+	)
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected ErrConflict for equal-value unmanaged collision, got: %v", err)
+	}
+	if _, statErr := os.Stat(statePath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected no state write after conflict, got: %v", statErr)
+	}
+}
+
+func newStewreadsManifest() registry.Manifest {
+	return registry.Manifest{
+		Name:    "stewreads",
+		Command: "stewreads-mcp",
+		Enabled: true,
+		Clients: []string{Target},
+		Env: map[string]string{
+			"STEWREADS_CONFIG_PATH": "~/.config/stewreads/config.toml",
+		},
+	}
+}
+
+func readRoot(t *testing.T, path string) map[string]any {
+	t.Helper()
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	root := map[string]any{}
+	if err := toml.Unmarshal(payload, &root); err != nil {
+		t.Fatalf("parse config root: %v", err)
+	}
+	return root
+}
+
+func readServers(t *testing.T, path string) map[string]serverConfig {
+	t.Helper()
+	_, _, servers, _, err := loadCodexConfig(path)
+	if err != nil {
+		t.Fatalf("load Codex config: %v", err)
+	}
+	return servers
+}
+
+func readManagedNames(t *testing.T, path string) []string {
+	t.Helper()
+	state, err := syncshared.LoadManagedState(path)
+	if err != nil {
+		t.Fatalf("load managed state: %v", err)
+	}
+	names := syncshared.MapKeys(state)
+	sort.Strings(names)
+	return names
+}

--- a/internal/clients/codex/sync_test.go
+++ b/internal/clients/codex/sync_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -210,6 +211,64 @@ STEWREADS_CONFIG_PATH = "~/.config/stewreads/config.toml"
 	}
 }
 
+func TestSyncConflictsOnDisabledUnmanagedEntry(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "codex-managed.json")
+	config := []byte(`[mcp_servers.stewreads]
+command = "stewreads-mcp"
+enabled = false
+
+[mcp_servers.stewreads.env]
+STEWREADS_CONFIG_PATH = "~/.config/stewreads/config.toml"
+`)
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	_, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+		DryRun:     true,
+	})
+	if !errors.Is(err, clients.ErrConflict) {
+		t.Fatalf("expected disabled unmanaged entry to conflict, got: %v", err)
+	}
+}
+
+func TestSyncUpdatesOwnedDisabledEntry(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "codex-managed.json")
+	config := []byte(`[mcp_servers.stewreads]
+command = "stewreads-mcp"
+enabled = false
+
+[mcp_servers.stewreads.env]
+STEWREADS_CONFIG_PATH = "~/.config/stewreads/config.toml"
+`)
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+	if err := syncshared.SaveManagedState(statePath, map[string][]string{
+		"stewreads": {syncshared.SourceStandalone},
+	}); err != nil {
+		t.Fatalf("write managed state: %v", err)
+	}
+
+	result, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+		DryRun:     true,
+	})
+	if err != nil {
+		t.Fatalf("sync dry-run failed: %v", err)
+	}
+	if !reflect.DeepEqual(result.Updated, []string{"stewreads"}) {
+		t.Fatalf("expected owned disabled entry to be reported updated, got: %+v", result)
+	}
+}
+
 func TestSyncApplyFailsClosedOnInvalidTOML(t *testing.T) {
 	tmp := t.TempDir()
 	configPath := filepath.Join(tmp, "config.toml")
@@ -236,6 +295,40 @@ func TestSyncApplyFailsClosedOnInvalidTOML(t *testing.T) {
 	}
 	if string(after) != string(invalid) {
 		t.Fatalf("expected fail-closed behavior with unchanged config")
+	}
+	if _, statErr := os.Stat(statePath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected no state file write on failure, got err=%v", statErr)
+	}
+	backups, globErr := filepath.Glob(configPath + ".bak.*")
+	if globErr != nil {
+		t.Fatalf("glob backup files: %v", globErr)
+	}
+	if len(backups) != 0 {
+		t.Fatalf("expected no backup files on parse failure, got: %#v", backups)
+	}
+}
+
+func TestSyncApplyFailsClosedOnMalformedArgs(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "codex-managed.json")
+	invalid := []byte(`[mcp_servers.stewreads]
+command = "stewreads-mcp"
+args = [1]
+`)
+	if err := os.WriteFile(configPath, invalid, 0o644); err != nil {
+		t.Fatalf("write invalid config fixture: %v", err)
+	}
+
+	_, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err == nil {
+		t.Fatalf("expected sync apply to fail on malformed args")
+	}
+	if !strings.Contains(err.Error(), "mcp_servers.stewreads.args") {
+		t.Fatalf("expected args parse error, got: %v", err)
 	}
 	if _, statErr := os.Stat(statePath); !errors.Is(statErr, os.ErrNotExist) {
 		t.Fatalf("expected no state file write on failure, got err=%v", statErr)
@@ -280,6 +373,75 @@ command = "uv"
 	}
 	if string(backupPayload) != string(original) {
 		t.Fatalf("expected backup content to match original config")
+	}
+}
+
+func TestSyncPreservesPrivateConfigAndBackupModes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix mode bits are used in this test")
+	}
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "codex-managed.json")
+	original := []byte(`[mcp_servers.weather]
+command = "uv"
+`)
+	if err := os.WriteFile(configPath, original, 0o600); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	if _, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	}); err != nil {
+		t.Fatalf("sync apply failed: %v", err)
+	}
+
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("stat config: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("expected rewritten config mode 0600, got %04o", got)
+	}
+
+	backups, err := filepath.Glob(configPath + ".bak.*")
+	if err != nil {
+		t.Fatalf("glob backup files: %v", err)
+	}
+	if len(backups) == 0 {
+		t.Fatalf("expected backup file to be created")
+	}
+	backupInfo, err := os.Stat(backups[0])
+	if err != nil {
+		t.Fatalf("stat backup: %v", err)
+	}
+	if got := backupInfo.Mode().Perm(); got != 0o600 {
+		t.Fatalf("expected backup mode 0600, got %04o", got)
+	}
+}
+
+func TestSyncCreatesNewConfigPrivate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix mode bits are used in this test")
+	}
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "codex-managed.json")
+
+	if _, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	}); err != nil {
+		t.Fatalf("sync apply failed: %v", err)
+	}
+
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("stat config: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("expected new config mode 0600, got %04o", got)
 	}
 }
 
@@ -445,7 +607,7 @@ func readRoot(t *testing.T, path string) map[string]any {
 
 func readServers(t *testing.T, path string) map[string]serverConfig {
 	t.Helper()
-	_, _, servers, _, err := loadCodexConfig(path)
+	_, _, servers, _, _, err := loadCodexConfig(path)
 	if err != nil {
 		t.Fatalf("load Codex config: %v", err)
 	}

--- a/internal/clients/syncshared/syncshared.go
+++ b/internal/clients/syncshared/syncshared.go
@@ -146,6 +146,12 @@ func MapKeys[K comparable, V any](m map[K]V) []K {
 }
 
 func BackupFile(path string) (string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+	mode := info.Mode().Perm()
+
 	source, err := os.Open(path)
 	if err != nil {
 		return "", err
@@ -157,8 +163,12 @@ func BackupFile(path string) (string, error) {
 		return "", fmt.Errorf("ensure backup directory: %w", err)
 	}
 
-	target, err := os.Create(backupPath)
+	target, err := os.OpenFile(backupPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
 	if err != nil {
+		return "", err
+	}
+	if err := target.Chmod(mode); err != nil {
+		_ = target.Close()
 		return "", err
 	}
 	if _, err := io.Copy(target, source); err != nil {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ankitvg/madari/internal/clients"
 	"github.com/ankitvg/madari/internal/clients/syncshared"
 	"github.com/ankitvg/madari/internal/registry"
+	"github.com/pelletier/go-toml/v2"
 )
 
 type Status string
@@ -178,7 +179,7 @@ func Run(store *registry.Store, opts Options) (Report, error) {
 		if err != nil {
 			return Report{}, err
 		}
-		cr := inspectClientConfig(configPath)
+		cr := inspectClientConfig(adapter.Target(), configPath)
 		cr.Target = adapter.Target()
 		report.ClientConfigs = append(report.ClientConfigs, cr)
 	}
@@ -413,10 +414,10 @@ func resolveAdapterConfigPath(adapter clients.ClientAdapter, overrides map[strin
 }
 
 func InspectConfigPath(path string) ClientConfigReport {
-	return inspectClientConfig(path)
+	return inspectClientConfig("", path)
 }
 
-func inspectClientConfig(path string) ClientConfigReport {
+func inspectClientConfig(target, path string) ClientConfigReport {
 	report := ClientConfigReport{Path: path}
 	payload, err := os.ReadFile(path)
 	if err != nil {
@@ -431,6 +432,13 @@ func inspectClientConfig(path string) ClientConfigReport {
 	}
 
 	report.Exists = true
+	if target == "codex" || filepath.Ext(path) == ".toml" {
+		return inspectTOMLClientConfig(payload, report)
+	}
+	return inspectJSONClientConfig(payload, report)
+}
+
+func inspectJSONClientConfig(payload []byte, report ClientConfigReport) ClientConfigReport {
 	root := map[string]json.RawMessage{}
 	if err := json.Unmarshal(payload, &root); err != nil {
 		report.Status = StatusError
@@ -443,6 +451,30 @@ func inspectClientConfig(path string) ClientConfigReport {
 		if err := json.Unmarshal(raw, &servers); err != nil {
 			report.Status = StatusError
 			report.Message = fmt.Sprintf("invalid mcpServers object: %v", err)
+			return report
+		}
+	}
+
+	report.Status = StatusReady
+	report.Message = "ok"
+	return report
+}
+
+func inspectTOMLClientConfig(payload []byte, report ClientConfigReport) ClientConfigReport {
+	root := map[string]any{}
+	if err := toml.Unmarshal(payload, &root); err != nil {
+		report.Status = StatusError
+		report.Message = fmt.Sprintf("invalid TOML: %v", err)
+		return report
+	}
+
+	if raw, exists := root["mcp_servers"]; exists {
+		switch raw.(type) {
+		case map[string]any, []any:
+			// Codex uses a table; Vibe uses an array of tables.
+		default:
+			report.Status = StatusError
+			report.Message = "invalid mcp_servers value: expected table or array"
 			return report
 		}
 	}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -417,6 +417,10 @@ func InspectConfigPath(path string) ClientConfigReport {
 	return inspectClientConfig("", path)
 }
 
+func InspectClientConfigPath(target, path string) ClientConfigReport {
+	return inspectClientConfig(target, path)
+}
+
 func inspectClientConfig(target, path string) ClientConfigReport {
 	report := ClientConfigReport{Path: path}
 	payload, err := os.ReadFile(path)
@@ -432,8 +436,13 @@ func inspectClientConfig(target, path string) ClientConfigReport {
 	}
 
 	report.Exists = true
-	if target == "codex" || filepath.Ext(path) == ".toml" {
-		return inspectTOMLClientConfig(payload, report)
+	switch target {
+	case "codex":
+		return inspectCodexTOMLClientConfig(payload, report)
+	case "":
+		if filepath.Ext(path) == ".toml" {
+			return inspectCodexTOMLClientConfig(payload, report)
+		}
 	}
 	return inspectJSONClientConfig(payload, report)
 }
@@ -460,7 +469,7 @@ func inspectJSONClientConfig(payload []byte, report ClientConfigReport) ClientCo
 	return report
 }
 
-func inspectTOMLClientConfig(payload []byte, report ClientConfigReport) ClientConfigReport {
+func inspectCodexTOMLClientConfig(payload []byte, report ClientConfigReport) ClientConfigReport {
 	root := map[string]any{}
 	if err := toml.Unmarshal(payload, &root); err != nil {
 		report.Status = StatusError
@@ -469,12 +478,9 @@ func inspectTOMLClientConfig(payload []byte, report ClientConfigReport) ClientCo
 	}
 
 	if raw, exists := root["mcp_servers"]; exists {
-		switch raw.(type) {
-		case map[string]any, []any:
-			// Codex uses a table; Vibe uses an array of tables.
-		default:
+		if _, ok := raw.(map[string]any); !ok {
 			report.Status = StatusError
-			report.Message = "invalid mcp_servers value: expected table or array"
+			report.Message = "invalid mcp_servers value: expected table"
 			return report
 		}
 	}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -376,6 +376,52 @@ func TestRunInspectsTOMLClientConfig(t *testing.T) {
 	if cc.Status != StatusError || !strings.Contains(cc.Message, "invalid TOML") {
 		t.Fatalf("expected invalid TOML status, got: %+v", cc)
 	}
+
+	if err := os.WriteFile(configPath, []byte("[[mcp_servers]]\nname = \"vibe-style\"\n"), 0o644); err != nil {
+		t.Fatalf("write array toml config: %v", err)
+	}
+	report, err = Run(store, Options{Adapters: []clients.ClientAdapter{adapter}})
+	if err != nil {
+		t.Fatalf("doctor run failed: %v", err)
+	}
+	cc, ok = findClientConfig(report, "codex")
+	if !ok {
+		t.Fatalf("expected codex client config report, got: %+v", report.ClientConfigs)
+	}
+	if cc.Status != StatusError || !strings.Contains(cc.Message, "expected table") {
+		t.Fatalf("expected Codex to reject array mcp_servers, got: %+v", cc)
+	}
+}
+
+func TestRunSelectsConfigParserByClientTarget(t *testing.T) {
+	tmp := t.TempDir()
+	store := registry.NewStore(filepath.Join(tmp, "servers"))
+	commandPath := writeTestExecutable(t, tmp, "claude-code-mcp")
+	if err := store.Save(registry.Manifest{
+		Name:    "claude-code-server",
+		Command: commandPath,
+		Enabled: true,
+		Clients: []string{"claude-code"},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	configPath := filepath.Join(tmp, "claude-code.toml")
+	if err := os.WriteFile(configPath, []byte("[mcp_servers]\n"), 0o644); err != nil {
+		t.Fatalf("write toml config: %v", err)
+	}
+
+	adapter := testAdapter{target: "claude-code", configPath: configPath}
+	report, err := Run(store, Options{Adapters: []clients.ClientAdapter{adapter}})
+	if err != nil {
+		t.Fatalf("doctor run failed: %v", err)
+	}
+	cc, ok := findClientConfig(report, "claude-code")
+	if !ok {
+		t.Fatalf("expected claude-code client config report, got: %+v", report.ClientConfigs)
+	}
+	if cc.Status != StatusError || !strings.Contains(cc.Message, "invalid JSON") {
+		t.Fatalf("expected JSON parser for claude-code despite .toml suffix, got: %+v", cc)
+	}
 }
 
 func writeTestExecutable(t *testing.T, dir, name string) string {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/ankitvg/madari/internal/clients"
@@ -323,6 +324,57 @@ func TestRunMissingClientConfigWarns(t *testing.T) {
 	}
 	if cc.Message != "config file not found" {
 		t.Fatalf("expected missing config message, got: %q", cc.Message)
+	}
+}
+
+func TestRunInspectsTOMLClientConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix fixture mode bits are used in this test")
+	}
+	tmp := t.TempDir()
+	store := registry.NewStore(filepath.Join(tmp, "servers"))
+
+	commandPath := writeTestExecutable(t, tmp, "codex-mcp")
+	if err := store.Save(registry.Manifest{
+		Name:    "codex-server",
+		Command: commandPath,
+		Enabled: true,
+		Clients: []string{"codex"},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+
+	configPath := filepath.Join(tmp, "codex-config")
+	if err := os.WriteFile(configPath, []byte("[mcp_servers]\n"), 0o644); err != nil {
+		t.Fatalf("write toml config: %v", err)
+	}
+
+	adapter := testAdapter{target: "codex", configPath: configPath}
+	report, err := Run(store, Options{Adapters: []clients.ClientAdapter{adapter}})
+	if err != nil {
+		t.Fatalf("doctor run failed: %v", err)
+	}
+	cc, ok := findClientConfig(report, "codex")
+	if !ok {
+		t.Fatalf("expected codex client config report, got: %+v", report.ClientConfigs)
+	}
+	if cc.Status != StatusReady {
+		t.Fatalf("expected ready TOML config status, got: %+v", cc)
+	}
+
+	if err := os.WriteFile(configPath, []byte("[mcp_servers = broken"), 0o644); err != nil {
+		t.Fatalf("write invalid toml config: %v", err)
+	}
+	report, err = Run(store, Options{Adapters: []clients.ClientAdapter{adapter}})
+	if err != nil {
+		t.Fatalf("doctor run failed: %v", err)
+	}
+	cc, ok = findClientConfig(report, "codex")
+	if !ok {
+		t.Fatalf("expected codex client config report, got: %+v", report.ClientConfigs)
+	}
+	if cc.Status != StatusError || !strings.Contains(cc.Message, "invalid TOML") {
+		t.Fatalf("expected invalid TOML status, got: %+v", cc)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add a first-class `codex` sync adapter that writes Codex TOML MCP config under `$CODEX_HOME/config.toml` or `~/.codex/config.toml`.
- Preserve unmanaged `mcp_servers` entries and unrelated top-level Codex config while retaining Madari managed-state ownership, backups, atomic writes, and ring attach/detach semantics.
- Wire `codex` into sync-capable clients, doctor/status config inspection, CLI tests, and documentation while keeping render targets separate.

## Codex config verification

Verified against local Codex CLI before implementing the adapter:

```sh
codex --version
CODEX_HOME=$(mktemp -d) codex mcp add echo-probe --env FOO=bar -- /bin/echo hello
CODEX_HOME=<same-temp-dir> codex mcp list --json
```

Observed Codex CLI `0.139.0` writing global user config at `$CODEX_HOME/config.toml` with this shape:

```toml
[mcp_servers.echo-probe]
command = "/bin/echo"
args = ["hello"]

[mcp_servers.echo-probe.env]
FOO = "bar"
```

`codex mcp list --json` reported a stdio MCP server with `command`, `args`, and nested `env`.

## Validation

```sh
go test ./internal/clients/codex
go test ./cmd/madari
go test ./internal/doctor
go test ./internal/clients/syncshared
go test ./...
make build
```

Native smoke with isolated Madari and Codex homes:

```sh
codex --version
TMPDIR_SMOKE=$(mktemp -d)
export MADARI_CONFIG_DIR="$TMPDIR_SMOKE/madari"
export CODEX_HOME="$TMPDIR_SMOKE/codex"
mkdir -p "$MADARI_CONFIG_DIR" "$CODEX_HOME"
export CODEX_SMOKE_TOKEN=present
bin/madari add echo-codex --command /bin/echo --client codex --arg ring-smoke --required-env CODEX_SMOKE_TOKEN
bin/madari ring create codex-ring --member echo-codex --description "Codex ring attach smoke"
bin/madari ring attach codex-ring codex
bin/madari ring status
sed -n '1,120p' "$CODEX_HOME/config.toml"
codex mcp list --json
```

Smoke result summary:

- `codex-cli 0.139.0`
- `ring attach` wrote `$CODEX_HOME/config.toml` for `echo-codex`.
- `ring status` showed `codex-ring [ok] members=1 owned=1` with `echo-codex: ring:codex-ring`.
- Generated TOML contained `command = '/bin/echo'`, `args = ['ring-smoke']`, and `env_vars = ['CODEX_SMOKE_TOKEN']`.
- `codex mcp list --json` reported `echo-codex` as enabled stdio transport with the same command, args, and `env_vars`.