### PR TITLE
[codex] Add Vibe sync adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,15 @@ Notes:
 - `ring delete` removes only unattached ring definitions. It refuses while any client scope still records `ring:<name>` ownership and prints scoped detach guidance; deletion never edits client configs or managed state.
 - `ring render` prints a self-contained MCP config to stdout for ephemeral use — `claude --mcp-config <(madari ring render research --client claude-code)` — mutating nothing; secret env values are never emitted. Render targets are independent from persistent sync support: Claude and Gemini emit JSON, while Codex and Vibe emit TOML. `ring status` shows attached rings and per-server ownership for every client and scope.
 - Codex sync writes static non-secret `[env]` values under `[mcp_servers.<name>.env]` and forwards `[required_env]` plus `[secret_env]` keys through `env_vars`; static secret values are not written into Codex config.
-- Supported sync clients: `claude-desktop`, `claude-code`, `gemini`, and `codex`.
+- Vibe sync writes static `[env]` values into user-scoped `[[mcp_servers]]` entries and preserves unmanaged HTTP/streamable/manual entries.
+- Supported sync clients: `claude-desktop`, `claude-code`, `gemini`, `codex`, and `vibe`.
 - Supported render targets: `claude-code`, `claude-desktop`, `gemini`, `codex`, and `vibe`.
 - Default sync config paths:
   - `claude-desktop`: platform-specific Claude Desktop config path.
   - `claude-code`: `<current working directory>/.mcp.json`.
   - `gemini`: `<current working directory>/.gemini/settings.json`.
   - `codex`: `$CODEX_HOME/config.toml` or `~/.codex/config.toml`.
+  - `vibe`: `$VIBE_HOME/config.toml` or `~/.vibe/config.toml`.
 - `install --config-path` can only be used when exactly one sync target is selected.
 - `export` writes a versioned JSON snapshot of server and ring manifests for backup/sharing (stdout by default).
 - `import` is dry-run by default and only adds/updates listed servers and rings (`--apply` persists). Existing servers and rings absent from the snapshot are left unchanged; imported rings are not attached or synced.
@@ -96,7 +98,7 @@ env_vars = ["STEWREADS_API_KEY"]
 STEWREADS_CONFIG_PATH = "~/.config/stewreads/config.toml"
 ```
 
-Vibe render output uses TOML array entries:
+Vibe sync/render output uses TOML array entries:
 
 ```toml
 [[mcp_servers]]
@@ -116,12 +118,14 @@ madari add stewreads --command /Users/me/.local/bin/stewreads-mcp --client claud
 madari add stewreads --command /Users/me/.local/bin/stewreads-mcp --client claude-code
 madari add stewreads --command /Users/me/.local/bin/stewreads-mcp --client gemini
 madari add stewreads --command /Users/me/.local/bin/stewreads-mcp --client codex
+madari add stewreads --command /Users/me/.local/bin/stewreads-mcp --client vibe
 madari list
 madari status
 madari sync claude-desktop --dry-run
 madari sync claude-code --dry-run
 madari sync gemini --dry-run
 madari sync codex --dry-run
+madari sync vibe --dry-run
 madari export --file madari-snapshot.json
 madari import --file madari-snapshot.json
 madari import --file madari-snapshot.json --apply
@@ -171,7 +175,7 @@ go test ./...
 - Reference-counted ring ownership: entries leave a client config only when nothing owns them
 - `doctor` and `status` for diagnostics, drift detection, and ring consistency
 - Supports `uv` and `npm` package manager installs, plus manual `add` for any runtime/framework
-- macOS, Linux, and Windows; supports Claude Desktop, Claude Code, Gemini, and Codex sync targets
+- macOS, Linux, and Windows; supports Claude Desktop, Claude Code, Gemini, Codex, and Vibe sync targets
 
 ## Principles
 

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ankitvg/madari/internal/clients/codex"
 	"github.com/ankitvg/madari/internal/clients/gemini"
 	"github.com/ankitvg/madari/internal/clients/syncshared"
+	"github.com/ankitvg/madari/internal/clients/vibe"
 	"github.com/ankitvg/madari/internal/doctor"
 	"github.com/ankitvg/madari/internal/registry"
 )
@@ -28,6 +29,7 @@ var syncAdapters = map[string]clients.ClientAdapter{
 	claudecode.Target:    claudecode.Adapter{},
 	codex.Target:         codex.Adapter{},
 	gemini.Target:        gemini.Adapter{},
+	vibe.Target:          vibe.Adapter{},
 }
 
 func supportedSyncTargets() []string {

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -996,6 +996,55 @@ func TestRunWithStoreSyncCodexApply(t *testing.T) {
 	}
 }
 
