### PR TITLE
[codex] Prepare client target registry for skills

### DIFF
--- a/cmd/madari/client_targets.go
+++ b/cmd/madari/client_targets.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"io"
+	"sort"
+
+	"github.com/ankitvg/madari/internal/clients"
+	claudedesktop "github.com/ankitvg/madari/internal/clients/claude-desktop"
+	"github.com/ankitvg/madari/internal/clients/claudecode"
+	"github.com/ankitvg/madari/internal/clients/codex"
+	"github.com/ankitvg/madari/internal/clients/gemini"
+	"github.com/ankitvg/madari/internal/clients/vibe"
+)
+
+// clientTarget records the command-layer capabilities Madari knows for one
+// AI client. Sync, render, and future skill support should extend this table
+// instead of scattering target-specific switches.
+type clientTarget struct {
+	target             string
+	syncAdapter        clients.ClientAdapter
+	ringConfigRenderer func(io.Writer, map[string]renderedServer) error
+	userScope          bool
+}
+
+var clientTargets = []clientTarget{
+	{
+		target:             claudedesktop.Target,
+		syncAdapter:        claudedesktop.Adapter{},
+		ringConfigRenderer: renderMCPServersJSON,
+	},
+	{
+		target:             claudecode.Target,
+		syncAdapter:        claudecode.Adapter{},
+		ringConfigRenderer: renderMCPServersJSON,
+		userScope:          true,
+	},
+	{
+		target:             codex.Target,
+		syncAdapter:        codex.Adapter{},
+		ringConfigRenderer: renderCodexTOML,
+	},
+	{
+		target:             gemini.Target,
+		syncAdapter:        gemini.Adapter{},
+		ringConfigRenderer: renderMCPServersJSON,
+		userScope:          true,
+	},
+	{
+		target:             vibe.Target,
+		syncAdapter:        vibe.Adapter{},
+		ringConfigRenderer: renderVibeTOML,
+	},
+}
+
+func defaultInstallClientTarget() string {
+	return claudedesktop.Target
+}
+
+func clientTargetByName(target string) (clientTarget, bool) {
+	for _, ct := range clientTargets {
+		if ct.target == target {
+			return ct, true
+		}
+	}
+	return clientTarget{}, false
+}
+
+func syncAdaptersFromClientTargets() map[string]clients.ClientAdapter {
+	adapters := map[string]clients.ClientAdapter{}
+	for _, ct := range clientTargets {
+		if ct.syncAdapter != nil {
+			adapters[ct.target] = ct.syncAdapter
+		}
+	}
+	return adapters
+}
+
+func ringRenderTargetsFromClientTargets() map[string]ringRenderTarget {
+	targets := map[string]ringRenderTarget{}
+	for _, ct := range clientTargets {
+		if ct.ringConfigRenderer != nil {
+			targets[ct.target] = ringRenderTarget{
+				target: ct.target,
+				render: ct.ringConfigRenderer,
+			}
+		}
+	}
+	return targets
+}
+
+func sortedClientTargetNames() []string {
+	names := make([]string, 0, len(clientTargets))
+	for _, ct := range clientTargets {
+		names = append(names, ct.target)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/cmd/madari/render_targets.go
+++ b/cmd/madari/render_targets.go
@@ -5,9 +5,6 @@ import (
 	"io"
 	"sort"
 	"strings"
-
-	claudedesktop "github.com/ankitvg/madari/internal/clients/claude-desktop"
-	"github.com/ankitvg/madari/internal/clients/claudecode"
 )
 
 // renderedServer is the self-contained client config entry ring render emits.
@@ -23,13 +20,7 @@ type ringRenderTarget struct {
 	render func(io.Writer, map[string]renderedServer) error
 }
 
-var ringRenderTargets = map[string]ringRenderTarget{
-	claudedesktop.Target: {target: claudedesktop.Target, render: renderMCPServersJSON},
-	claudecode.Target:    {target: claudecode.Target, render: renderMCPServersJSON},
-	"codex":              {target: "codex", render: renderCodexTOML},
-	"gemini":             {target: "gemini", render: renderMCPServersJSON},
-	"vibe":               {target: "vibe", render: renderVibeTOML},
-}
+var ringRenderTargets = ringRenderTargetsFromClientTargets()
 
 func supportedRingRenderTargets() []string {
 	targets := make([]string, 0, len(ringRenderTargets))

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -12,25 +12,14 @@ import (
 	"strings"
 
 	"github.com/ankitvg/madari/internal/clients"
-	claudedesktop "github.com/ankitvg/madari/internal/clients/claude-desktop"
-	"github.com/ankitvg/madari/internal/clients/claudecode"
-	"github.com/ankitvg/madari/internal/clients/codex"
-	"github.com/ankitvg/madari/internal/clients/gemini"
 	"github.com/ankitvg/madari/internal/clients/syncshared"
-	"github.com/ankitvg/madari/internal/clients/vibe"
 	"github.com/ankitvg/madari/internal/doctor"
 	"github.com/ankitvg/madari/internal/registry"
 )
 
 var version = "0.0.0-dev"
 
-var syncAdapters = map[string]clients.ClientAdapter{
-	claudedesktop.Target: claudedesktop.Adapter{},
-	claudecode.Target:    claudecode.Adapter{},
-	codex.Target:         codex.Adapter{},
-	gemini.Target:        gemini.Adapter{},
-	vibe.Target:          vibe.Adapter{},
-}
+var syncAdapters = syncAdaptersFromClientTargets()
 
 func supportedSyncTargets() []string {
 	targets := make([]string, 0, len(syncAdapters))
@@ -246,7 +235,7 @@ func (a cliApp) cmdInstall(args []string) error {
 	}
 
 	if len(clients) == 0 {
-		clients = append(clients, claudedesktop.Target)
+		clients = append(clients, defaultInstallClientTarget())
 	}
 
 	if !skipInstall {
@@ -1278,12 +1267,8 @@ func userScopedSyncTargets() []string {
 }
 
 func targetSupportsUserScope(target string) bool {
-	switch target {
-	case claudecode.Target, gemini.Target:
-		return true
-	default:
-		return false
-	}
+	ct, ok := clientTargetByName(target)
+	return ok && ct.userScope
 }
 
 func parseClientConfigOverrides(pairs []string) (map[string]string, error) {

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -1263,6 +1263,25 @@ func TestRunWithStoreClientsListsAllAdapters(t *testing.T) {
 	}
 }
 
+func TestClientTargetRegistryDefinesCurrentCapabilities(t *testing.T) {
+	wantTargets := []string{"claude-code", "claude-desktop", "codex", "gemini", "vibe"}
+	if got := sortedClientTargetNames(); !reflect.DeepEqual(got, wantTargets) {
+		t.Fatalf("unexpected client targets: got %#v want %#v", got, wantTargets)
+	}
+	if got := supportedSyncTargets(); !reflect.DeepEqual(got, wantTargets) {
+		t.Fatalf("unexpected sync targets: got %#v want %#v", got, wantTargets)
+	}
+	if got := supportedRingRenderTargets(); !reflect.DeepEqual(got, wantTargets) {
+		t.Fatalf("unexpected ring render targets: got %#v want %#v", got, wantTargets)
+	}
+	if got := userScopedSyncTargets(); !reflect.DeepEqual(got, []string{"claude-code", "gemini"}) {
+		t.Fatalf("unexpected user-scoped targets: got %#v", got)
+	}
+	if got := defaultInstallClientTarget(); got != "claude-desktop" {
+		t.Fatalf("unexpected default install client target: %q", got)
+	}
+}
+
 func TestRunWithStoreClientsShowsHeaderAndStatus(t *testing.T) {
 	store := newTestStore(t)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,6 +6,27 @@
 - Materialize valid client config files without clobbering user-managed entries.
 - Provide deterministic lifecycle operations and diagnostics.
 
+## Primitive Boundary
+
+Madari keeps four concepts separate:
+
+- Server: an executable MCP capability with command, args, env, and target
+  client metadata.
+- Ring: a named capability grouping. Today persisted rings contain server
+  members only; the grouping surface is intentionally the place where future
+  capability types such as skills can compose with MCP servers.
+- Skill: procedural or domain instructions for how an agent should use
+  capabilities. Skills are not implemented yet, and should get their own
+  registry/render surface rather than being hidden inside server sync.
+- Run: ephemeral execution that combines a task, selected capabilities, client
+  target, optional skills/context, and result capture. Run is not implemented
+  yet and should not be modeled as persistent client sync.
+
+Current behavior follows this boundary: `sync` and `ring attach` persist MCP
+server config, while `ring render` emits MCP config only. Future skill work
+should add an explicit skill render path before combining rings and skills in
+execution flows.
+
 ## Components
 
 1. Registry
@@ -16,7 +37,11 @@
   export refuses rings that would not round-trip, import validates everything
   before writing anything and never attaches or syncs.
 
-2. Client Adapters
+2. Client Targets and Adapters
+- The command layer keeps a single client target registry for target-level
+  capabilities: sync adapter, ring config renderer, and scope support.
+  Future skill render support should extend that registry instead of adding
+  another target-specific switch.
 - Translate registry entries into client-specific config.
 - Current adapters: Claude Desktop, Claude Code, Gemini, Codex, and Vibe.
 - Adapters own read/merge/write behavior for their client format.
@@ -48,9 +73,10 @@
   released only by detach or membership reconciliation.
 
 5. Rings
-- Named capability sets of servers (`rings/<name>.toml`); members reference
-  registry entries by name only — the server manifest stays the single
-  source of truth for command, args, and env.
+- Named capability sets (`rings/<name>.toml`). In the current schema, members
+  are server references by name only — the server manifest stays the single
+  source of truth for command, args, and env. Future skill support should grow
+  the capability model deliberately rather than overloading server manifests.
 - Attachment is derived state: ring `R` is attached to a target+scope iff
   `ring:R` appears among ownership sources there. Attach records the source
   on every member and materializes the eligible ones; detach releases it by

--- a/docs/manifest-spec.md
+++ b/docs/manifest-spec.md
@@ -71,8 +71,9 @@ keys = ["STEWREADS_GMAIL_APP_PASSWORD"]
 
 ## Ring Files
 
-Rings are named capability sets of servers, stored one TOML document per
-ring at `<config-root>/rings/<name>.toml` (sibling of `servers/`).
+Rings are named capability sets. The current schema supports server members
+only and stores one TOML document per ring at
+`<config-root>/rings/<name>.toml` (sibling of `servers/`).
 
 - `name` (string, required): stable ring ID; same pattern as server names.
 - `members` (array of strings, required, non-empty, unique): server names.
@@ -83,7 +84,9 @@ ring at `<config-root>/rings/<name>.toml` (sibling of `servers/`).
 - `description` (string, optional): friendly description.
 
 Ring manifests have no sections; unknown keys are rejected. Files are
-written deterministically with sorted members.
+written deterministically with sorted members. Future capability types such as
+skills should extend this schema explicitly instead of embedding procedural
+instructions in server manifests.
 
 ### Example
 


### PR DESCRIPTION
## What changed

- Centralized command-layer client target capabilities in `cmd/madari/client_targets.go`.
- Derived sync adapters, ring render targets, user-scope support, and the default install target from that registry.
- Documented the server/ring/skill/run primitive boundary in `docs/architecture.md`.
- Clarified that today's ring manifest schema supports server members only, leaving future skill support as an explicit schema extension.

## Why

This pays down target-capability drift before adding skills as a first-class primitive. Future `skill render` support should extend one client target registry instead of adding another scattered target switch or overloading `ring render` / `sync`.

## Validation

- `go test ./cmd/madari`
- `go test ./...`
- `make build`
- `git diff --check HEAD~1..HEAD`