+func TestRunWithStoreSyncVibeApply(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	addResult := runCmd(store, "add", "stewreads", "--command", commandPath, "--client", "vibe")
+	if addResult.code != 0 {
+		t.Fatalf("setup add failed: %s", addResult.stderr)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(configPath, []byte(`active_model = "dev"
+
+[[mcp_servers]]
+name = "weather"
+transport = "http"
+url = "http://localhost:8000"
+`), 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	result := runCmd(store, "sync", "vibe", "--config-path", configPath)
+	if result.code != 0 {
+		t.Fatalf("sync apply failed with stderr: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "mode: applied") {
+		t.Fatalf("expected applied mode output, got: %s", result.stdout)
+	}
+	if !strings.Contains(result.stdout, "sync target: vibe") {
+		t.Fatalf("expected vibe target output, got: %s", result.stdout)
+	}
+
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config after sync: %v", err)
+	}
+	for _, want := range []string{
+		"active_model",
+		"dev",
+		"weather",
+		"stewreads",
+		"transport = 'stdio'",
+		commandPath,
+	} {
+		if !strings.Contains(string(after), want) {
+			t.Fatalf("expected synced Vibe config to contain %q, got: %s", want, after)
+		}
+	}
+}
+
 func TestRunWithStoreSyncSkipsMissingExecutable(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("executable fixture handling not needed in this test environment")
@@ -1209,6 +1258,9 @@ func TestRunWithStoreClientsListsAllAdapters(t *testing.T) {
 	if !strings.Contains(result.stdout, "gemini") {
 		t.Fatalf("expected gemini in clients output, got: %s", result.stdout)
 	}
+	if !strings.Contains(result.stdout, "vibe") {
+		t.Fatalf("expected vibe in clients output, got: %s", result.stdout)
+	}
 }
 
 func TestRunWithStoreClientsShowsHeaderAndStatus(t *testing.T) {
@@ -1389,7 +1441,37 @@ func TestRunWithStoreDoctorAndStatusInspectCodexConfig(t *testing.T) {
 	}
 }
 
-func TestRunWithStoreDoctorChecksRenderOnlyTargets(t *testing.T) {
+func TestRunWithStoreDoctorAndStatusInspectVibeConfig(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	if result := runCmd(store, "add", "stewreads", "--command", commandPath, "--client", "vibe"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(configPath, []byte("[[mcp_servers]]\nname = \"weather\"\ntransport = \"http\"\nurl = \"http://localhost:8000\"\n"), 0o644); err != nil {
+		t.Fatalf("write Vibe config fixture: %v", err)
+	}
+
+	result := runCmd(store, "doctor", "--client-config", "vibe="+configPath)
+	if result.code != 0 {
+		t.Fatalf("doctor expected success, got code=%d stderr=%s stdout=%s", result.code, result.stderr, result.stdout)
+	}
+	if !strings.Contains(result.stdout, "vibe config:") {
+		t.Fatalf("expected doctor output to include vibe config details, got: %s", result.stdout)
+	}
+
+	result = runCmd(store, "status", "--client-config", "vibe="+configPath)
+	if result.code != 0 {
+		t.Fatalf("status expected success, got code=%d stderr=%s stdout=%s", result.code, result.stderr, result.stdout)
+	}
+	if !strings.Contains(result.stdout, "vibe-config: ready") {
+		t.Fatalf("expected status output to include vibe config readiness, got: %s", result.stdout)
+	}
+}
+
+func TestRunWithStoreDoctorChecksVibeTarget(t *testing.T) {
 	store := newTestStore(t)
 	commandPath := mustCurrentExecutable(t)
 
@@ -1399,15 +1481,20 @@ func TestRunWithStoreDoctorChecksRenderOnlyTargets(t *testing.T) {
 		t.Fatalf("setup add failed: %s", result.stderr)
 	}
 
-	result := runCmd(store, "doctor")
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(configPath, []byte("mcp_servers = []\n"), 0o644); err != nil {
+		t.Fatalf("write Vibe config fixture: %v", err)
+	}
+
+	result := runCmd(store, "doctor", "--client-config", "vibe="+configPath)
 	if result.code != 0 {
-		t.Fatalf("doctor with render-only warning should exit 0, got code=%d stderr=%s stdout=%s", result.code, result.stderr, result.stdout)
+		t.Fatalf("doctor with Vibe warning should exit 0, got code=%d stderr=%s stdout=%s", result.code, result.stderr, result.stdout)
 	}
 	if !strings.Contains(result.stdout, "portable [warn]") || !strings.Contains(result.stdout, "missing required env key PORTABLE_TOKEN") {
-		t.Fatalf("expected render-only target to receive server diagnostics, got: %s", result.stdout)
+		t.Fatalf("expected Vibe target to receive server diagnostics, got: %s", result.stdout)
 	}
 	if !strings.Contains(result.stdout, "summary: total=1 ready=0 warn=1 error=0 skipped=0") {
-		t.Fatalf("expected render-only target not to be skipped, got: %s", result.stdout)
+		t.Fatalf("expected Vibe target not to be skipped, got: %s", result.stdout)
 	}
 }
 
@@ -2402,6 +2489,49 @@ func TestRunWithStoreRingAttachDetachCodex(t *testing.T) {
 	}
 }
 
+func TestRunWithStoreRingAttachDetachVibe(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	if result := runCmd(store, "add", "stewreads", "--command", commandPath, "--client", "vibe"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "ring", "create", "research", "--member", "stewreads"); result.code != 0 {
+		t.Fatalf("ring create failed: %s", result.stderr)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	result := runCmd(store, "ring", "attach", "research", "vibe", "--config-path", configPath)
+	if result.code != 0 {
+		t.Fatalf("attach failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "sync target: vibe") || !strings.Contains(result.stdout, "added: stewreads") {
+		t.Fatalf("expected vibe attach output, got: %s", result.stdout)
+	}
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read Vibe config after attach: %v", err)
+	}
+	if !strings.Contains(string(after), "stewreads") || !strings.Contains(string(after), "[[mcp_servers]]") {
+		t.Fatalf("expected attached ring member in Vibe config, got: %s", after)
+	}
+
+	result = runCmd(store, "ring", "detach", "research", "vibe", "--config-path", configPath)
+	if result.code != 0 {
+		t.Fatalf("detach failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "removed: stewreads") {
+		t.Fatalf("expected vibe detach removal, got: %s", result.stdout)
+	}
+	after, err = os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read Vibe config after detach: %v", err)
+	}
+	if strings.Contains(string(after), "stewreads") {
+		t.Fatalf("expected detached ring member removed from Vibe config, got: %s", after)
+	}
+}
+
 func TestRunWithStoreRingAttachWarnsDisabledMember(t *testing.T) {
 	store := newTestStore(t)
 	commandPath := mustCurrentExecutable(t)
@@ -2552,10 +2682,6 @@ func TestRunWithStoreRingRenderJSONTargets(t *testing.T) {
 func TestRunWithStoreRingRenderTOMLTargets(t *testing.T) {
 	store := newTestStore(t)
 	commandPath := mustCurrentExecutable(t)
-
-	if _, ok := syncAdapters["vibe"]; ok {
-		t.Fatal("vibe must not be registered as a sync adapter")
-	}
 
 	if result := runCmd(store, "add", "portable", "--command", commandPath,
 		"--client", "codex",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@
 
 2. Client Adapters
 - Translate registry entries into client-specific config.
-- Current adapters: Claude Desktop, Claude Code, Gemini, and Codex.
+- Current adapters: Claude Desktop, Claude Code, Gemini, Codex, and Vibe.
 - Adapters own read/merge/write behavior for their client format.
 
 3. Sync Engine

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -33,6 +33,8 @@ madari sync gemini
 madari sync gemini --scope user
 madari sync codex --dry-run
 madari sync codex
+madari sync vibe --dry-run
+madari sync vibe
 ```
 
 `--scope` applies to clients with project and user configs: `claude-code`
@@ -49,6 +51,11 @@ values are written under `[mcp_servers.<name>.env]`; `[required_env]` and
 `[secret_env]` keys are forwarded through `env_vars`, and static secret
 values are not written into Codex config.
 
+`vibe` sync targets Vibe's user config (`$VIBE_HOME/config.toml`, or
+`~/.vibe/config.toml` when `VIBE_HOME` is unset). Static `[env]` values are
+written into `[[mcp_servers]]` stdio entries. Existing unmanaged HTTP,
+streamable HTTP, or hand-managed stdio entries are preserved and never adopted.
+
 ## Rings
 
 ```bash
@@ -60,9 +67,11 @@ madari ring attach research claude-code --scope user
 madari ring attach research gemini
 madari ring attach research gemini --scope user
 madari ring attach research codex
+madari ring attach research vibe
 madari ring detach research claude-code
 madari ring detach research gemini
 madari ring detach research codex
+madari ring detach research vibe
 madari ring delete research
 madari ring render research --client claude-code
 madari ring render research --client gemini
@@ -193,7 +202,8 @@ summaries cover every sync target):
     {"target": "claude-code", "status": "skipped"},
     {"target": "codex", "status": "skipped"},
     {"target": "claude-desktop", "status": "ready"},
-    {"target": "gemini", "status": "skipped"}
+    {"target": "gemini", "status": "skipped"},
+    {"target": "vibe", "status": "skipped"}
   ],
   "managed": [
     {"target": "claude-code", "scope": "default", "entries": 0, "sources": []},
@@ -201,7 +211,8 @@ summaries cover every sync target):
     {"target": "codex", "scope": "default", "entries": 0, "sources": []},
     {"target": "claude-desktop", "scope": "default", "entries": 1, "sources": ["standalone"]},
     {"target": "gemini", "scope": "default", "entries": 0, "sources": []},
-    {"target": "gemini", "scope": "user", "entries": 0, "sources": []}
+    {"target": "gemini", "scope": "user", "entries": 0, "sources": []},
+    {"target": "vibe", "scope": "default", "entries": 0, "sources": []}
   ],
   "manifest_errors": 0,
   "drift": [

--- a/docs/manifest-spec.md
+++ b/docs/manifest-spec.md
@@ -23,9 +23,8 @@ Known client IDs:
 - `codex`
 - `vibe`
 
-`claude-desktop`, `claude-code`, `gemini`, and `codex` are sync-capable
-today. `vibe` is a render target for `madari ring render`; it is not a
-persistent sync target unless adapter support is added separately.
+`claude-desktop`, `claude-code`, `gemini`, `codex`, and `vibe` are
+sync-capable today. All are also render targets for `madari ring render`.
 
 ### `[env]`
 
@@ -42,7 +41,9 @@ Key/value static environment variables.
   client configs (for example Claude Code `.mcp.json` or Gemini
   `.gemini/settings.json`); secret values may only land in user-scoped
   configs. Codex sync forwards secret keys through `env_vars` and does not
-  write static secret values into Codex config.
+  write static secret values into Codex config. Vibe sync targets the user
+  config, so static secret values are allowed there like other user-scoped
+  configs.
 
 ## Example
 

--- a/internal/clients/vibe/adapter.go
+++ b/internal/clients/vibe/adapter.go
@@ -1,0 +1,31 @@
+package vibe
+
+import (
+	"github.com/ankitvg/madari/internal/clients"
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+// Adapter implements clients.ClientAdapter for Vibe.
+type Adapter struct{}
+
+var _ clients.ClientAdapter = Adapter{}
+
+func (Adapter) Target() string {
+	return Target
+}
+
+func (Adapter) DefaultConfigPath() (string, error) {
+	return DefaultConfigPath()
+}
+
+func (Adapter) Sync(manifests []registry.Manifest, opts clients.SyncOptions) (clients.SyncResult, error) {
+	return Sync(manifests, opts)
+}
+
+func (Adapter) AttachRing(ring registry.Ring, manifests []registry.Manifest, opts clients.SyncOptions) (clients.SyncResult, error) {
+	return AttachRing(ring, manifests, opts)
+}
+
+func (Adapter) DetachRing(ring string, opts clients.SyncOptions) (clients.SyncResult, error) {
+	return DetachRing(ring, opts)
+}

--- a/internal/clients/vibe/sync.go
+++ b/internal/clients/vibe/sync.go
@@ -1,0 +1,599 @@
+package vibe
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/ankitvg/madari/internal/clients"
+	"github.com/ankitvg/madari/internal/clients/syncshared"
+	"github.com/ankitvg/madari/internal/registry"
+	"github.com/pelletier/go-toml/v2"
+)
+
+const (
+	Target            = "vibe"
+	defaultConfigMode = 0o600
+)
+
+var ErrConflict = clients.ErrConflict
+
+// SyncOptions configures sync behavior.
+type SyncOptions = clients.SyncOptions
+
+// SyncResult captures the computed or applied mutation plan.
+type SyncResult = clients.SyncResult
+
+// Sync synchronizes enabled Vibe-targeted manifests into the Vibe user config.
+// Vibe stores persistent MCP servers in $VIBE_HOME/config.toml, defaulting to
+// ~/.vibe/config.toml, under [[mcp_servers]] array entries.
+func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
+	if err := validateScope(opts.Scope); err != nil {
+		return SyncResult{}, err
+	}
+	configPath, err := resolveConfigPath(opts.ConfigPath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	statePath, err := resolveStatePath(opts.StatePath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	root, rawServers, existingServers, configExists, configMode, err := loadVibeConfig(configPath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	managedState, err := syncshared.LoadManagedState(statePath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	result, nextState, writeSet, err := syncshared.PlanSync(existingServers, managedState, entriesForTarget(manifests), opts.Rings, equalServer, ErrConflict)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	result.ConfigPath = configPath
+	result.DryRun = opts.DryRun
+
+	if opts.DryRun {
+		return result, nil
+	}
+
+	if err := applyPlan(configPath, statePath, root, rawServers, configExists, configMode, result.Removed, writeSet, nextState); err != nil {
+		return SyncResult{}, err
+	}
+	return result, nil
+}
+
+// AttachRing adds the ring's ownership source to every member and materializes
+// eligible ones into Vibe config. Attaching onto any pre-existing unmanaged
+// entry, equal values included, refuses with ErrConflict.
+func AttachRing(ring registry.Ring, manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
+	if err := validateScope(opts.Scope); err != nil {
+		return SyncResult{}, err
+	}
+	configPath, err := resolveConfigPath(opts.ConfigPath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	statePath, err := resolveStatePath(opts.StatePath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	root, rawServers, existingServers, configExists, configMode, err := loadVibeConfig(configPath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	managedState, err := syncshared.LoadManagedState(statePath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	result, nextState, writeSet, err := syncshared.PlanAttach(existingServers, managedState, ring.Name, ring.Members, entriesForTarget(manifests), opts.Rings, equalServer, ErrConflict)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	result.ConfigPath = configPath
+	result.DryRun = opts.DryRun
+
+	if opts.DryRun {
+		return result, nil
+	}
+	if err := applyPlan(configPath, statePath, root, rawServers, configExists, configMode, result.Removed, writeSet, nextState); err != nil {
+		return SyncResult{}, err
+	}
+	return result, nil
+}
+
+// DetachRing removes the ring's ownership source everywhere; entries that lose
+// their last source leave the config. The ring file is not required, so stale
+// sources can always be released.
+func DetachRing(ringName string, opts SyncOptions) (SyncResult, error) {
+	if err := validateScope(opts.Scope); err != nil {
+		return SyncResult{}, err
+	}
+	configPath, err := resolveConfigPath(opts.ConfigPath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	statePath, err := resolveStatePath(opts.StatePath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	root, rawServers, existingServers, configExists, configMode, err := loadVibeConfig(configPath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	managedState, err := syncshared.LoadManagedState(statePath)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	result, nextState := syncshared.PlanDetach(existingServers, managedState, ringName, opts.Rings)
+	result.ConfigPath = configPath
+	result.DryRun = opts.DryRun
+
+	if opts.DryRun {
+		return result, nil
+	}
+	if err := applyPlan(configPath, statePath, root, rawServers, configExists, configMode, result.Removed, nil, nextState); err != nil {
+		return SyncResult{}, err
+	}
+	return result, nil
+}
+
+func applyPlan(
+	configPath, statePath string,
+	root map[string]any,
+	rawServers []rawServerEntry,
+	configExists bool,
+	configMode os.FileMode,
+	removed []string,
+	writeSet map[string]serverConfig,
+	nextState map[string][]string,
+) error {
+	removedSet := map[string]bool{}
+	for _, name := range removed {
+		removedSet[name] = true
+	}
+
+	mutated := make([]any, 0, len(rawServers)+len(writeSet))
+	written := map[string]bool{}
+	for _, entry := range rawServers {
+		if removedSet[entry.Name] {
+			continue
+		}
+		if server, exists := writeSet[entry.Name]; exists {
+			mutated = append(mutated, server)
+			written[entry.Name] = true
+			continue
+		}
+		mutated = append(mutated, entry.Raw)
+	}
+
+	pending := make([]string, 0, len(writeSet))
+	for name := range writeSet {
+		if !written[name] && !removedSet[name] {
+			pending = append(pending, name)
+		}
+	}
+	sort.Strings(pending)
+	for _, name := range pending {
+		mutated = append(mutated, writeSet[name])
+	}
+
+	updatedRoot := make(map[string]any, len(root)+1)
+	for key, value := range root {
+		updatedRoot[key] = value
+	}
+	updatedRoot["mcp_servers"] = mutated
+
+	payload, err := toml.Marshal(updatedRoot)
+	if err != nil {
+		return fmt.Errorf("marshal Vibe config: %w", err)
+	}
+
+	if configExists {
+		if _, err := syncshared.BackupFile(configPath); err != nil {
+			return fmt.Errorf("backup Vibe config: %w", err)
+		}
+	}
+	if err := syncshared.WriteFileAtomically(configPath, payload, configMode); err != nil {
+		return fmt.Errorf("write Vibe config: %w", err)
+	}
+
+	if err := syncshared.SaveManagedState(statePath, nextState); err != nil {
+		return fmt.Errorf("write managed sync state: %w", err)
+	}
+	return nil
+}
+
+func DefaultConfigPath() (string, error) {
+	if vibeHome := strings.TrimSpace(os.Getenv("VIBE_HOME")); vibeHome != "" {
+		resolved, err := syncshared.ExpandHome(vibeHome)
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(filepath.Clean(resolved), "config.toml"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user home: %w", err)
+	}
+	return filepath.Join(home, ".vibe", "config.toml"), nil
+}
+
+func DefaultStatePath() (string, error) {
+	root, err := registry.DefaultRootDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, "state", Target+"-managed.json"), nil
+}
+
+func resolveConfigPath(configPath string) (string, error) {
+	return syncshared.ResolvePath(configPath, DefaultConfigPath)
+}
+
+func resolveStatePath(statePath string) (string, error) {
+	return syncshared.ResolvePath(statePath, DefaultStatePath)
+}
+
+func validateScope(scope string) error {
+	switch strings.TrimSpace(scope) {
+	case "", clients.ScopeUser:
+		return nil
+	default:
+		return fmt.Errorf("%s sync supports the user-scoped config only", Target)
+	}
+}
+
+func entriesForTarget(manifests []registry.Manifest) map[string]syncshared.Entry[serverConfig] {
+	entries := map[string]syncshared.Entry[serverConfig]{}
+	for _, manifest := range manifests {
+		if !manifest.HasClient(Target) {
+			continue
+		}
+		entry := syncshared.Entry[serverConfig]{}
+		if manifest.Enabled {
+			entry.Eligible = true
+			entry.Value = materializeServer(manifest)
+		}
+		entries[manifest.Name] = entry
+	}
+	return entries
+}
+
+func materializeServer(manifest registry.Manifest) serverConfig {
+	entry := serverConfig{
+		Name:      manifest.Name,
+		Transport: "stdio",
+		Command:   manifest.Command,
+	}
+	if len(manifest.Args) > 0 {
+		entry.Args = append([]string(nil), manifest.Args...)
+	}
+	if len(manifest.Env) > 0 {
+		entry.Env = map[string]string{}
+		for key, value := range manifest.Env {
+			entry.Env[key] = value
+		}
+	}
+	return entry
+}
+
+func equalServer(a, b serverConfig) bool {
+	if a.Name != b.Name || a.Transport != b.Transport || a.Command != b.Command {
+		return false
+	}
+	if !equalStringSlices(a.CommandList, b.CommandList) {
+		return false
+	}
+	if a.HasExtra || b.HasExtra {
+		return false
+	}
+	if effectiveDisabled(a) != effectiveDisabled(b) {
+		return false
+	}
+	if !equalStringSlices(a.DisabledTools, b.DisabledTools) {
+		return false
+	}
+	if !equalStringSlices(a.Args, b.Args) {
+		return false
+	}
+	if len(a.Env) != len(b.Env) {
+		return false
+	}
+	for key, value := range a.Env {
+		if b.Env[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func effectiveDisabled(server serverConfig) bool {
+	return server.Disabled != nil && *server.Disabled
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func loadVibeConfig(path string) (map[string]any, []rawServerEntry, map[string]serverConfig, bool, os.FileMode, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]any{}, []rawServerEntry{}, map[string]serverConfig{}, false, defaultConfigMode, nil
+		}
+		return nil, nil, nil, false, 0, fmt.Errorf("stat Vibe config %q: %w", path, err)
+	}
+	configMode := info.Mode().Perm()
+	if configMode == 0 {
+		configMode = defaultConfigMode
+	}
+
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, nil, false, 0, fmt.Errorf("read Vibe config %q: %w", path, err)
+	}
+
+	root := map[string]any{}
+	if err := toml.Unmarshal(payload, &root); err != nil {
+		return nil, nil, nil, true, configMode, fmt.Errorf("parse Vibe config TOML: %w", err)
+	}
+	if root == nil {
+		root = map[string]any{}
+	}
+
+	rawServers := []rawServerEntry{}
+	if raw, exists := root["mcp_servers"]; exists {
+		servers, ok := raw.([]any)
+		if !ok {
+			return nil, nil, nil, true, configMode, fmt.Errorf("parse mcp_servers: expected array")
+		}
+		for i, server := range servers {
+			parsed, err := parseServer(i, server)
+			if err != nil {
+				return nil, nil, nil, true, configMode, err
+			}
+			rawServers = append(rawServers, rawServerEntry{
+				Name: parsed.Name,
+				Raw:  server,
+			})
+		}
+	}
+
+	servers := make(map[string]serverConfig, len(rawServers))
+	for i, entry := range rawServers {
+		if _, exists := servers[entry.Name]; exists {
+			return nil, nil, nil, true, configMode, fmt.Errorf("parse mcp_servers[%d].name: duplicate server name %q", i, entry.Name)
+		}
+		server, err := parseServer(i, entry.Raw)
+		if err != nil {
+			return nil, nil, nil, true, configMode, err
+		}
+		servers[entry.Name] = server
+	}
+
+	return root, rawServers, servers, true, configMode, nil
+}
+
+func parseServer(index int, raw any) (serverConfig, error) {
+	table, ok := raw.(map[string]any)
+	if !ok {
+		return serverConfig{}, fmt.Errorf("parse mcp_servers[%d]: expected table", index)
+	}
+
+	entry := serverConfig{}
+	name, ok, err := requiredString(table, "name")
+	if err != nil {
+		return serverConfig{}, fmt.Errorf("parse mcp_servers[%d].name: %w", index, err)
+	}
+	if !ok || strings.TrimSpace(name) == "" {
+		return serverConfig{}, fmt.Errorf("parse mcp_servers[%d].name: expected non-empty string", index)
+	}
+	entry.Name = name
+
+	transport, ok, err := requiredString(table, "transport")
+	if err != nil {
+		return serverConfig{}, fmt.Errorf("parse mcp_servers[%d].transport: %w", index, err)
+	}
+	if !ok || strings.TrimSpace(transport) == "" {
+		return serverConfig{}, fmt.Errorf("parse mcp_servers[%d].transport: expected non-empty string", index)
+	}
+	entry.Transport = transport
+
+	if disabled, ok, err := optionalBool(table, "disabled"); err != nil {
+		return serverConfig{}, fmt.Errorf("parse mcp_servers[%d].disabled: %w", index, err)
+	} else if ok {
+		entry.Disabled = &disabled
+	}
+	if disabledTools, ok, err := optionalStringSlice(table, "disabled_tools"); err != nil {
+		return serverConfig{}, fmt.Errorf("parse mcp_servers[%d].disabled_tools: %w", index, err)
+	} else if ok {
+		entry.DisabledTools = disabledTools
+	}
+
+	if entry.Transport == "stdio" {
+		if command, commandList, ok, err := requiredCommand(table); err != nil {
+			return serverConfig{}, fmt.Errorf("parse mcp_servers[%d].command: %w", index, err)
+		} else if !ok {
+			return serverConfig{}, fmt.Errorf("parse mcp_servers[%d].command: expected string or array of strings", index)
+		} else {
+			entry.Command = command
+			entry.CommandList = commandList
+		}
+		if args, ok, err := optionalStringSlice(table, "args"); err != nil {
+			return serverConfig{}, fmt.Errorf("parse mcp_servers[%d].args: %w", index, err)
+		} else if ok {
+			entry.Args = args
+		}
+		if env, ok, err := optionalStringMap(table, "env"); err != nil {
+			return serverConfig{}, fmt.Errorf("parse mcp_servers[%d].env: %w", index, err)
+		} else if ok {
+			entry.Env = env
+		}
+	}
+
+	entry.HasExtra = hasBehavioralExtras(table)
+	return entry, nil
+}
+
+func requiredString(table map[string]any, key string) (string, bool, error) {
+	raw, exists := table[key]
+	if !exists {
+		return "", false, nil
+	}
+	value, ok := raw.(string)
+	if !ok {
+		return "", true, fmt.Errorf("expected string")
+	}
+	return value, true, nil
+}
+
+func requiredCommand(table map[string]any) (string, []string, bool, error) {
+	raw, exists := table["command"]
+	if !exists {
+		return "", nil, false, nil
+	}
+	if command, ok := raw.(string); ok {
+		if strings.TrimSpace(command) == "" {
+			return "", nil, true, fmt.Errorf("expected non-empty string")
+		}
+		return command, nil, true, nil
+	}
+	values, ok := raw.([]any)
+	if !ok {
+		return "", nil, true, fmt.Errorf("expected string or array of strings")
+	}
+	commandList := make([]string, 0, len(values))
+	for _, value := range values {
+		str, ok := value.(string)
+		if !ok {
+			return "", nil, true, fmt.Errorf("expected string or array of strings")
+		}
+		commandList = append(commandList, str)
+	}
+	if len(commandList) == 0 {
+		return "", nil, true, fmt.Errorf("expected non-empty array")
+	}
+	return "", commandList, true, nil
+}
+
+func optionalBool(table map[string]any, key string) (bool, bool, error) {
+	raw, exists := table[key]
+	if !exists {
+		return false, false, nil
+	}
+	value, ok := raw.(bool)
+	if !ok {
+		return false, true, fmt.Errorf("expected bool")
+	}
+	return value, true, nil
+}
+
+func optionalStringSlice(table map[string]any, key string) ([]string, bool, error) {
+	raw, exists := table[key]
+	if !exists {
+		return nil, false, nil
+	}
+	values, ok := raw.([]any)
+	if !ok {
+		if strings, ok := raw.([]string); ok {
+			return append([]string(nil), strings...), true, nil
+		}
+		return nil, true, fmt.Errorf("expected array of strings")
+	}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		str, ok := value.(string)
+		if !ok {
+			return nil, true, fmt.Errorf("expected array of strings")
+		}
+		out = append(out, str)
+	}
+	return out, true, nil
+}
+
+func optionalStringMap(table map[string]any, key string) (map[string]string, bool, error) {
+	raw, exists := table[key]
+	if !exists {
+		return nil, false, nil
+	}
+	values, ok := raw.(map[string]any)
+	if !ok {
+		if strings, ok := raw.(map[string]string); ok {
+			out := make(map[string]string, len(strings))
+			for key, value := range strings {
+				out[key] = value
+			}
+			return out, true, nil
+		}
+		return nil, true, fmt.Errorf("expected table of strings")
+	}
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		str, ok := value.(string)
+		if !ok {
+			return nil, true, fmt.Errorf("expected table of strings")
+		}
+		out[key] = str
+	}
+	return out, true, nil
+}
+
+func hasBehavioralExtras(table map[string]any) bool {
+	for key, raw := range table {
+		switch key {
+		case "name", "transport", "command", "args", "env":
+			continue
+		case "disabled":
+			disabled, _ := raw.(bool)
+			if disabled {
+				return true
+			}
+		case "disabled_tools":
+			if values, ok := raw.([]any); ok && len(values) > 0 {
+				return true
+			}
+			if values, ok := raw.([]string); ok && len(values) > 0 {
+				return true
+			}
+		default:
+			return true
+		}
+	}
+	return false
+}
+
+type rawServerEntry struct {
+	Name string
+	Raw  any
+}
+
+type serverConfig struct {
+	Name          string            `toml:"name"`
+	Transport     string            `toml:"transport"`
+	Command       string            `toml:"command,omitempty"`
+	CommandList   []string          `toml:"-"`
+	Args          []string          `toml:"args,omitempty"`
+	Env           map[string]string `toml:"env,omitempty"`
+	Disabled      *bool             `toml:"disabled,omitempty"`
+	DisabledTools []string          `toml:"disabled_tools,omitempty"`
+	HasExtra      bool              `toml:"-"`
+}

--- a/internal/clients/vibe/sync_test.go
+++ b/internal/clients/vibe/sync_test.go
@@ -1,0 +1,608 @@
+package vibe
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/ankitvg/madari/internal/clients"
+	"github.com/ankitvg/madari/internal/clients/syncshared"
+	"github.com/ankitvg/madari/internal/registry"
+	"github.com/pelletier/go-toml/v2"
+)
+
+func TestSyncDryRunDoesNotMutateFiles(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "vibe-managed.json")
+	original := []byte(`active_model = "mistral-large"
+
+[[mcp_servers]]
+name = "weather"
+transport = "http"
+url = "http://localhost:8000"
+`)
+	if err := os.WriteFile(configPath, original, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	result, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+		DryRun:     true,
+	})
+	if err != nil {
+		t.Fatalf("sync dry-run failed: %v", err)
+	}
+	if len(result.Added) != 1 || result.Added[0] != "stewreads" {
+		t.Fatalf("expected stewreads to be planned as added, got: %+v", result)
+	}
+
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config after dry-run: %v", err)
+	}
+	if string(after) != string(original) {
+		t.Fatalf("expected dry-run to keep config unchanged")
+	}
+	if _, err := os.Stat(statePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected no state file write on dry-run, got err=%v", err)
+	}
+}
+
+func TestSyncApplyAddUpdateRemoveLifecycle(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "vibe-managed.json")
+	baseConfig := []byte(`active_model = "mistral-large"
+
+[[mcp_servers]]
+name = "weather"
+transport = "http"
+url = "http://localhost:8000"
+`)
+	if err := os.WriteFile(configPath, baseConfig, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	manifest := newStewreadsManifest()
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("initial sync failed: %v", err)
+	}
+	if len(result.Added) != 1 || result.Added[0] != "stewreads" {
+		t.Fatalf("expected add result, got: %+v", result)
+	}
+
+	root := readRoot(t, configPath)
+	if root["active_model"] != "mistral-large" {
+		t.Fatalf("expected unrelated top-level active_model preserved, got: %#v", root["active_model"])
+	}
+	rawServers := root["mcp_servers"].([]any)
+	if len(rawServers) != 2 {
+		t.Fatalf("expected unmanaged and synced entries, got: %#v", rawServers)
+	}
+	servers := readServers(t, configPath)
+	if got := servers["weather"].Transport; got != "http" {
+		t.Fatalf("expected existing weather HTTP server to be preserved, got transport %q", got)
+	}
+	if got := servers["stewreads"].Command; got != "stewreads-mcp" {
+		t.Fatalf("expected stewreads command to be synced, got: %q", got)
+	}
+
+	managedNames := readManagedNames(t, statePath)
+	if len(managedNames) != 1 || managedNames[0] != "stewreads" {
+		t.Fatalf("expected managed state to track stewreads, got: %#v", managedNames)
+	}
+
+	result, err = Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("unchanged sync failed: %v", err)
+	}
+	if len(result.Unchanged) != 1 || result.Unchanged[0] != "stewreads" {
+		t.Fatalf("expected unchanged result, got: %+v", result)
+	}
+
+	manifest.Args = []string{"--stdio"}
+	result, err = Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("update sync failed: %v", err)
+	}
+	if len(result.Updated) != 1 || result.Updated[0] != "stewreads" {
+		t.Fatalf("expected update result, got: %+v", result)
+	}
+	servers = readServers(t, configPath)
+	if !reflect.DeepEqual(servers["stewreads"].Args, []string{"--stdio"}) {
+		t.Fatalf("expected synced args update, got: %#v", servers["stewreads"].Args)
+	}
+
+	manifest.Enabled = false
+	result, err = Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("remove sync failed: %v", err)
+	}
+	if len(result.Removed) != 1 || result.Removed[0] != "stewreads" {
+		t.Fatalf("expected remove result, got: %+v", result)
+	}
+	servers = readServers(t, configPath)
+	if _, ok := servers["stewreads"]; ok {
+		t.Fatalf("expected stewreads to be removed from Vibe config")
+	}
+	if _, ok := servers["weather"]; !ok {
+		t.Fatalf("expected weather to remain after removal")
+	}
+}
+
+func TestSyncRejectsUnmanagedNameCollision(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "vibe-managed.json")
+	config := []byte(`[[mcp_servers]]
+name = "stewreads"
+transport = "stdio"
+command = "manual-custom-command"
+`)
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	_, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+		DryRun:     true,
+	})
+	if !errors.Is(err, clients.ErrConflict) {
+		t.Fatalf("expected clients.ErrConflict, got: %v", err)
+	}
+}
+
+func TestSyncDoesNotAdoptEqualUnmanagedEntry(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "vibe-managed.json")
+	config := []byte(`[[mcp_servers]]
+name = "stewreads"
+transport = "stdio"
+command = "stewreads-mcp"
+env = { STEWREADS_CONFIG_PATH = "~/.config/stewreads/config.toml" }
+`)
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	manifest := newStewreadsManifest()
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync apply failed: %v", err)
+	}
+	if len(result.Unchanged) != 1 || result.Unchanged[0] != "stewreads" {
+		t.Fatalf("expected equal unmanaged entry to be unchanged, got: %+v", result)
+	}
+	if managedNames := readManagedNames(t, statePath); len(managedNames) != 0 {
+		t.Fatalf("expected no adoption of unmanaged entry, got managed: %#v", managedNames)
+	}
+
+	manifest.Enabled = false
+	result, err = Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync after disable failed: %v", err)
+	}
+	if len(result.Removed) != 0 {
+		t.Fatalf("expected no removal of never-owned entry, got: %#v", result.Removed)
+	}
+	servers := readServers(t, configPath)
+	if _, ok := servers["stewreads"]; !ok {
+		t.Fatalf("expected hand-managed stewreads entry to survive disable")
+	}
+}
+
+func TestSyncConflictsOnDisabledUnmanagedEntry(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "vibe-managed.json")
+	config := []byte(`[[mcp_servers]]
+name = "stewreads"
+transport = "stdio"
+command = "stewreads-mcp"
+disabled = true
+env = { STEWREADS_CONFIG_PATH = "~/.config/stewreads/config.toml" }
+`)
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	_, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+		DryRun:     true,
+	})
+	if !errors.Is(err, clients.ErrConflict) {
+		t.Fatalf("expected disabled unmanaged entry to conflict, got: %v", err)
+	}
+}
+
+func TestSyncUpdatesOwnedDisabledEntry(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "vibe-managed.json")
+	config := []byte(`[[mcp_servers]]
+name = "stewreads"
+transport = "stdio"
+command = "stewreads-mcp"
+disabled = true
+env = { STEWREADS_CONFIG_PATH = "~/.config/stewreads/config.toml" }
+`)
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+	if err := syncshared.SaveManagedState(statePath, map[string][]string{
+		"stewreads": {syncshared.SourceStandalone},
+	}); err != nil {
+		t.Fatalf("write managed state: %v", err)
+	}
+
+	result, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+		DryRun:     true,
+	})
+	if err != nil {
+		t.Fatalf("sync dry-run failed: %v", err)
+	}
+	if !reflect.DeepEqual(result.Updated, []string{"stewreads"}) {
+		t.Fatalf("expected owned disabled entry to be reported updated, got: %+v", result)
+	}
+}
+
+func TestSyncApplyFailsClosedOnInvalidTOML(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "vibe-managed.json")
+	invalid := []byte("[broken")
+	if err := os.WriteFile(configPath, invalid, 0o644); err != nil {
+		t.Fatalf("write invalid config fixture: %v", err)
+	}
+
+	_, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err == nil {
+		t.Fatalf("expected sync apply to fail on invalid TOML")
+	}
+	if !strings.Contains(err.Error(), "parse Vibe config TOML") {
+		t.Fatalf("expected parse error, got: %v", err)
+	}
+
+	after, readErr := os.ReadFile(configPath)
+	if readErr != nil {
+		t.Fatalf("read config after failed sync: %v", readErr)
+	}
+	if string(after) != string(invalid) {
+		t.Fatalf("expected fail-closed behavior with unchanged config")
+	}
+	if _, statErr := os.Stat(statePath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected no state file write on failure, got err=%v", statErr)
+	}
+	backups, globErr := filepath.Glob(configPath + ".bak.*")
+	if globErr != nil {
+		t.Fatalf("glob backup files: %v", globErr)
+	}
+	if len(backups) != 0 {
+		t.Fatalf("expected no backup files on parse failure, got: %#v", backups)
+	}
+}
+
+func TestSyncApplyFailsClosedOnMalformedArgs(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "vibe-managed.json")
+	invalid := []byte(`[[mcp_servers]]
+name = "stewreads"
+transport = "stdio"
+command = "stewreads-mcp"
+args = [1]
+`)
+	if err := os.WriteFile(configPath, invalid, 0o644); err != nil {
+		t.Fatalf("write invalid config fixture: %v", err)
+	}
+
+	_, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err == nil {
+		t.Fatalf("expected sync apply to fail on malformed args")
+	}
+	if !strings.Contains(err.Error(), "mcp_servers[0].args") {
+		t.Fatalf("expected args parse error, got: %v", err)
+	}
+	if _, statErr := os.Stat(statePath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected no state file write on failure, got err=%v", statErr)
+	}
+	backups, globErr := filepath.Glob(configPath + ".bak.*")
+	if globErr != nil {
+		t.Fatalf("glob backup files: %v", globErr)
+	}
+	if len(backups) != 0 {
+		t.Fatalf("expected no backup files on parse failure, got: %#v", backups)
+	}
+}
+
+func TestSyncApplyCreatesBackup(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "vibe-managed.json")
+	original := []byte(`[[mcp_servers]]
+name = "weather"
+transport = "http"
+url = "http://localhost:8000"
+`)
+	if err := os.WriteFile(configPath, original, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	if _, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	}); err != nil {
+		t.Fatalf("sync apply failed: %v", err)
+	}
+
+	backups, err := filepath.Glob(configPath + ".bak.*")
+	if err != nil {
+		t.Fatalf("glob backup files: %v", err)
+	}
+	if len(backups) == 0 {
+		t.Fatalf("expected backup file to be created")
+	}
+	backupPayload, err := os.ReadFile(backups[0])
+	if err != nil {
+		t.Fatalf("read backup file: %v", err)
+	}
+	if string(backupPayload) != string(original) {
+		t.Fatalf("expected backup content to match original config")
+	}
+}
+
+func TestSyncPreservesPrivateConfigAndBackupModes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix mode bits are used in this test")
+	}
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "vibe-managed.json")
+	original := []byte(`[[mcp_servers]]
+name = "weather"
+transport = "http"
+url = "http://localhost:8000"
+`)
+	if err := os.WriteFile(configPath, original, 0o600); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	if _, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	}); err != nil {
+		t.Fatalf("sync apply failed: %v", err)
+	}
+
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("stat config: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("expected rewritten config mode 0600, got %04o", got)
+	}
+
+	backups, err := filepath.Glob(configPath + ".bak.*")
+	if err != nil {
+		t.Fatalf("glob backup files: %v", err)
+	}
+	if len(backups) == 0 {
+		t.Fatalf("expected backup file to be created")
+	}
+	backupInfo, err := os.Stat(backups[0])
+	if err != nil {
+		t.Fatalf("stat backup: %v", err)
+	}
+	if got := backupInfo.Mode().Perm(); got != 0o600 {
+		t.Fatalf("expected backup mode 0600, got %04o", got)
+	}
+}
+
+func TestSyncCreatesNewConfigPrivate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix mode bits are used in this test")
+	}
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "vibe-managed.json")
+
+	if _, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	}); err != nil {
+		t.Fatalf("sync apply failed: %v", err)
+	}
+
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("stat config: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("expected new config mode 0600, got %04o", got)
+	}
+}
+
+func TestSyncDefaultPathHonorsVibeHome(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("VIBE_HOME", tmp)
+	t.Setenv("MADARI_CONFIG_DIR", filepath.Join(tmp, "madari"))
+
+	result, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{})
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	expectedPath := filepath.Join(tmp, "config.toml")
+	if result.ConfigPath != expectedPath {
+		t.Fatalf("expected default config path %q, got %q", expectedPath, result.ConfigPath)
+	}
+	if _, err := os.Stat(expectedPath); err != nil {
+		t.Fatalf("expected config at default VIBE_HOME path: %v", err)
+	}
+}
+
+func TestAttachDetachOverlappingRingsAtConfigLevel(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "vibe-managed.json")
+	opts := SyncOptions{ConfigPath: configPath, StatePath: statePath}
+
+	shared := newStewreadsManifest()
+	only2 := newStewreadsManifest()
+	only2.Name = "arxiv"
+	manifests := []registry.Manifest{shared, only2}
+
+	r1 := registry.Ring{Name: "r1", Members: []string{"stewreads"}}
+	r2 := registry.Ring{Name: "r2", Members: []string{"stewreads", "arxiv"}}
+
+	if _, err := AttachRing(r1, manifests, opts); err != nil {
+		t.Fatalf("attach r1: %v", err)
+	}
+	result, err := AttachRing(r2, manifests, opts)
+	if err != nil {
+		t.Fatalf("attach r2: %v", err)
+	}
+	if len(result.Added) != 1 || result.Added[0] != "arxiv" {
+		t.Fatalf("expected arxiv added on r2 attach, got: %+v", result)
+	}
+
+	state, err := syncshared.LoadManagedState(statePath)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	expected := map[string][]string{
+		"stewreads": {"ring:r1", "ring:r2"},
+		"arxiv":     {"ring:r2"},
+	}
+	if !reflect.DeepEqual(state, expected) {
+		t.Fatalf("expected overlapping refcounts, got: %#v", state)
+	}
+
+	result, err = DetachRing("r1", opts)
+	if err != nil {
+		t.Fatalf("detach r1: %v", err)
+	}
+	if len(result.Removed) != 0 {
+		t.Fatalf("expected no removals while r2 owns shared member, got: %+v", result)
+	}
+
+	result, err = DetachRing("r2", opts)
+	if err != nil {
+		t.Fatalf("detach r2: %v", err)
+	}
+	if !reflect.DeepEqual(result.Removed, []string{"arxiv", "stewreads"}) {
+		t.Fatalf("expected both members removed, got: %+v", result)
+	}
+	servers := readServers(t, configPath)
+	if len(servers) != 0 {
+		t.Fatalf("expected clean config, got: %#v", servers)
+	}
+}
+
+func TestAttachRingConflictsOnEqualUnmanagedEntry(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "vibe-managed.json")
+	config := []byte(`[[mcp_servers]]
+name = "stewreads"
+transport = "stdio"
+command = "stewreads-mcp"
+env = { STEWREADS_CONFIG_PATH = "~/.config/stewreads/config.toml" }
+`)
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	_, err := AttachRing(
+		registry.Ring{Name: "r1", Members: []string{"stewreads"}},
+		[]registry.Manifest{newStewreadsManifest()},
+		SyncOptions{ConfigPath: configPath, StatePath: statePath},
+	)
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected ErrConflict for equal-value unmanaged collision, got: %v", err)
+	}
+	if _, statErr := os.Stat(statePath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected no state write after conflict, got: %v", statErr)
+	}
+}
+
+func newStewreadsManifest() registry.Manifest {
+	return registry.Manifest{
+		Name:    "stewreads",
+		Command: "stewreads-mcp",
+		Enabled: true,
+		Clients: []string{Target},
+		Env: map[string]string{
+			"STEWREADS_CONFIG_PATH": "~/.config/stewreads/config.toml",
+		},
+	}
+}
+
+func readRoot(t *testing.T, path string) map[string]any {
+	t.Helper()
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	root := map[string]any{}
+	if err := toml.Unmarshal(payload, &root); err != nil {
+		t.Fatalf("parse config root: %v", err)
+	}
+	return root
+}
+
+func readServers(t *testing.T, path string) map[string]serverConfig {
+	t.Helper()
+	_, _, servers, _, _, err := loadVibeConfig(path)
+	if err != nil {
+		t.Fatalf("load Vibe config: %v", err)
+	}
+	return servers
+}
+
+func readManagedNames(t *testing.T, path string) []string {
+	t.Helper()
+	state, err := syncshared.LoadManagedState(path)
+	if err != nil {
+		t.Fatalf("load managed state: %v", err)
+	}
+	names := syncshared.MapKeys(state)
+	sort.Strings(names)
+	return names
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -439,6 +439,8 @@ func inspectClientConfig(target, path string) ClientConfigReport {
 	switch target {
 	case "codex":
 		return inspectCodexTOMLClientConfig(payload, report)
+	case "vibe":
+		return inspectVibeTOMLClientConfig(payload, report)
 	case "":
 		if filepath.Ext(path) == ".toml" {
 			return inspectCodexTOMLClientConfig(payload, report)
@@ -482,6 +484,46 @@ func inspectCodexTOMLClientConfig(payload []byte, report ClientConfigReport) Cli
 			report.Status = StatusError
 			report.Message = "invalid mcp_servers value: expected table"
 			return report
+		}
+	}
+
+	report.Status = StatusReady
+	report.Message = "ok"
+	return report
+}
+
+func inspectVibeTOMLClientConfig(payload []byte, report ClientConfigReport) ClientConfigReport {
+	root := map[string]any{}
+	if err := toml.Unmarshal(payload, &root); err != nil {
+		report.Status = StatusError
+		report.Message = fmt.Sprintf("invalid TOML: %v", err)
+		return report
+	}
+
+	if raw, exists := root["mcp_servers"]; exists {
+		servers, ok := raw.([]any)
+		if !ok {
+			report.Status = StatusError
+			report.Message = "invalid mcp_servers value: expected array"
+			return report
+		}
+		for i, rawServer := range servers {
+			server, ok := rawServer.(map[string]any)
+			if !ok {
+				report.Status = StatusError
+				report.Message = fmt.Sprintf("invalid mcp_servers[%d] value: expected table", i)
+				return report
+			}
+			if name, ok := server["name"].(string); !ok || strings.TrimSpace(name) == "" {
+				report.Status = StatusError
+				report.Message = fmt.Sprintf("invalid mcp_servers[%d].name value: expected non-empty string", i)
+				return report
+			}
+			if transport, ok := server["transport"].(string); !ok || strings.TrimSpace(transport) == "" {
+				report.Status = StatusError
+				report.Message = fmt.Sprintf("invalid mcp_servers[%d].transport value: expected non-empty string", i)
+				return report
+			}
 		}
 	}
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -519,10 +519,18 @@ func inspectVibeTOMLClientConfig(payload []byte, report ClientConfigReport) Clie
 				report.Message = fmt.Sprintf("invalid mcp_servers[%d].name value: expected non-empty string", i)
 				return report
 			}
-			if transport, ok := server["transport"].(string); !ok || strings.TrimSpace(transport) == "" {
+			transport, ok := server["transport"].(string)
+			if !ok || strings.TrimSpace(transport) == "" {
 				report.Status = StatusError
 				report.Message = fmt.Sprintf("invalid mcp_servers[%d].transport value: expected non-empty string", i)
 				return report
+			}
+			if strings.TrimSpace(transport) == "stdio" {
+				if err := validateVibeStdioCommand(server["command"]); err != nil {
+					report.Status = StatusError
+					report.Message = fmt.Sprintf("invalid mcp_servers[%d].command value: %v", i, err)
+					return report
+				}
 			}
 		}
 	}
@@ -530,6 +538,30 @@ func inspectVibeTOMLClientConfig(payload []byte, report ClientConfigReport) Clie
 	report.Status = StatusReady
 	report.Message = "ok"
 	return report
+}
+
+func validateVibeStdioCommand(raw any) error {
+	command, ok := raw.(string)
+	if ok {
+		if strings.TrimSpace(command) == "" {
+			return fmt.Errorf("expected non-empty string")
+		}
+		return nil
+	}
+
+	values, ok := raw.([]any)
+	if !ok {
+		return fmt.Errorf("expected string or array of strings")
+	}
+	if len(values) == 0 {
+		return fmt.Errorf("expected non-empty array")
+	}
+	for _, value := range values {
+		if _, ok := value.(string); !ok {
+			return fmt.Errorf("expected string or array of strings")
+		}
+	}
+	return nil
 }
 
 func loadManifests(serversDir string) ([]registry.Manifest, []ManifestError, error) {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -393,6 +393,57 @@ func TestRunInspectsTOMLClientConfig(t *testing.T) {
 	}
 }
 
+func TestRunInspectsVibeTOMLClientConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix fixture mode bits are used in this test")
+	}
+	tmp := t.TempDir()
+	store := registry.NewStore(filepath.Join(tmp, "servers"))
+
+	commandPath := writeTestExecutable(t, tmp, "vibe-mcp")
+	if err := store.Save(registry.Manifest{
+		Name:    "vibe-server",
+		Command: commandPath,
+		Enabled: true,
+		Clients: []string{"vibe"},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+
+	configPath := filepath.Join(tmp, "vibe-config")
+	if err := os.WriteFile(configPath, []byte("[[mcp_servers]]\nname = \"weather\"\ntransport = \"http\"\nurl = \"http://localhost:8000\"\n"), 0o644); err != nil {
+		t.Fatalf("write toml config: %v", err)
+	}
+
+	adapter := testAdapter{target: "vibe", configPath: configPath}
+	report, err := Run(store, Options{Adapters: []clients.ClientAdapter{adapter}})
+	if err != nil {
+		t.Fatalf("doctor run failed: %v", err)
+	}
+	cc, ok := findClientConfig(report, "vibe")
+	if !ok {
+		t.Fatalf("expected vibe client config report, got: %+v", report.ClientConfigs)
+	}
+	if cc.Status != StatusReady {
+		t.Fatalf("expected ready Vibe TOML config status, got: %+v", cc)
+	}
+
+	if err := os.WriteFile(configPath, []byte("[mcp_servers]\n"), 0o644); err != nil {
+		t.Fatalf("write table toml config: %v", err)
+	}
+	report, err = Run(store, Options{Adapters: []clients.ClientAdapter{adapter}})
+	if err != nil {
+		t.Fatalf("doctor run failed: %v", err)
+	}
+	cc, ok = findClientConfig(report, "vibe")
+	if !ok {
+		t.Fatalf("expected vibe client config report, got: %+v", report.ClientConfigs)
+	}
+	if cc.Status != StatusError || !strings.Contains(cc.Message, "expected array") {
+		t.Fatalf("expected Vibe to reject table mcp_servers, got: %+v", cc)
+	}
+}
+
 func TestRunSelectsConfigParserByClientTarget(t *testing.T) {
 	tmp := t.TempDir()
 	store := registry.NewStore(filepath.Join(tmp, "servers"))

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -442,6 +442,46 @@ func TestRunInspectsVibeTOMLClientConfig(t *testing.T) {
 	if cc.Status != StatusError || !strings.Contains(cc.Message, "expected array") {
 		t.Fatalf("expected Vibe to reject table mcp_servers, got: %+v", cc)
 	}
+
+	invalidCommands := []struct {
+		name    string
+		payload string
+		want    string
+	}{
+		{
+			name:    "missing stdio command",
+			payload: "[[mcp_servers]]\nname = \"broken\"\ntransport = \"stdio\"\n",
+			want:    "command",
+		},
+		{
+			name:    "non-string stdio command",
+			payload: "[[mcp_servers]]\nname = \"broken\"\ntransport = \"stdio\"\ncommand = 1\n",
+			want:    "expected string or array of strings",
+		},
+		{
+			name:    "empty string stdio command",
+			payload: "[[mcp_servers]]\nname = \"broken\"\ntransport = \"stdio\"\ncommand = \"\"\n",
+			want:    "expected non-empty string",
+		},
+	}
+	for _, tc := range invalidCommands {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := os.WriteFile(configPath, []byte(tc.payload), 0o644); err != nil {
+				t.Fatalf("write invalid command toml config: %v", err)
+			}
+			report, err = Run(store, Options{Adapters: []clients.ClientAdapter{adapter}})
+			if err != nil {
+				t.Fatalf("doctor run failed: %v", err)
+			}
+			cc, ok = findClientConfig(report, "vibe")
+			if !ok {
+				t.Fatalf("expected vibe client config report, got: %+v", report.ClientConfigs)
+			}
+			if cc.Status != StatusError || !strings.Contains(cc.Message, tc.want) {
+				t.Fatalf("expected Vibe to reject %s, got: %+v", tc.name, cc)
+			}
+		})
+	}
 }
 
 func TestRunSelectsConfigParserByClientTarget(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add a first-class `vibe` sync adapter that writes Vibe TOML MCP config under `$VIBE_HOME/config.toml` or `~/.vibe/config.toml`.
- Preserve unmanaged `[[mcp_servers]]` entries, including HTTP/streamable/manual stdio entries, while retaining Madari managed-state ownership, backups, atomic writes, and ring attach/detach semantics.
- Wire `vibe` into sync-capable clients, doctor/status config inspection, CLI tests, and documentation while keeping render targets separate.

## Vibe config verification

Verified against local Vibe CLI before implementing the adapter:

```sh
vibe --version
```

Observed local Vibe CLI `2.15.0`. Installed Vibe metadata and config models document user config at `$VIBE_HOME/config.toml` or `~/.vibe/config.toml` and MCP entries as TOML arrays:

```toml
[[mcp_servers]]
name = "fetch_server"
transport = "stdio"
command = "uvx"
args = ["mcp-server-fetch"]
env = { "DEBUG" = "1", "LOG_LEVEL" = "info" }
```

The installed `VibeConfig` schema models `mcp_servers` as a list keyed by `name`; stdio entries require `transport = "stdio"`, `command`, optional `args`, and optional `env`. It also supports `disabled` and `disabled_tools`, which this adapter treats as behavior-affecting drift for Madari-owned or desired entries.

## Validation

```sh
go test ./internal/clients/vibe
go test ./cmd/madari
go test ./internal/doctor
go test ./internal/clients/syncshared
go test ./...
make build
```

Native smoke with isolated Madari and Vibe homes:

```sh
vibe --version
TMPDIR_SMOKE=$(mktemp -d)
export MADARI_CONFIG_DIR="$TMPDIR_SMOKE/madari"
export VIBE_HOME="$TMPDIR_SMOKE/vibe"
mkdir -p "$MADARI_CONFIG_DIR" "$VIBE_HOME"
bin/madari add echo-vibe --command /bin/echo --client vibe --arg ring-smoke --env VIBE_SMOKE_MODE=1
bin/madari ring create vibe-ring --member echo-vibe --description "Vibe ring attach smoke"
bin/madari ring attach vibe-ring vibe
bin/madari ring status
stat -f '%Lp %N' "$VIBE_HOME/config.toml"
sed -n '1,140p' "$VIBE_HOME/config.toml"
MISTRAL_API_KEY=dummy /Users/ankitgupta/.local/share/uv/tools/mistral-vibe/bin/python - <<'PY'
from vibe.core.config.harness_files._harness_manager import init_harness_files_manager
from vibe.core.config._settings import VibeConfig
init_harness_files_manager("user")
cfg = VibeConfig()
for server in cfg.mcp_servers:
    print({
        "name": server.name,
        "transport": server.transport,
        "command": getattr(server, "command", None),
        "args": getattr(server, "args", None),
        "env": getattr(server, "env", None),
        "disabled": server.disabled,
    })
PY
```

Smoke result summary:

- `vibe 2.15.0`
- `ring attach` wrote `$VIBE_HOME/config.toml` for `echo-vibe`.
- `ring status` showed `vibe-ring [ok] members=1 owned=1` with `echo-vibe: ring:vibe-ring`.
- Generated config mode was `600`.
- Generated TOML contained `[[mcp_servers]]`, `name = 'echo-vibe'`, `transport = 'stdio'`, `command = '/bin/echo'`, `args = ['ring-smoke']`, and env `VIBE_SMOKE_MODE = '1'`.
- Vibe's installed `VibeConfig` parser loaded the server as stdio with the same command, args, env, and `disabled=False`.