### PR TITLE
[codex] Add skill primitive v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ go install github.com/ankitvg/madari/cmd/madari@latest
 - `madari ring delete <name>`
 - `madari ring render <name> --client <target>`
 - `madari ring status [--json]`
+- `madari skill add <name> --file <path> [--description <text>]`
+- `madari skill update <name> --file <path> [--description <text>]`
+- `madari skill remove <name>`
+- `madari skill list [--json]`
+- `madari skill show <name> [--json]`
+- `madari skill render <name>`
 - `madari clients`
 - `madari doctor [--client-config target=path ...] [--json]`
 - `madari status [--client-config target=path ...] [--json]`
@@ -51,11 +57,12 @@ Notes:
 - `sync` skips servers with missing/non-executable command paths and continues syncing others.
 - Manifests can mark secret env keys (`[secret_env]`, or `--secret-env` on `add`/`install`); sync refuses to write their static values into repo-scoped configs such as Claude Code `.mcp.json` and Gemini `.gemini/settings.json` — refused entries are reported with guidance (and scrubbed if previously materialized) while other servers sync normally. Use `madari sync <client> --scope user` for clients that support user scope.
 - `list` shows the managed sources owning each synced entry (`standalone` today; `-` when not synced), and `status` summarizes managed entries per client.
-- `list`, `status`, `doctor`, `sync --dry-run`, `ring list`, `ring show`, and `ring status` accept `--json` for machine-readable output with a versioned schema; schemas and exit codes are documented in `docs/cli-reference.md`.
+- `list`, `status`, `doctor`, `sync --dry-run`, `ring list`, `ring show`, `ring status`, `skill list`, and `skill show` accept `--json` for machine-readable output with a versioned schema; schemas and exit codes are documented in `docs/cli-reference.md`.
 - Rings are named capability sets of servers (`madari ring …`). Members reference registry entries by name — the server manifest stays the single source of truth for command, args, and env.
 - `ring attach` records reference-counted ownership (`ring:<name>` sources) and materializes eligible members; `ring detach` releases it, and an entry only leaves the client config when nothing owns it anymore. Overlapping rings and standalone+ring combinations resolve by refcount, in any order. Attaching onto an entry madari does not manage is refused — even when values match.
 - `ring delete` removes only unattached ring definitions. It refuses while any client scope still records `ring:<name>` ownership and prints scoped detach guidance; deletion never edits client configs or managed state.
 - `ring render` prints a self-contained MCP config to stdout for ephemeral use — `claude --mcp-config <(madari ring render research --client claude-code)` — mutating nothing; secret env values are never emitted. Render targets are independent from persistent sync support: Claude and Gemini emit JSON, while Codex and Vibe emit TOML. `ring status` shows attached rings and per-server ownership for every client and scope.
+- Skills are standalone Markdown instruction primitives (`madari skill …`). Madari stores skill metadata and a managed Markdown copy, and `skill render` prints that Markdown exactly to stdout. V1 skills are not ring members, are not synced to client configs, and are not consumed by `run`.
 - Codex sync writes static non-secret `[env]` values under `[mcp_servers.<name>.env]` and forwards `[required_env]` plus `[secret_env]` keys through `env_vars`; static secret values are not written into Codex config.
 - Vibe sync writes static `[env]` values into user-scoped `[[mcp_servers]]` entries and preserves unmanaged HTTP/streamable/manual entries.
 - Supported sync clients: `claude-desktop`, `claude-code`, `gemini`, `codex`, and `vibe`.
@@ -67,8 +74,8 @@ Notes:
   - `codex`: `$CODEX_HOME/config.toml` or `~/.codex/config.toml`.
   - `vibe`: `$VIBE_HOME/config.toml` or `~/.vibe/config.toml`.
 - `install --config-path` can only be used when exactly one sync target is selected.
-- `export` writes a versioned JSON snapshot of server and ring manifests for backup/sharing (stdout by default).
-- `import` is dry-run by default and only adds/updates listed servers and rings (`--apply` persists). Existing servers and rings absent from the snapshot are left unchanged; imported rings are not attached or synced.
+- `export` writes a versioned JSON snapshot of server, ring, and skill manifests for backup/sharing (stdout by default).
+- `import` is dry-run by default and only adds/updates listed servers, rings, and skills (`--apply` persists). Existing entries absent from the snapshot are left unchanged; imported rings are not attached or synced.
 
 Claude and Gemini config shape:
 
@@ -126,6 +133,8 @@ madari sync claude-code --dry-run
 madari sync gemini --dry-run
 madari sync codex --dry-run
 madari sync vibe --dry-run
+madari skill add release --file ./SKILL.md --description "Release workflow"
+madari skill render release
 madari export --file madari-snapshot.json
 madari import --file madari-snapshot.json
 madari import --file madari-snapshot.json --apply

--- a/cmd/madari/json_output.go
+++ b/cmd/madari/json_output.go
@@ -206,6 +206,32 @@ type ringServerJSON struct {
 	Sources []string `json:"sources"`
 }
 
+type skillListJSON struct {
+	SchemaVersion int         `json:"schema_version"`
+	Command       string      `json:"command"`
+	Skills        []skillJSON `json:"skills"`
+}
+
+type skillShowJSON struct {
+	SchemaVersion int       `json:"schema_version"`
+	Command       string    `json:"command"`
+	Skill         skillJSON `json:"skill"`
+}
+
+type skillJSON struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	ContentPath string `json:"content_path,omitempty"`
+}
+
+func skillToJSON(skill registry.Skill, contentPath string) skillJSON {
+	return skillJSON{
+		Name:        skill.Name,
+		Description: skill.Description,
+		ContentPath: contentPath,
+	}
+}
+
 // writeJSON emits one indented JSON document followed by a newline; --json
 // modes must write nothing else to stdout.
 func writeJSON(out io.Writer, payload any) error {

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -154,6 +154,8 @@ func (a cliApp) dispatch(args []string) error {
 		return a.cmdSync(args[1:])
 	case "ring":
 		return a.cmdRing(args[1:])
+	case "skill":
+		return a.cmdSkill(args[1:])
 	default:
 		return fmt.Errorf("unknown command: %s", args[0])
 	}
@@ -1169,7 +1171,7 @@ func (a cliApp) cmdExport(args []string) error {
 	if err := os.WriteFile(cleanPath, payload, 0o644); err != nil {
 		return fmt.Errorf("write snapshot file %q: %w", cleanPath, err)
 	}
-	fmt.Fprintf(a.stdout, "exported %d server(s), %d ring(s) to %s\n", len(snapshot.Servers), len(snapshot.Rings), cleanPath)
+	fmt.Fprintf(a.stdout, "exported %d server(s), %d ring(s), %d skill(s) to %s\n", len(snapshot.Servers), len(snapshot.Rings), len(snapshot.Skills), cleanPath)
 	return nil
 }
 
@@ -1227,6 +1229,9 @@ func (a cliApp) cmdImport(args []string) error {
 	fmt.Fprintf(a.stdout, "rings added: %s\n", formatNameList(result.RingsAdded))
 	fmt.Fprintf(a.stdout, "rings updated: %s\n", formatNameList(result.RingsUpdated))
 	fmt.Fprintf(a.stdout, "rings unchanged: %s\n", formatNameList(result.RingsUnchanged))
+	fmt.Fprintf(a.stdout, "skills added: %s\n", formatNameList(result.SkillsAdded))
+	fmt.Fprintf(a.stdout, "skills updated: %s\n", formatNameList(result.SkillsUpdated))
+	fmt.Fprintf(a.stdout, "skills unchanged: %s\n", formatNameList(result.SkillsUnchanged))
 	if !result.HasChanges() {
 		fmt.Fprintln(a.stdout, "no changes")
 	}
@@ -1529,6 +1534,8 @@ func printCommandHelp(command string, out io.Writer) bool {
 		printSyncHelp(out)
 	case "ring":
 		printRingHelp(out)
+	case "skill":
+		printSkillHelp(out)
 	case "clients":
 		printClientsHelp(out)
 	case "doctor":
@@ -1723,7 +1730,7 @@ func printExportHelp(out io.Writer) {
 	fmt.Fprintln(out, "  --file <path>              Write snapshot JSON to file (default: stdout)")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Description:")
-	fmt.Fprintln(out, "  Export all server and ring manifests as a versioned JSON snapshot.")
+	fmt.Fprintln(out, "  Export all server, ring, and skill manifests as a versioned JSON snapshot.")
 }
 
 func printImportHelp(out io.Writer) {
@@ -1735,8 +1742,8 @@ func printImportHelp(out io.Writer) {
 	fmt.Fprintln(out, "  --apply                    Apply changes to registry (default: dry-run)")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Description:")
-	fmt.Fprintln(out, "  Import a snapshot into the registry by adding/updating listed servers")
-	fmt.Fprintln(out, "  and rings. Existing servers and rings absent from the snapshot are")
+	fmt.Fprintln(out, "  Import a snapshot into the registry by adding/updating listed servers,")
+	fmt.Fprintln(out, "  rings, and skills. Existing entries absent from the snapshot are")
 	fmt.Fprintln(out, "  left unchanged; importing rings never attaches or syncs them.")
 }
 
@@ -1752,6 +1759,7 @@ func printHelp(out io.Writer) {
 	fmt.Fprintln(out, "  disable   Disable a server")
 	fmt.Fprintln(out, "  sync      Sync server manifests to a client config")
 	fmt.Fprintln(out, "  ring      Manage rings (named capability sets of servers)")
+	fmt.Fprintln(out, "  skill     Manage standalone Markdown skills")
 	fmt.Fprintln(out, "  clients   List sync client config readiness")
 	fmt.Fprintln(out, "  doctor    Run diagnostics on local MCP setup")
 	fmt.Fprintln(out, "  status    Show concise readiness summary")
@@ -1769,6 +1777,8 @@ func printHelp(out io.Writer) {
 	fmt.Fprintln(out, "  madari disable stewreads")
 	fmt.Fprintln(out, "  madari sync claude-desktop --dry-run")
 	fmt.Fprintln(out, "  madari sync claude-code --dry-run")
+	fmt.Fprintln(out, "  madari skill add release --file SKILL.md")
+	fmt.Fprintln(out, "  madari skill render release")
 	fmt.Fprintln(out, "  madari export --file madari-snapshot.json")
 	fmt.Fprintln(out, "  madari import --file madari-snapshot.json")
 	fmt.Fprintln(out, "  madari import --file madari-snapshot.json --apply")

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -60,6 +60,15 @@ func writeTestExecutable(t *testing.T, dir, name string) string {
 	return path
 }
 
+func writeSkillFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write skill file: %v", err)
+	}
+	return path
+}
+
 func TestRunWithStoreLifecycleCommands(t *testing.T) {
 	store := newTestStore(t)
 	commandPath := mustCurrentExecutable(t)
@@ -289,6 +298,204 @@ func TestRunWithStoreAddRejectsUnexpectedPositionals(t *testing.T) {
 	}
 }
 
+func TestRunWithStoreSkillLifecycleCommands(t *testing.T) {
+	store := newTestStore(t)
+	tmp := t.TempDir()
+	content := "# Release\n\nCut a patch release.\n"
+	path := writeSkillFile(t, tmp, "release.md", content)
+
+	result := runCmd(store, "skill", "add", "release", "--file", path, "--description", "Release workflow")
+	if result.code != 0 {
+		t.Fatalf("skill add failed with code %d, stderr=%s", result.code, result.stderr)
+	}
+	if !strings.Contains(result.stdout, "added skill release") {
+		t.Fatalf("expected add output, got: %s", result.stdout)
+	}
+
+	skill, err := store.GetSkill("release")
+	if err != nil {
+		t.Fatalf("expected skill to exist: %v", err)
+	}
+	if skill.Description != "Release workflow" {
+		t.Fatalf("expected description to be saved, got: %q", skill.Description)
+	}
+	storedContent, err := store.GetSkillContent("release")
+	if err != nil {
+		t.Fatalf("expected skill content to exist: %v", err)
+	}
+	if string(storedContent) != content {
+		t.Fatalf("expected managed copy to match source, got: %q", storedContent)
+	}
+
+	result = runCmd(store, "skill", "list")
+	if result.code != 0 {
+		t.Fatalf("skill list failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "release") || !strings.Contains(result.stdout, "Release workflow") {
+		t.Fatalf("expected list output to include skill, got: %s", result.stdout)
+	}
+
+	result = runCmd(store, "skill", "show", "release")
+	if result.code != 0 {
+		t.Fatalf("skill show failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "name: release") || !strings.Contains(result.stdout, "content:") {
+		t.Fatalf("expected show output, got: %s", result.stdout)
+	}
+
+	result = runCmd(store, "skill", "render", "release")
+	if result.code != 0 {
+		t.Fatalf("skill render failed: %s", result.stderr)
+	}
+	if result.stdout != content {
+		t.Fatalf("expected exact render content %q, got %q", content, result.stdout)
+	}
+
+	updatedContent := "# Release\n\nUpdated steps.\n"
+	updatedPath := writeSkillFile(t, tmp, "release-updated.md", updatedContent)
+	result = runCmd(store, "skill", "update", "release", "--file", updatedPath)
+	if result.code != 0 {
+		t.Fatalf("skill update failed: %s", result.stderr)
+	}
+	skill, err = store.GetSkill("release")
+	if err != nil {
+		t.Fatalf("load updated skill: %v", err)
+	}
+	if skill.Description != "Release workflow" {
+		t.Fatalf("expected update without --description to preserve description, got: %q", skill.Description)
+	}
+	result = runCmd(store, "skill", "update", "release", "--file", updatedPath, "--description", "Updated workflow")
+	if result.code != 0 {
+		t.Fatalf("skill update with description failed: %s", result.stderr)
+	}
+	skill, err = store.GetSkill("release")
+	if err != nil {
+		t.Fatalf("load updated skill metadata: %v", err)
+	}
+	if skill.Description != "Updated workflow" {
+		t.Fatalf("expected description update, got: %q", skill.Description)
+	}
+	result = runCmd(store, "skill", "render", "release")
+	if result.code != 0 {
+		t.Fatalf("skill render after update failed: %s", result.stderr)
+	}
+	if result.stdout != updatedContent {
+		t.Fatalf("expected updated render content %q, got %q", updatedContent, result.stdout)
+	}
+
+	result = runCmd(store, "skill", "remove", "release")
+	if result.code != 0 {
+		t.Fatalf("skill remove failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "removed skill release") {
+		t.Fatalf("expected remove output, got: %s", result.stdout)
+	}
+	if _, err := store.GetSkill("release"); !errors.Is(err, registry.ErrSkillNotFound) {
+		t.Fatalf("expected skill removal, got: %v", err)
+	}
+}
+
+func TestRunWithStoreSkillJSONOutputs(t *testing.T) {
+	store := newTestStore(t)
+	path := writeSkillFile(t, t.TempDir(), "release.md", "# Release\n")
+
+	if result := runCmd(store, "skill", "add", "release", "--file", path, "--description", "Release workflow"); result.code != 0 {
+		t.Fatalf("skill add failed: %s", result.stderr)
+	}
+
+	listResult := runCmd(store, "skill", "list", "--json")
+	if listResult.code != 0 {
+		t.Fatalf("skill list --json failed: %s", listResult.stderr)
+	}
+	var listPayload skillListJSON
+	if err := json.Unmarshal([]byte(listResult.stdout), &listPayload); err != nil {
+		t.Fatalf("parse skill list json: %v\n%s", err, listResult.stdout)
+	}
+	if listPayload.SchemaVersion != jsonSchemaVersion || listPayload.Command != "skill list" {
+		t.Fatalf("unexpected list json envelope: %+v", listPayload)
+	}
+	if len(listPayload.Skills) != 1 || listPayload.Skills[0].Name != "release" || listPayload.Skills[0].ContentPath != "" {
+		t.Fatalf("unexpected skill list json: %+v", listPayload.Skills)
+	}
+
+	showResult := runCmd(store, "skill", "show", "release", "--json")
+	if showResult.code != 0 {
+		t.Fatalf("skill show --json failed: %s", showResult.stderr)
+	}
+	var showPayload skillShowJSON
+	if err := json.Unmarshal([]byte(showResult.stdout), &showPayload); err != nil {
+		t.Fatalf("parse skill show json: %v\n%s", err, showResult.stdout)
+	}
+	if showPayload.SchemaVersion != jsonSchemaVersion || showPayload.Command != "skill show" {
+		t.Fatalf("unexpected show json envelope: %+v", showPayload)
+	}
+	if showPayload.Skill.Name != "release" ||
+		showPayload.Skill.Description != "Release workflow" ||
+		!strings.HasSuffix(showPayload.Skill.ContentPath, filepath.Join("skills", "release.md")) {
+		t.Fatalf("unexpected skill show json: %+v", showPayload.Skill)
+	}
+}
+
+func TestRunWithStoreSkillValidatesInputs(t *testing.T) {
+	store := newTestStore(t)
+	tmp := t.TempDir()
+	path := writeSkillFile(t, tmp, "release.md", "# Release\n")
+	emptyPath := writeSkillFile(t, tmp, "empty.md", "  \n")
+
+	if result := runCmd(store, "skill", "add", "release", "--file", path); result.code != 0 {
+		t.Fatalf("setup skill add failed: %s", result.stderr)
+	}
+
+	tests := []struct {
+		name     string
+		args     []string
+		expected string
+	}{
+		{
+			name:     "duplicate add",
+			args:     []string{"skill", "add", "release", "--file", path},
+			expected: "already exists",
+		},
+		{
+			name:     "update missing skill",
+			args:     []string{"skill", "update", "missing", "--file", path},
+			expected: "skill \"missing\" not found",
+		},
+		{
+			name:     "add empty content",
+			args:     []string{"skill", "add", "empty", "--file", emptyPath},
+			expected: "is empty",
+		},
+		{
+			name:     "add missing file flag",
+			args:     []string{"skill", "add", "nofile"},
+			expected: "--file is required",
+		},
+		{
+			name:     "render missing skill",
+			args:     []string{"skill", "render", "missing"},
+			expected: "skill \"missing\" not found",
+		},
+		{
+			name:     "list extra positional",
+			args:     []string{"skill", "list", "extra"},
+			expected: "unexpected positional arguments",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := runCmd(store, tt.args...)
+			if result.code == 0 {
+				t.Fatalf("expected command to fail")
+			}
+			if !strings.Contains(result.stderr, tt.expected) {
+				t.Fatalf("expected stderr to contain %q, got: %s", tt.expected, result.stderr)
+			}
+		})
+	}
+}
+
 func TestRunWithStoreCommandUsageValidation(t *testing.T) {
 	store := newTestStore(t)
 
@@ -314,6 +521,8 @@ func TestRunWithStoreCommandUsageValidation(t *testing.T) {
 		{name: "export extra positionals", args: []string{"export", "extra"}, expected: "unexpected positional arguments", helpCommand: "export"},
 		{name: "import missing file", args: []string{"import"}, expected: "--file is required", helpCommand: "import"},
 		{name: "import extra positionals", args: []string{"import", "--file", "snapshot.json", "extra"}, expected: "unexpected positional arguments", helpCommand: "import"},
+		{name: "skill missing subcommand", args: []string{"skill"}, expected: "usage: madari skill", helpCommand: "skill"},
+		{name: "skill unknown subcommand", args: []string{"skill", "bogus"}, expected: "unknown skill subcommand", helpCommand: "skill"},
 	}
 
 	for _, tt := range tests {
@@ -376,6 +585,7 @@ func TestRunHelpSubcommandOutput(t *testing.T) {
 		{name: "help add", args: []string{"help", "add"}, contains: "madari add <name>"},
 		{name: "help sync", args: []string{"help", "sync"}, contains: "madari sync <client>"},
 		{name: "help ring", args: []string{"help", "ring"}, contains: "madari ring <subcommand>"},
+		{name: "help skill", args: []string{"help", "skill"}, contains: "madari skill <subcommand>"},
 		{name: "help list", args: []string{"help", "list"}, contains: "madari list"},
 		{name: "help doctor", args: []string{"help", "doctor"}, contains: "madari doctor"},
 		{name: "help status", args: []string{"help", "status"}, contains: "madari status"},
@@ -489,6 +699,12 @@ func TestRunWithStoreSubcommandHelpFlags(t *testing.T) {
 	}
 	if result := runCmd(store, "sync", "--help"); result.code != 0 || !strings.Contains(result.stdout, "madari sync <client>") {
 		t.Fatalf("expected sync --help to print command help, got code=%d stdout=%s stderr=%s", result.code, result.stdout, result.stderr)
+	}
+	if result := runCmd(store, "skill", "--help"); result.code != 0 || !strings.Contains(result.stdout, "madari skill <subcommand>") {
+		t.Fatalf("expected skill --help to print command help, got code=%d stdout=%s stderr=%s", result.code, result.stdout, result.stderr)
+	}
+	if result := runCmd(store, "skill", "add", "--help"); result.code != 0 || !strings.Contains(result.stdout, "madari skill add <name>") {
+		t.Fatalf("expected skill add --help to print command help, got code=%d stdout=%s stderr=%s", result.code, result.stdout, result.stderr)
 	}
 	if result := runCmd(store, "list", "--help"); result.code != 0 || !strings.Contains(result.stdout, "madari list") {
 		t.Fatalf("expected list --help to print command help, got code=%d stdout=%s stderr=%s", result.code, result.stdout, result.stderr)
@@ -1112,6 +1328,9 @@ func TestRunWithStoreExportStdout(t *testing.T) {
 	if len(snapshot.Rings) != 0 {
 		t.Fatalf("unexpected snapshot rings: %+v", snapshot.Rings)
 	}
+	if len(snapshot.Skills) != 0 {
+		t.Fatalf("unexpected snapshot skills: %+v", snapshot.Skills)
+	}
 }
 
 func TestRunWithStoreExportFile(t *testing.T) {
@@ -1180,6 +1399,13 @@ func TestRunWithStoreImportDryRunAndApply(t *testing.T) {
 				Members: []string{"alpha", "beta"},
 			},
 		},
+		Skills: []registry.SnapshotSkill{
+			{
+				Name:        "release",
+				Description: "Release workflow",
+				Content:     "# Release\n",
+			},
+		},
 	}
 	payload, err := registry.MarshalSnapshotJSON(snapshot)
 	if err != nil {
@@ -1203,6 +1429,9 @@ func TestRunWithStoreImportDryRunAndApply(t *testing.T) {
 	if !strings.Contains(dryRun.stdout, "rings added: research") {
 		t.Fatalf("expected dry-run ring diff output, got: %s", dryRun.stdout)
 	}
+	if !strings.Contains(dryRun.stdout, "skills added: release") {
+		t.Fatalf("expected dry-run skill diff output, got: %s", dryRun.stdout)
+	}
 	alphaAfterDryRun, err := store.Get("alpha")
 	if err != nil {
 		t.Fatalf("load alpha after dry-run: %v", err)
@@ -1215,6 +1444,9 @@ func TestRunWithStoreImportDryRunAndApply(t *testing.T) {
 	}
 	if _, err := store.GetRing("research"); !errors.Is(err, registry.ErrRingNotFound) {
 		t.Fatalf("expected dry-run not to create research ring, got: %v", err)
+	}
+	if _, err := store.GetSkill("release"); !errors.Is(err, registry.ErrSkillNotFound) {
+		t.Fatalf("expected dry-run not to create release skill, got: %v", err)
 	}
 
 	apply := runCmd(store, "import", "--file", path, "--apply")
@@ -1236,6 +1468,16 @@ func TestRunWithStoreImportDryRunAndApply(t *testing.T) {
 	}
 	if _, err := store.GetRing("research"); err != nil {
 		t.Fatalf("expected research ring after apply: %v", err)
+	}
+	if _, err := store.GetSkill("release"); err != nil {
+		t.Fatalf("expected release skill after apply: %v", err)
+	}
+	releaseContent, err := store.GetSkillContent("release")
+	if err != nil {
+		t.Fatalf("expected release skill content after apply: %v", err)
+	}
+	if string(releaseContent) != "# Release\n" {
+		t.Fatalf("unexpected release skill content: %q", releaseContent)
 	}
 }
 

--- a/cmd/madari/skill.go
+++ b/cmd/madari/skill.go
@@ -1,0 +1,408 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+func (a cliApp) cmdSkill(args []string) error {
+	if len(args) == 0 {
+		return commandUsageError("skill", "madari skill <add|update|remove|list|show|render> [options]")
+	}
+	if isHelpToken(args[0]) {
+		printSkillHelp(a.stdout)
+		return nil
+	}
+
+	sub, rest := args[0], args[1:]
+	switch sub {
+	case "add":
+		return a.cmdSkillAdd(rest)
+	case "update":
+		return a.cmdSkillUpdate(rest)
+	case "remove":
+		return a.cmdSkillRemove(rest)
+	case "list":
+		return a.cmdSkillList(rest)
+	case "show":
+		return a.cmdSkillShow(rest)
+	case "render":
+		return a.cmdSkillRender(rest)
+	default:
+		return commandInputError("skill", fmt.Sprintf("unknown skill subcommand %q (supported: add, update, remove, list, show, render)", sub))
+	}
+}
+
+func (a cliApp) cmdSkillAdd(args []string) error {
+	if len(args) == 0 {
+		return commandUsageError("skill add", "madari skill add <name> --file <path> [--description <text>]")
+	}
+	if isHelpToken(args[0]) {
+		printSkillAddHelp(a.stdout)
+		return nil
+	}
+	name := strings.TrimSpace(args[0])
+
+	fs := flag.NewFlagSet("skill add", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var filePath string
+	var description string
+	fs.StringVar(&filePath, "file", "", "Markdown skill file to copy into Madari (required)")
+	fs.StringVar(&description, "description", "", "Skill description")
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printSkillAddHelp(a.stdout)
+			return nil
+		}
+		return commandInputError("skill add", err.Error())
+	}
+	if fs.NArg() != 0 {
+		return commandUnexpectedArgsError("skill add", fs.Args())
+	}
+
+	content, err := readSkillSourceFile(filePath)
+	if err != nil {
+		return err
+	}
+	if err := a.store.AddSkill(registry.Skill{Name: name, Description: description}, content); err != nil {
+		return err
+	}
+	fmt.Fprintf(a.stdout, "added skill %s\n", name)
+	return nil
+}
+
+func (a cliApp) cmdSkillUpdate(args []string) error {
+	if len(args) == 0 {
+		return commandUsageError("skill update", "madari skill update <name> --file <path> [--description <text>]")
+	}
+	if isHelpToken(args[0]) {
+		printSkillUpdateHelp(a.stdout)
+		return nil
+	}
+	name := strings.TrimSpace(args[0])
+
+	fs := flag.NewFlagSet("skill update", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var filePath string
+	var description string
+	fs.StringVar(&filePath, "file", "", "Markdown skill file to copy into Madari (required)")
+	fs.StringVar(&description, "description", "", "Skill description")
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printSkillUpdateHelp(a.stdout)
+			return nil
+		}
+		return commandInputError("skill update", err.Error())
+	}
+	if fs.NArg() != 0 {
+		return commandUnexpectedArgsError("skill update", fs.Args())
+	}
+
+	skill, err := a.store.GetSkill(name)
+	if err != nil {
+		if errors.Is(err, registry.ErrSkillNotFound) {
+			return fmt.Errorf("skill %q not found", name)
+		}
+		return err
+	}
+	if flagWasProvided(fs, "description") {
+		skill.Description = description
+	}
+	content, err := readSkillSourceFile(filePath)
+	if err != nil {
+		return err
+	}
+	if err := a.store.SaveSkill(skill, content); err != nil {
+		return err
+	}
+	fmt.Fprintf(a.stdout, "updated skill %s\n", name)
+	return nil
+}
+
+func (a cliApp) cmdSkillRemove(args []string) error {
+	if len(args) == 1 && isHelpToken(args[0]) {
+		printSkillRemoveHelp(a.stdout)
+		return nil
+	}
+	fs := flag.NewFlagSet("skill remove", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printSkillRemoveHelp(a.stdout)
+			return nil
+		}
+		return commandInputError("skill remove", err.Error())
+	}
+	if fs.NArg() != 1 {
+		return commandUsageError("skill remove", "madari skill remove <name>")
+	}
+
+	name := strings.TrimSpace(fs.Arg(0))
+	if err := a.store.RemoveSkill(name); err != nil {
+		if errors.Is(err, registry.ErrSkillNotFound) {
+			return fmt.Errorf("skill %q not found", name)
+		}
+		return err
+	}
+	fmt.Fprintf(a.stdout, "removed skill %s\n", name)
+	return nil
+}
+
+func (a cliApp) cmdSkillList(args []string) error {
+	if len(args) == 1 && isHelpToken(args[0]) {
+		printSkillListHelp(a.stdout)
+		return nil
+	}
+	fs := flag.NewFlagSet("skill list", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var jsonOut bool
+	fs.BoolVar(&jsonOut, "json", false, "Emit JSON instead of text")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printSkillListHelp(a.stdout)
+			return nil
+		}
+		return commandInputError("skill list", err.Error())
+	}
+	if fs.NArg() != 0 {
+		return commandUnexpectedArgsError("skill list", fs.Args())
+	}
+
+	skills, err := a.store.ListSkills()
+	if err != nil {
+		return err
+	}
+
+	if jsonOut {
+		payload := skillListJSON{
+			SchemaVersion: jsonSchemaVersion,
+			Command:       "skill list",
+			Skills:        make([]skillJSON, 0, len(skills)),
+		}
+		for _, skill := range skills {
+			payload.Skills = append(payload.Skills, skillToJSON(skill, ""))
+		}
+		return writeJSON(a.stdout, payload)
+	}
+
+	if len(skills) == 0 {
+		fmt.Fprintln(a.stdout, "no skills configured")
+		return nil
+	}
+	fmt.Fprintln(a.stdout, "NAME\tDESCRIPTION")
+	for _, skill := range skills {
+		fmt.Fprintf(a.stdout, "%s\t%s\n", skill.Name, skill.Description)
+	}
+	return nil
+}
+
+func (a cliApp) cmdSkillShow(args []string) error {
+	if len(args) == 0 {
+		return commandUsageError("skill show", "madari skill show <name> [--json]")
+	}
+	if isHelpToken(args[0]) {
+		printSkillShowHelp(a.stdout)
+		return nil
+	}
+	name := strings.TrimSpace(args[0])
+
+	fs := flag.NewFlagSet("skill show", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var jsonOut bool
+	fs.BoolVar(&jsonOut, "json", false, "Emit JSON instead of text")
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printSkillShowHelp(a.stdout)
+			return nil
+		}
+		return commandInputError("skill show", err.Error())
+	}
+	if fs.NArg() != 0 {
+		return commandUnexpectedArgsError("skill show", fs.Args())
+	}
+
+	skill, err := a.store.GetSkill(name)
+	if err != nil {
+		if errors.Is(err, registry.ErrSkillNotFound) {
+			return fmt.Errorf("skill %q not found", name)
+		}
+		return err
+	}
+	contentPath, err := a.store.SkillContentPath(skill.Name)
+	if err != nil {
+		return err
+	}
+
+	if jsonOut {
+		return writeJSON(a.stdout, skillShowJSON{
+			SchemaVersion: jsonSchemaVersion,
+			Command:       "skill show",
+			Skill:         skillToJSON(skill, contentPath),
+		})
+	}
+
+	fmt.Fprintf(a.stdout, "name: %s\n", skill.Name)
+	if strings.TrimSpace(skill.Description) != "" {
+		fmt.Fprintf(a.stdout, "description: %s\n", skill.Description)
+	}
+	fmt.Fprintf(a.stdout, "content: %s\n", contentPath)
+	return nil
+}
+
+func (a cliApp) cmdSkillRender(args []string) error {
+	if len(args) == 0 {
+		return commandUsageError("skill render", "madari skill render <name>")
+	}
+	if isHelpToken(args[0]) {
+		printSkillRenderHelp(a.stdout)
+		return nil
+	}
+	name := strings.TrimSpace(args[0])
+
+	fs := flag.NewFlagSet("skill render", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printSkillRenderHelp(a.stdout)
+			return nil
+		}
+		return commandInputError("skill render", err.Error())
+	}
+	if fs.NArg() != 0 {
+		return commandUnexpectedArgsError("skill render", fs.Args())
+	}
+
+	if _, err := a.store.GetSkill(name); err != nil {
+		if errors.Is(err, registry.ErrSkillNotFound) {
+			return fmt.Errorf("skill %q not found", name)
+		}
+		return err
+	}
+	content, err := a.store.GetSkillContent(name)
+	if err != nil {
+		if errors.Is(err, registry.ErrSkillNotFound) {
+			return fmt.Errorf("skill %q content not found", name)
+		}
+		return err
+	}
+	_, err = a.stdout.Write(content)
+	return err
+}
+
+func readSkillSourceFile(path string) ([]byte, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil, commandInputError("skill", "--file is required")
+	}
+	cleanPath := filepath.Clean(path)
+	content, err := os.ReadFile(cleanPath)
+	if err != nil {
+		return nil, fmt.Errorf("read skill file %q: %w", cleanPath, err)
+	}
+	if strings.TrimSpace(string(content)) == "" {
+		return nil, fmt.Errorf("skill file %q is empty", cleanPath)
+	}
+	return content, nil
+}
+
+func flagWasProvided(fs *flag.FlagSet, name string) bool {
+	provided := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			provided = true
+		}
+	})
+	return provided
+}
+
+func printSkillHelp(out io.Writer) {
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  madari skill <subcommand> [options]")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Subcommands:")
+	fmt.Fprintln(out, "  add       Add a managed skill from a Markdown file")
+	fmt.Fprintln(out, "  update    Replace a managed skill's Markdown content")
+	fmt.Fprintln(out, "  remove    Remove a managed skill")
+	fmt.Fprintln(out, "  list      List configured skills")
+	fmt.Fprintln(out, "  show      Show one skill's metadata")
+	fmt.Fprintln(out, "  render    Print one skill's Markdown instructions")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Description:")
+	fmt.Fprintln(out, "  Skills are standalone Markdown instructions that teach a model about")
+	fmt.Fprintln(out, "  a domain or workflow. V1 stores and renders skills only; rings, run,")
+	fmt.Fprintln(out, "  and client config writers do not consume skills yet.")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Run `madari skill <subcommand> --help` for subcommand help.")
+}
+
+func printSkillAddHelp(out io.Writer) {
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  madari skill add <name> --file <path> [--description <text>]")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Options:")
+	fmt.Fprintln(out, "  --file <path>              Markdown skill file to copy into Madari (required)")
+	fmt.Fprintln(out, "  --description <text>       Skill description")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Description:")
+	fmt.Fprintln(out, "  Add a standalone skill by copying a non-empty Markdown file into")
+	fmt.Fprintln(out, "  Madari's managed skills directory.")
+}
+
+func printSkillUpdateHelp(out io.Writer) {
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  madari skill update <name> --file <path> [--description <text>]")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Options:")
+	fmt.Fprintln(out, "  --file <path>              Markdown skill file to copy into Madari (required)")
+	fmt.Fprintln(out, "  --description <text>       Replace the skill description")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Description:")
+	fmt.Fprintln(out, "  Replace the managed Markdown content for an existing skill. The")
+	fmt.Fprintln(out, "  current description is preserved unless --description is passed.")
+}
+
+func printSkillRemoveHelp(out io.Writer) {
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  madari skill remove <name>")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Description:")
+	fmt.Fprintln(out, "  Remove a standalone skill from Madari's registry.")
+}
+
+func printSkillListHelp(out io.Writer) {
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  madari skill list [--json]")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Options:")
+	fmt.Fprintln(out, "  --json                     Emit JSON instead of text")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Description:")
+	fmt.Fprintln(out, "  List configured standalone skills.")
+}
+
+func printSkillShowHelp(out io.Writer) {
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  madari skill show <name> [--json]")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Options:")
+	fmt.Fprintln(out, "  --json                     Emit JSON instead of text")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Description:")
+	fmt.Fprintln(out, "  Show one skill's metadata and managed Markdown file path.")
+}
+
+func printSkillRenderHelp(out io.Writer) {
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  madari skill render <name>")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Description:")
+	fmt.Fprintln(out, "  Print the managed Markdown instructions for a standalone skill to")
+	fmt.Fprintln(out, "  stdout exactly. Render mutates no state and writes no client files.")
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,32 +16,34 @@ Madari keeps four concepts separate:
   members only; the grouping surface is intentionally the place where future
   capability types such as skills can compose with MCP servers.
 - Skill: procedural or domain instructions for how an agent should use
-  capabilities. Skills are not implemented yet, and should get their own
-  registry/render surface rather than being hidden inside server sync.
+  capabilities. Skills are standalone Markdown primitives with their own
+  metadata, managed content, and render surface.
 - Run: ephemeral execution that combines a task, selected capabilities, client
   target, optional skills/context, and result capture. Run is not implemented
   yet and should not be modeled as persistent client sync.
 
 Current behavior follows this boundary: `sync` and `ring attach` persist MCP
-server config, while `ring render` emits MCP config only. Future skill work
-should add an explicit skill render path before combining rings and skills in
-execution flows.
+server config, `ring render` emits MCP config only, and `skill render` emits
+Markdown instructions only. Skills do not write client config and are not ring
+members or run inputs yet.
 
 ## Components
 
 1. Registry
 - Path: `<os.UserConfigDir()>/madari/servers/*.toml` (or `$MADARI_CONFIG_DIR/servers/*.toml`)
-- One file per server entry; rings live alongside as `rings/<name>.toml`.
+- One file per server entry; rings live alongside as `rings/<name>.toml`;
+  skills live alongside as `skills/<name>.toml` plus managed Markdown content
+  at `skills/<name>.md`.
 - Human-readable and versionable.
-- Snapshots (`export`/`import`) carry servers and rings as versioned JSON;
-  export refuses rings that would not round-trip, import validates everything
-  before writing anything and never attaches or syncs.
+- Snapshots (`export`/`import`) carry servers, rings, and skills as versioned
+  JSON; export refuses rings that would not round-trip, import validates
+  everything before writing anything and never attaches or syncs.
 
 2. Client Targets and Adapters
 - The command layer keeps a single client target registry for target-level
   capabilities: sync adapter, ring config renderer, and scope support.
-  Future skill render support should extend that registry instead of adding
-  another target-specific switch.
+  Future client-native skill render support should extend that registry
+  instead of adding another target-specific switch.
 - Translate registry entries into client-specific config.
 - Current adapters: Claude Desktop, Claude Code, Gemini, Codex, and Vibe.
 - Adapters own read/merge/write behavior for their client format.
@@ -75,8 +77,9 @@ execution flows.
 5. Rings
 - Named capability sets (`rings/<name>.toml`). In the current schema, members
   are server references by name only — the server manifest stays the single
-  source of truth for command, args, and env. Future skill support should grow
-  the capability model deliberately rather than overloading server manifests.
+  source of truth for command, args, and env. Skills are standalone in V1;
+  future skill membership should grow the ring schema deliberately rather than
+  overloading server manifests.
 - Attachment is derived state: ring `R` is attached to a target+scope iff
   `ring:R` appears among ownership sources there. Attach records the source
   on every member and materializes the eligible ones; detach releases it by
@@ -95,7 +98,19 @@ execution flows.
 - `ring delete` refuses while any target/scope still records the ring as an
   ownership source, and never edits client configs or managed state.
 
-6. Doctor Engine
+6. Skills
+- Standalone instruction primitives stored as metadata plus managed Markdown:
+  `skills/<name>.toml` and `skills/<name>.md`.
+- `skill add` copies a non-empty Markdown file into Madari; `skill update`
+  replaces that managed copy and preserves description unless a new one is
+  provided.
+- `skill render` prints the managed Markdown exactly to stdout. It mutates no
+  state, writes no client files, and does not imply model restriction to that
+  workflow.
+- V1 skills are exported/imported in snapshots but are not consumed by rings,
+  sync adapters, or run execution.
+
+7. Doctor Engine
 - Verifies command/binary resolution.
 - Validates required env values are present.
 - Validates client config parseability.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -124,6 +124,28 @@ paths — pass `--config-path` when the ring was attached to a custom config. `m
 the same conditions as `ring_issues` (missing ring file = error, dangling
 member = warning).
 
+## Skills
+
+```bash
+madari skill add release --file ./SKILL.md --description "Release workflow"
+madari skill update release --file ./SKILL.md
+madari skill update release --file ./SKILL.md --description "Updated workflow"
+madari skill list
+madari skill show release
+madari skill render release
+madari skill remove release
+```
+
+Skills are standalone Markdown instructions stored as managed local copies:
+metadata lives at `<config-root>/skills/<name>.toml`, and content lives at
+`<config-root>/skills/<name>.md`. `skill add` fails if the skill exists;
+`skill update` fails if it does not. Updating preserves the existing
+description unless `--description` is passed.
+
+`skill render` prints the managed Markdown bytes exactly to stdout and
+mutates nothing. V1 skills are not ring members, are not synced into client
+configs, and are not consumed by `run`.
+
 ## Diagnostics
 
 ```bash
@@ -141,17 +163,19 @@ madari import --file madari-snapshot.json
 madari import --file madari-snapshot.json --apply
 ```
 
-Snapshots are versioned JSON documents containing server manifests and ring
-definitions. Export writes the current snapshot version with both `servers`
-and `rings`. Import is a dry-run by default; `--apply` adds or updates listed
-servers and rings, never deletes entries absent from the snapshot, and never
-attaches or syncs imported rings. Ring membership changes converge through
-the normal reconciliation pass on the next sync, attach, or detach.
+Snapshots are versioned JSON documents containing server manifests, ring
+definitions, and skill content. Export writes the current snapshot version
+with `servers`, `rings`, and `skills`. Import is a dry-run by default;
+`--apply` adds or updates listed servers, rings, and skills, never deletes
+entries absent from the snapshot, and never attaches or syncs imported rings.
+Ring membership changes converge through the normal reconciliation pass on
+the next sync, attach, or detach.
 
 ## JSON Output
 
-`list`, `status`, `doctor`, `sync --dry-run`, `ring list`, `ring show`, and
-`ring status` accept `--json` and emit a single JSON document on stdout with nothing else.
+`list`, `status`, `doctor`, `sync --dry-run`, `ring list`, `ring show`,
+`ring status`, `skill list`, and `skill show` accept `--json` and emit a
+single JSON document on stdout with nothing else.
 Every payload carries the envelope fields `schema_version` (currently `1`)
 and `command`. Field additions are backward-compatible; renames or removals
 bump `schema_version`. List-valued fields are always present (empty arrays,
@@ -165,6 +189,8 @@ madari sync claude-code --dry-run --json
 madari ring list --json
 madari ring show research --json
 madari ring status --json
+madari skill list --json
+madari skill show release --json
 ```
 
 `sync --json` requires `--dry-run`; the apply-mode output contract is not yet
@@ -331,6 +357,36 @@ itself.
     "name": "research",
     "members": ["arxiv", "stewreads"],
     "description": "Research helpers"
+  }
+}
+```
+
+`madari skill list --json`:
+
+```json
+{
+  "schema_version": 1,
+  "command": "skill list",
+  "skills": [
+    {
+      "name": "release",
+      "description": "Release workflow"
+    }
+  ]
+}
+```
+
+`madari skill show <name> --json` wraps one skill object and includes the
+managed content path:
+
+```json
+{
+  "schema_version": 1,
+  "command": "skill show",
+  "skill": {
+    "name": "release",
+    "description": "Release workflow",
+    "content_path": "/path/to/madari/skills/release.md"
   }
 }
 ```

--- a/docs/manifest-spec.md
+++ b/docs/manifest-spec.md
@@ -95,3 +95,24 @@ name = "research"
 members = ["arxiv", "stewreads"]
 description = "Research helpers"
 ```
+
+## Skill Files
+
+Skills are standalone Markdown instruction primitives. Madari stores skill
+metadata at `<config-root>/skills/<name>.toml` and the managed Markdown body
+at `<config-root>/skills/<name>.md`.
+
+- `name` (string, required): stable skill ID; same pattern as server names.
+- `description` (string, optional): friendly description.
+
+Skill manifests have no sections; unknown keys are rejected. The Markdown
+body is arbitrary text, but it must be non-empty. V1 skills are managed and
+rendered independently: they are not ring members, are not synced into client
+configs, and are not consumed by `run`.
+
+### Example
+
+```toml
+name = "release"
+description = "Release workflow"
+```

--- a/internal/registry/skill.go
+++ b/internal/registry/skill.go
@@ -1,0 +1,99 @@
+package registry
+
+import (
+	"bufio"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Skill is a standalone instruction primitive. The TOML manifest stores only
+// metadata; the managed Markdown body is stored alongside it by the Store.
+type Skill struct {
+	Name        string `toml:"name" json:"name"`
+	Description string `toml:"description,omitempty" json:"description,omitempty"`
+}
+
+// Validate enforces skill-level invariants.
+func (s Skill) Validate() error {
+	if err := validateServerName(s.Name); err != nil {
+		return fmt.Errorf("invalid skill: %w", err)
+	}
+	return nil
+}
+
+// ParseSkill parses a constrained TOML skill manifest and rejects unknown
+// fields, mirroring ring manifest strictness.
+func ParseSkill(data []byte) (Skill, error) {
+	var skill Skill
+
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		line = stripInlineComment(line)
+		if line == "" {
+			continue
+		}
+
+		if strings.HasPrefix(line, "[") {
+			return Skill{}, fmt.Errorf("line %d: skill manifests have no sections", lineNo)
+		}
+
+		key, value, err := splitKeyValue(line)
+		if err != nil {
+			return Skill{}, fmt.Errorf("line %d: %w", lineNo, err)
+		}
+
+		switch key {
+		case "name":
+			sv, err := parseString(value)
+			if err != nil {
+				return Skill{}, fmt.Errorf("line %d: invalid name: %w", lineNo, err)
+			}
+			skill.Name = sv
+		case "description":
+			sv, err := parseString(value)
+			if err != nil {
+				return Skill{}, fmt.Errorf("line %d: invalid description: %w", lineNo, err)
+			}
+			skill.Description = sv
+		default:
+			return Skill{}, fmt.Errorf("line %d: unknown key %q", lineNo, key)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return Skill{}, fmt.Errorf("scan skill manifest: %w", err)
+	}
+
+	if err := skill.Validate(); err != nil {
+		return Skill{}, err
+	}
+	return skill, nil
+}
+
+// MarshalSkill renders a deterministic TOML skill manifest.
+func MarshalSkill(skill Skill) ([]byte, error) {
+	if err := skill.Validate(); err != nil {
+		return nil, err
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "name = %s\n", strconv.Quote(skill.Name))
+	if strings.TrimSpace(skill.Description) != "" {
+		fmt.Fprintf(&b, "description = %s\n", strconv.Quote(skill.Description))
+	}
+	return []byte(b.String()), nil
+}
+
+func validateSkillContent(content []byte) error {
+	if strings.TrimSpace(string(content)) == "" {
+		return fmt.Errorf("skill content is required")
+	}
+	return nil
+}

--- a/internal/registry/skill_store.go
+++ b/internal/registry/skill_store.go
@@ -1,0 +1,181 @@
+package registry
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+var ErrSkillNotFound = errors.New("skill not found")
+
+// SkillsDir returns the on-disk skills directory, a sibling of the servers
+// directory under the same config root.
+func (s *Store) SkillsDir() string {
+	return filepath.Join(filepath.Dir(s.serversDir), "skills")
+}
+
+// AddSkill inserts a new skill; it fails if the skill already exists.
+func (s *Store) AddSkill(skill Skill, content []byte) error {
+	if err := skill.Validate(); err != nil {
+		return err
+	}
+	if err := validateSkillContent(content); err != nil {
+		return err
+	}
+	if _, err := s.GetSkill(skill.Name); err == nil {
+		return fmt.Errorf("skill %q already exists", skill.Name)
+	} else if !errors.Is(err, ErrSkillNotFound) {
+		return err
+	}
+	return s.SaveSkill(skill, content)
+}
+
+// SaveSkill writes or updates a skill manifest and its managed Markdown body.
+func (s *Store) SaveSkill(skill Skill, content []byte) error {
+	if err := skill.Validate(); err != nil {
+		return err
+	}
+	if err := validateSkillContent(content); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(s.SkillsDir(), 0o755); err != nil {
+		return fmt.Errorf("ensure skills directory: %w", err)
+	}
+
+	metaPath, err := s.pathForSkill(skill.Name)
+	if err != nil {
+		return err
+	}
+	contentPath, err := s.SkillContentPath(skill.Name)
+	if err != nil {
+		return err
+	}
+	metaPayload, err := MarshalSkill(skill)
+	if err != nil {
+		return err
+	}
+
+	if err := writeFileAtomically(metaPath, metaPayload, 0o644); err != nil {
+		return fmt.Errorf("save skill %q metadata: %w", skill.Name, err)
+	}
+	if err := writeFileAtomically(contentPath, content, 0o644); err != nil {
+		return fmt.Errorf("save skill %q content: %w", skill.Name, err)
+	}
+	return nil
+}
+
+// GetSkill loads one skill manifest by name.
+func (s *Store) GetSkill(name string) (Skill, error) {
+	path, err := s.pathForSkill(name)
+	if err != nil {
+		return Skill{}, err
+	}
+
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return Skill{}, ErrSkillNotFound
+		}
+		return Skill{}, fmt.Errorf("read skill %q: %w", name, err)
+	}
+
+	skill, err := ParseSkill(payload)
+	if err != nil {
+		return Skill{}, fmt.Errorf("parse skill %q: %w", name, err)
+	}
+	if skill.Name != name {
+		return Skill{}, fmt.Errorf("skill %q has mismatched name %q", name, skill.Name)
+	}
+	return skill, nil
+}
+
+// GetSkillContent loads one skill's managed Markdown body by name.
+func (s *Store) GetSkillContent(name string) ([]byte, error) {
+	path, err := s.SkillContentPath(name)
+	if err != nil {
+		return nil, err
+	}
+
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ErrSkillNotFound
+		}
+		return nil, fmt.Errorf("read skill %q content: %w", name, err)
+	}
+	if err := validateSkillContent(payload); err != nil {
+		return nil, fmt.Errorf("read skill %q content: %w", name, err)
+	}
+	return payload, nil
+}
+
+// ListSkills returns all skills sorted by name.
+func (s *Store) ListSkills() ([]Skill, error) {
+	entries, err := os.ReadDir(s.SkillsDir())
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return []Skill{}, nil
+		}
+		return nil, fmt.Errorf("read skills directory: %w", err)
+	}
+
+	skills := make([]Skill, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".toml" {
+			continue
+		}
+		name := strings.TrimSuffix(entry.Name(), ".toml")
+		skill, err := s.GetSkill(name)
+		if err != nil {
+			return nil, err
+		}
+		skills = append(skills, skill)
+	}
+
+	sort.Slice(skills, func(i, j int) bool {
+		return skills[i].Name < skills[j].Name
+	})
+	return skills, nil
+}
+
+// RemoveSkill deletes one skill manifest and its managed Markdown body.
+func (s *Store) RemoveSkill(name string) error {
+	metaPath, err := s.pathForSkill(name)
+	if err != nil {
+		return err
+	}
+
+	if err := os.Remove(metaPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return ErrSkillNotFound
+		}
+		return fmt.Errorf("remove skill %q metadata: %w", name, err)
+	}
+
+	contentPath, err := s.SkillContentPath(name)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(contentPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove skill %q content: %w", name, err)
+	}
+	return nil
+}
+
+// SkillContentPath returns the managed Markdown file path for a skill.
+func (s *Store) SkillContentPath(name string) (string, error) {
+	if err := validateServerName(name); err != nil {
+		return "", err
+	}
+	return filepath.Join(s.SkillsDir(), name+".md"), nil
+}
+
+func (s *Store) pathForSkill(name string) (string, error) {
+	if err := validateServerName(name); err != nil {
+		return "", err
+	}
+	return filepath.Join(s.SkillsDir(), name+".toml"), nil
+}

--- a/internal/registry/skill_store_test.go
+++ b/internal/registry/skill_store_test.go
@@ -1,0 +1,124 @@
+package registry
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSkillStoreLifecycle(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "servers"))
+	skill := Skill{Name: "release", Description: "Release workflow"}
+	content := []byte("# Release\n\nFollow the checklist.\n")
+
+	if err := store.AddSkill(skill, content); err != nil {
+		t.Fatalf("add skill: %v", err)
+	}
+	if err := store.AddSkill(skill, content); err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected duplicate add error, got: %v", err)
+	}
+
+	got, err := store.GetSkill("release")
+	if err != nil {
+		t.Fatalf("get skill: %v", err)
+	}
+	if got != skill {
+		t.Fatalf("unexpected skill: %#v", got)
+	}
+	gotContent, err := store.GetSkillContent("release")
+	if err != nil {
+		t.Fatalf("get skill content: %v", err)
+	}
+	if string(gotContent) != string(content) {
+		t.Fatalf("unexpected skill content: %q", gotContent)
+	}
+
+	if err := store.SaveSkill(Skill{Name: "release", Description: "Updated"}, []byte("new instructions")); err != nil {
+		t.Fatalf("save skill: %v", err)
+	}
+	updated, err := store.GetSkill("release")
+	if err != nil {
+		t.Fatalf("get updated skill: %v", err)
+	}
+	if updated.Description != "Updated" {
+		t.Fatalf("expected updated description, got: %#v", updated)
+	}
+
+	skills, err := store.ListSkills()
+	if err != nil {
+		t.Fatalf("list skills: %v", err)
+	}
+	if len(skills) != 1 || skills[0].Name != "release" {
+		t.Fatalf("unexpected skills: %#v", skills)
+	}
+
+	if err := store.RemoveSkill("release"); err != nil {
+		t.Fatalf("remove skill: %v", err)
+	}
+	if _, err := store.GetSkill("release"); !errors.Is(err, ErrSkillNotFound) {
+		t.Fatalf("expected ErrSkillNotFound after removal, got: %v", err)
+	}
+	if _, err := store.GetSkillContent("release"); !errors.Is(err, ErrSkillNotFound) {
+		t.Fatalf("expected content removal, got: %v", err)
+	}
+	if err := store.RemoveSkill("release"); !errors.Is(err, ErrSkillNotFound) {
+		t.Fatalf("expected ErrSkillNotFound for second removal, got: %v", err)
+	}
+}
+
+func TestSkillStoreRejectsEmptyContent(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "servers"))
+
+	err := store.AddSkill(Skill{Name: "release"}, []byte("\n"))
+	if err == nil || !strings.Contains(err.Error(), "skill content is required") {
+		t.Fatalf("expected content validation error, got: %v", err)
+	}
+	if _, getErr := store.GetSkill("release"); !errors.Is(getErr, ErrSkillNotFound) {
+		t.Fatalf("expected no skill written after validation failure, got: %v", getErr)
+	}
+}
+
+func TestListSkillsEmptyWithoutDirectory(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "servers"))
+	skills, err := store.ListSkills()
+	if err != nil {
+		t.Fatalf("list skills: %v", err)
+	}
+	if len(skills) != 0 {
+		t.Fatalf("expected no skills, got: %#v", skills)
+	}
+}
+
+func TestGetSkillRejectsMismatchedName(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "servers"))
+	if err := store.SaveSkill(Skill{Name: "release"}, []byte("# Release\n")); err != nil {
+		t.Fatalf("save skill: %v", err)
+	}
+
+	oldPath := filepath.Join(store.SkillsDir(), "release.toml")
+	newPath := filepath.Join(store.SkillsDir(), "renamed.toml")
+	if err := os.Rename(oldPath, newPath); err != nil {
+		t.Fatalf("rename skill file: %v", err)
+	}
+
+	_, err := store.GetSkill("renamed")
+	if err == nil || !strings.Contains(err.Error(), "mismatched name") {
+		t.Fatalf("expected mismatched-name error, got: %v", err)
+	}
+}
+
+func TestSkillsDirIsSiblingOfServersDir(t *testing.T) {
+	store := NewStore("/tmp/example/servers")
+	if got := store.SkillsDir(); got != filepath.Clean("/tmp/example/skills") {
+		t.Fatalf("unexpected skills dir: %s", got)
+	}
+	path, err := store.SkillContentPath("release")
+	if err != nil {
+		t.Fatalf("skill content path: %v", err)
+	}
+	if path != filepath.Clean("/tmp/example/skills/release.md") {
+		t.Fatalf("unexpected content path: %s", path)
+	}
+}

--- a/internal/registry/skill_test.go
+++ b/internal/registry/skill_test.go
@@ -1,0 +1,111 @@
+package registry
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseAndMarshalSkillRoundTrip(t *testing.T) {
+	in := Skill{
+		Name:        "release-helper",
+		Description: "Release workflow instructions",
+	}
+
+	encoded, err := MarshalSkill(in)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	expected := "name = \"release-helper\"\ndescription = \"Release workflow instructions\"\n"
+	if string(encoded) != expected {
+		t.Fatalf("expected deterministic output:\n%s\ngot:\n%s", expected, encoded)
+	}
+
+	out, err := ParseSkill(encoded)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if out != in {
+		t.Fatalf("roundtrip mismatch: %#v", out)
+	}
+}
+
+func TestParseSkillRejectsUnknownKey(t *testing.T) {
+	manifest := `
+name = "release"
+content = "inline"
+`
+	_, err := ParseSkill([]byte(manifest))
+	if err == nil {
+		t.Fatalf("expected parse error for unknown key")
+	}
+	if !strings.Contains(err.Error(), "unknown key") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestParseSkillRejectsSections(t *testing.T) {
+	manifest := `
+name = "release"
+
+[env]
+KEY = "value"
+`
+	_, err := ParseSkill([]byte(manifest))
+	if err == nil {
+		t.Fatalf("expected parse error for section")
+	}
+	if !strings.Contains(err.Error(), "no sections") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSkillValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		skill   Skill
+		expects string
+	}{
+		{
+			name:    "empty name",
+			skill:   Skill{},
+			expects: "name is required",
+		},
+		{
+			name:    "invalid name",
+			skill:   Skill{Name: "Bad Name"},
+			expects: "name must match",
+		},
+		{
+			name:    "valid dotted name",
+			skill:   Skill{Name: "release.patch"},
+			expects: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.skill.Validate()
+			if tt.expects == "" {
+				if err != nil {
+					t.Fatalf("expected valid skill, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected validation error")
+			}
+			if !strings.Contains(err.Error(), tt.expects) {
+				t.Fatalf("expected error containing %q, got: %v", tt.expects, err)
+			}
+		})
+	}
+}
+
+func TestValidateSkillContentRejectsEmpty(t *testing.T) {
+	if err := validateSkillContent([]byte("  \n\t")); err == nil {
+		t.Fatalf("expected empty content error")
+	}
+	if err := validateSkillContent([]byte("# Release\n")); err != nil {
+		t.Fatalf("expected non-empty content to pass: %v", err)
+	}
+}

--- a/internal/registry/snapshot.go
+++ b/internal/registry/snapshot.go
@@ -155,13 +155,16 @@ func ImportSnapshot(store *Store, snapshot Snapshot, apply bool) (ImportResult, 
 	for _, ring := range existingRings {
 		existingRingsByName[ring.Name] = ring
 	}
-	existingSkills, err := snapshotSkillsFromStore(store)
-	if err != nil {
-		return ImportResult{}, err
-	}
-	existingSkillsByName := make(map[string]SnapshotSkill, len(existingSkills))
-	for _, skill := range existingSkills {
-		existingSkillsByName[skill.Name] = skill
+	existingSkillsByName := map[string]Skill{}
+	if len(snapshot.Skills) > 0 {
+		existingSkills, err := store.ListSkills()
+		if err != nil {
+			return ImportResult{}, err
+		}
+		existingSkillsByName = make(map[string]Skill, len(existingSkills))
+		for _, skill := range existingSkills {
+			existingSkillsByName[skill.Name] = skill
+		}
 	}
 
 	// Validate every ring before any write: a rejected snapshot must not
@@ -255,7 +258,14 @@ func ImportSnapshot(store *Store, snapshot Snapshot, apply bool) (ImportResult, 
 			continue
 		}
 
-		if skillsEqual(existingSkill, incoming) {
+		existingSnapshot := SnapshotSkill{
+			Name:        existingSkill.Name,
+			Description: existingSkill.Description,
+		}
+		if content, err := store.GetSkillContent(incoming.Name); err == nil {
+			existingSnapshot.Content = string(content)
+		}
+		if skillsEqual(existingSnapshot, incoming) {
 			result.SkillsUnchanged = append(result.SkillsUnchanged, incoming.Name)
 			continue
 		}

--- a/internal/registry/snapshot.go
+++ b/internal/registry/snapshot.go
@@ -10,26 +10,37 @@ import (
 
 const (
 	snapshotVersionV1 = 1
-	SnapshotVersion   = 2
+	snapshotVersionV2 = 2
+	SnapshotVersion   = 3
 )
 
 type Snapshot struct {
-	Version int        `json:"version"`
-	Servers []Manifest `json:"servers"`
-	Rings   []Ring     `json:"rings"`
+	Version int             `json:"version"`
+	Servers []Manifest      `json:"servers"`
+	Rings   []Ring          `json:"rings"`
+	Skills  []SnapshotSkill `json:"skills"`
+}
+
+type SnapshotSkill struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Content     string `json:"content"`
 }
 
 type ImportResult struct {
-	Added          []string
-	Updated        []string
-	Unchanged      []string
-	RingsAdded     []string
-	RingsUpdated   []string
-	RingsUnchanged []string
+	Added           []string
+	Updated         []string
+	Unchanged       []string
+	RingsAdded      []string
+	RingsUpdated    []string
+	RingsUnchanged  []string
+	SkillsAdded     []string
+	SkillsUpdated   []string
+	SkillsUnchanged []string
 }
 
 func (r ImportResult) HasChanges() bool {
-	return len(r.Added)+len(r.Updated)+len(r.RingsAdded)+len(r.RingsUpdated) > 0
+	return len(r.Added)+len(r.Updated)+len(r.RingsAdded)+len(r.RingsUpdated)+len(r.SkillsAdded)+len(r.SkillsUpdated) > 0
 }
 
 func ExportSnapshot(store *Store) (Snapshot, error) {
@@ -41,6 +52,10 @@ func ExportSnapshot(store *Store) (Snapshot, error) {
 		return Snapshot{}, err
 	}
 	rings, err := store.ListRings()
+	if err != nil {
+		return Snapshot{}, err
+	}
+	skills, err := snapshotSkillsFromStore(store)
 	if err != nil {
 		return Snapshot{}, err
 	}
@@ -62,11 +77,12 @@ func ExportSnapshot(store *Store) (Snapshot, error) {
 		Version: SnapshotVersion,
 		Servers: servers,
 		Rings:   rings,
+		Skills:  skills,
 	}, nil
 }
 
 func MarshalSnapshotJSON(snapshot Snapshot) ([]byte, error) {
-	if snapshot.Version == 0 || snapshot.Version == snapshotVersionV1 {
+	if snapshot.Version == 0 || snapshot.Version == snapshotVersionV1 || snapshot.Version == snapshotVersionV2 {
 		snapshot.Version = SnapshotVersion
 	}
 	if snapshot.Servers == nil {
@@ -74,6 +90,9 @@ func MarshalSnapshotJSON(snapshot Snapshot) ([]byte, error) {
 	}
 	if snapshot.Rings == nil {
 		snapshot.Rings = []Ring{}
+	}
+	if snapshot.Skills == nil {
+		snapshot.Skills = []SnapshotSkill{}
 	}
 	if err := snapshot.Validate(); err != nil {
 		return nil, err
@@ -102,6 +121,9 @@ func ParseSnapshotJSON(payload []byte) (Snapshot, error) {
 	}
 	if snapshot.Rings == nil {
 		snapshot.Rings = []Ring{}
+	}
+	if snapshot.Skills == nil {
+		snapshot.Skills = []SnapshotSkill{}
 	}
 	if err := snapshot.Validate(); err != nil {
 		return Snapshot{}, err
@@ -132,6 +154,14 @@ func ImportSnapshot(store *Store, snapshot Snapshot, apply bool) (ImportResult, 
 	existingRingsByName := make(map[string]Ring, len(existingRings))
 	for _, ring := range existingRings {
 		existingRingsByName[ring.Name] = ring
+	}
+	existingSkills, err := snapshotSkillsFromStore(store)
+	if err != nil {
+		return ImportResult{}, err
+	}
+	existingSkillsByName := make(map[string]SnapshotSkill, len(existingSkills))
+	for _, skill := range existingSkills {
+		existingSkillsByName[skill.Name] = skill
 	}
 
 	// Validate every ring before any write: a rejected snapshot must not
@@ -209,15 +239,47 @@ func ImportSnapshot(store *Store, snapshot Snapshot, apply bool) (ImportResult, 
 		}
 	}
 
+	skills := append([]SnapshotSkill(nil), snapshot.Skills...)
+	sort.Slice(skills, func(i, j int) bool {
+		return skills[i].Name < skills[j].Name
+	})
+	for _, incoming := range skills {
+		existingSkill, exists := existingSkillsByName[incoming.Name]
+		if !exists {
+			result.SkillsAdded = append(result.SkillsAdded, incoming.Name)
+			if apply {
+				if err := store.SaveSkill(incoming.toSkill(), []byte(incoming.Content)); err != nil {
+					return ImportResult{}, fmt.Errorf("save imported skill %q: %w", incoming.Name, err)
+				}
+			}
+			continue
+		}
+
+		if skillsEqual(existingSkill, incoming) {
+			result.SkillsUnchanged = append(result.SkillsUnchanged, incoming.Name)
+			continue
+		}
+
+		result.SkillsUpdated = append(result.SkillsUpdated, incoming.Name)
+		if apply {
+			if err := store.SaveSkill(incoming.toSkill(), []byte(incoming.Content)); err != nil {
+				return ImportResult{}, fmt.Errorf("update imported skill %q: %w", incoming.Name, err)
+			}
+		}
+	}
+
 	return result, nil
 }
 
 func (s Snapshot) Validate() error {
-	if s.Version != snapshotVersionV1 && s.Version != SnapshotVersion {
+	if s.Version != snapshotVersionV1 && s.Version != snapshotVersionV2 && s.Version != SnapshotVersion {
 		return fmt.Errorf("unsupported snapshot version %d (supported: %d)", s.Version, SnapshotVersion)
 	}
 	if s.Version == snapshotVersionV1 && len(s.Rings) > 0 {
 		return fmt.Errorf("snapshot version %d does not support rings", snapshotVersionV1)
+	}
+	if s.Version < SnapshotVersion && len(s.Skills) > 0 {
+		return fmt.Errorf("snapshot version %d does not support skills", s.Version)
 	}
 
 	seen := map[string]struct{}{}
@@ -240,6 +302,17 @@ func (s Snapshot) Validate() error {
 			return fmt.Errorf("duplicate ring name %q in snapshot", ring.Name)
 		}
 		seenRings[ring.Name] = struct{}{}
+	}
+
+	seenSkills := map[string]struct{}{}
+	for _, skill := range s.Skills {
+		if err := skill.Validate(); err != nil {
+			return fmt.Errorf("invalid skill %q: %w", skill.Name, err)
+		}
+		if _, exists := seenSkills[skill.Name]; exists {
+			return fmt.Errorf("duplicate skill name %q in snapshot", skill.Name)
+		}
+		seenSkills[skill.Name] = struct{}{}
 	}
 
 	return nil
@@ -309,6 +382,41 @@ func ringsEqual(a, b Ring) bool {
 	aMembers := normalizedRingMembers(a)
 	bMembers := normalizedRingMembers(b)
 	return slices.Equal(aMembers, bMembers)
+}
+
+func skillsEqual(a, b SnapshotSkill) bool {
+	return a.Name == b.Name && a.Description == b.Description && a.Content == b.Content
+}
+
+func snapshotSkillsFromStore(store *Store) ([]SnapshotSkill, error) {
+	skills, err := store.ListSkills()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]SnapshotSkill, 0, len(skills))
+	for _, skill := range skills {
+		content, err := store.GetSkillContent(skill.Name)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, SnapshotSkill{
+			Name:        skill.Name,
+			Description: skill.Description,
+			Content:     string(content),
+		})
+	}
+	return out, nil
+}
+
+func (s SnapshotSkill) Validate() error {
+	if err := s.toSkill().Validate(); err != nil {
+		return err
+	}
+	return validateSkillContent([]byte(s.Content))
+}
+
+func (s SnapshotSkill) toSkill() Skill {
+	return Skill{Name: s.Name, Description: s.Description}
 }
 
 func normalizedRingMembers(r Ring) []string {

--- a/internal/registry/snapshot_test.go
+++ b/internal/registry/snapshot_test.go
@@ -391,6 +391,77 @@ func TestImportSnapshotSkillsDryRunAndApply(t *testing.T) {
 	}
 }
 
+func TestImportSnapshotDoesNotReadUnrelatedBrokenLocalSkillContent(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "servers"))
+	if err := store.SaveSkill(Skill{Name: "broken", Description: "local"}, []byte("# Broken\n")); err != nil {
+		t.Fatalf("save broken skill: %v", err)
+	}
+	contentPath, err := store.SkillContentPath("broken")
+	if err != nil {
+		t.Fatalf("skill content path: %v", err)
+	}
+	if err := os.Remove(contentPath); err != nil {
+		t.Fatalf("remove skill content: %v", err)
+	}
+
+	snapshot := Snapshot{
+		Version: SnapshotVersion,
+		Servers: []Manifest{
+			{Name: "alpha", Command: "/usr/bin/env", Enabled: true, Clients: []string{"claude-desktop"}},
+		},
+	}
+	result, err := ImportSnapshot(store, snapshot, false)
+	if err != nil {
+		t.Fatalf("server-only import should ignore unrelated broken skill content: %v", err)
+	}
+	if len(result.Added) != 1 || result.Added[0] != "alpha" {
+		t.Fatalf("expected alpha added, got: %+v", result)
+	}
+}
+
+func TestImportSnapshotCanRepairBrokenLocalSkillContent(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "servers"))
+	if err := store.SaveSkill(Skill{Name: "release", Description: "old"}, []byte("# Old\n")); err != nil {
+		t.Fatalf("save release skill: %v", err)
+	}
+	contentPath, err := store.SkillContentPath("release")
+	if err != nil {
+		t.Fatalf("skill content path: %v", err)
+	}
+	if err := os.Remove(contentPath); err != nil {
+		t.Fatalf("remove skill content: %v", err)
+	}
+
+	snapshot := Snapshot{
+		Version: SnapshotVersion,
+		Skills: []SnapshotSkill{
+			{Name: "release", Description: "new", Content: "# Release\n"},
+		},
+	}
+	dryRunResult, err := ImportSnapshot(store, snapshot, false)
+	if err != nil {
+		t.Fatalf("dry-run import should classify broken local skill as updated: %v", err)
+	}
+	if len(dryRunResult.SkillsUpdated) != 1 || dryRunResult.SkillsUpdated[0] != "release" {
+		t.Fatalf("expected release updated in dry-run, got: %+v", dryRunResult)
+	}
+
+	applyResult, err := ImportSnapshot(store, snapshot, true)
+	if err != nil {
+		t.Fatalf("apply import should repair broken local skill content: %v", err)
+	}
+	if len(applyResult.SkillsUpdated) != 1 || applyResult.SkillsUpdated[0] != "release" {
+		t.Fatalf("expected release updated in apply, got: %+v", applyResult)
+	}
+	content, err := store.GetSkillContent("release")
+	if err != nil {
+		t.Fatalf("load repaired skill content: %v", err)
+	}
+	if string(content) != "# Release\n" {
+		t.Fatalf("expected repaired content, got: %q", content)
+	}
+}
+
 func TestImportSnapshotRejectsUnknownRingMembers(t *testing.T) {
 	store := NewStore(filepath.Join(t.TempDir(), "servers"))
 	if err := store.Save(Manifest{Name: "alpha", Command: "/usr/bin/env", Enabled: true, Clients: []string{"claude-desktop"}}); err != nil {

--- a/internal/registry/snapshot_test.go
+++ b/internal/registry/snapshot_test.go
@@ -33,6 +33,12 @@ func TestSnapshotExportParseRoundTrip(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("save ring: %v", err)
 	}
+	if err := store.SaveSkill(Skill{
+		Name:        "release",
+		Description: "Release workflow",
+	}, []byte("# Release\n\nCut a patch release.\n")); err != nil {
+		t.Fatalf("save skill: %v", err)
+	}
 
 	snapshot, err := ExportSnapshot(store)
 	if err != nil {
@@ -63,6 +69,12 @@ func TestSnapshotExportParseRoundTrip(t *testing.T) {
 	if got := strings.Join(parsed.Rings[0].Members, ","); got != "alpha,beta" {
 		t.Fatalf("expected deterministic ring members, got: %s", got)
 	}
+	if len(parsed.Skills) != 1 || parsed.Skills[0].Name != "release" {
+		t.Fatalf("expected release skill in parsed snapshot, got: %#v", parsed.Skills)
+	}
+	if parsed.Skills[0].Content != "# Release\n\nCut a patch release.\n" {
+		t.Fatalf("unexpected skill content: %q", parsed.Skills[0].Content)
+	}
 }
 
 func TestMarshalSnapshotUsesSnakeCaseKeys(t *testing.T) {
@@ -87,6 +99,13 @@ func TestMarshalSnapshotUsesSnakeCaseKeys(t *testing.T) {
 				Description: "Research helpers",
 			},
 		},
+		Skills: []SnapshotSkill{
+			{
+				Name:        "release",
+				Description: "Release workflow",
+				Content:     "# Release\n",
+			},
+		},
 	}
 
 	payload, err := MarshalSnapshotJSON(snapshot)
@@ -94,7 +113,7 @@ func TestMarshalSnapshotUsesSnakeCaseKeys(t *testing.T) {
 		t.Fatalf("marshal snapshot failed: %v", err)
 	}
 	text := string(payload)
-	for _, key := range []string{`"name"`, `"command"`, `"args"`, `"enabled"`, `"clients"`, `"required_env"`, `"keys"`, `"rings"`, `"members"`, `"description"`} {
+	for _, key := range []string{`"name"`, `"command"`, `"args"`, `"enabled"`, `"clients"`, `"required_env"`, `"keys"`, `"rings"`, `"members"`, `"skills"`, `"content"`, `"description"`} {
 		if !strings.Contains(text, key) {
 			t.Fatalf("expected payload to contain key %s, payload=%s", key, text)
 		}
@@ -117,6 +136,26 @@ func TestParseSnapshotV1TreatsMissingRingsAsEmpty(t *testing.T) {
 	}
 	if len(snapshot.Rings) != 0 {
 		t.Fatalf("expected missing v1 rings to parse as empty, got: %#v", snapshot.Rings)
+	}
+	if len(snapshot.Skills) != 0 {
+		t.Fatalf("expected missing v1 skills to parse as empty, got: %#v", snapshot.Skills)
+	}
+}
+
+func TestParseSnapshotV2TreatsMissingSkillsAsEmpty(t *testing.T) {
+	payload := []byte(`{"version":2,"servers":[{"name":"alpha","command":"/usr/bin/env","enabled":true,"clients":["claude-desktop"]}],"rings":[{"name":"research","members":["alpha"]}]}`)
+	snapshot, err := ParseSnapshotJSON(payload)
+	if err != nil {
+		t.Fatalf("parse v2 snapshot: %v", err)
+	}
+	if snapshot.Version != 2 {
+		t.Fatalf("expected v2 snapshot to keep version 2, got %d", snapshot.Version)
+	}
+	if len(snapshot.Rings) != 1 {
+		t.Fatalf("expected v2 rings to parse, got: %#v", snapshot.Rings)
+	}
+	if len(snapshot.Skills) != 0 {
+		t.Fatalf("expected missing v2 skills to parse as empty, got: %#v", snapshot.Skills)
 	}
 }
 
@@ -275,6 +314,83 @@ func TestImportSnapshotRingsDryRunAndApply(t *testing.T) {
 	}
 }
 
+func TestImportSnapshotSkillsDryRunAndApply(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "servers"))
+	for _, skill := range []SnapshotSkill{
+		{Name: "release", Description: "old", Content: "# Old\n"},
+		{Name: "stable", Description: "same", Content: "# Stable\n"},
+		{Name: "local", Description: "preserved", Content: "# Local\n"},
+	} {
+		if err := store.SaveSkill(Skill{Name: skill.Name, Description: skill.Description}, []byte(skill.Content)); err != nil {
+			t.Fatalf("save skill %s: %v", skill.Name, err)
+		}
+	}
+
+	snapshot := Snapshot{
+		Version: SnapshotVersion,
+		Skills: []SnapshotSkill{
+			{Name: "new-skill", Description: "new", Content: "# New\n"},
+			{Name: "release", Description: "new", Content: "# Release\n"},
+			{Name: "stable", Description: "same", Content: "# Stable\n"},
+		},
+	}
+
+	dryRunResult, err := ImportSnapshot(store, snapshot, false)
+	if err != nil {
+		t.Fatalf("dry-run import failed: %v", err)
+	}
+	if len(dryRunResult.SkillsAdded) != 1 || dryRunResult.SkillsAdded[0] != "new-skill" {
+		t.Fatalf("expected new-skill added in dry-run, got: %+v", dryRunResult)
+	}
+	if len(dryRunResult.SkillsUpdated) != 1 || dryRunResult.SkillsUpdated[0] != "release" {
+		t.Fatalf("expected release updated in dry-run, got: %+v", dryRunResult)
+	}
+	if len(dryRunResult.SkillsUnchanged) != 1 || dryRunResult.SkillsUnchanged[0] != "stable" {
+		t.Fatalf("expected stable unchanged in dry-run, got: %+v", dryRunResult)
+	}
+	releaseAfterDryRun, err := store.GetSkill("release")
+	if err != nil {
+		t.Fatalf("load release after dry-run: %v", err)
+	}
+	if releaseAfterDryRun.Description != "old" {
+		t.Fatalf("expected dry-run not to change skill, got: %#v", releaseAfterDryRun)
+	}
+	if _, err := store.GetSkill("new-skill"); !errors.Is(err, ErrSkillNotFound) {
+		t.Fatalf("expected dry-run not to create new skill, got: %v", err)
+	}
+
+	applyResult, err := ImportSnapshot(store, snapshot, true)
+	if err != nil {
+		t.Fatalf("apply import failed: %v", err)
+	}
+	if len(applyResult.SkillsAdded) != 1 || applyResult.SkillsAdded[0] != "new-skill" {
+		t.Fatalf("expected new-skill added in apply, got: %+v", applyResult)
+	}
+	if len(applyResult.SkillsUpdated) != 1 || applyResult.SkillsUpdated[0] != "release" {
+		t.Fatalf("expected release updated in apply, got: %+v", applyResult)
+	}
+	releaseAfterApply, err := store.GetSkill("release")
+	if err != nil {
+		t.Fatalf("load release after apply: %v", err)
+	}
+	if releaseAfterApply.Description != "new" {
+		t.Fatalf("expected release skill metadata updated, got: %#v", releaseAfterApply)
+	}
+	releaseContent, err := store.GetSkillContent("release")
+	if err != nil {
+		t.Fatalf("load release content after apply: %v", err)
+	}
+	if string(releaseContent) != "# Release\n" {
+		t.Fatalf("expected release content updated, got: %q", releaseContent)
+	}
+	if _, err := store.GetSkill("new-skill"); err != nil {
+		t.Fatalf("expected new skill to exist after apply: %v", err)
+	}
+	if _, err := store.GetSkill("local"); err != nil {
+		t.Fatalf("existing skill absent from snapshot should be preserved: %v", err)
+	}
+}
+
 func TestImportSnapshotRejectsUnknownRingMembers(t *testing.T) {
 	store := NewStore(filepath.Join(t.TempDir(), "servers"))
 	if err := store.Save(Manifest{Name: "alpha", Command: "/usr/bin/env", Enabled: true, Clients: []string{"claude-desktop"}}); err != nil {
@@ -322,6 +438,21 @@ func TestParseSnapshotRejectsInvalidPayloads(t *testing.T) {
 	_, err = ParseSnapshotJSON([]byte(`{"version":2,"servers":[],"rings":[{"name":"research","members":["alpha"]},{"name":"research","members":["beta"]}]}`))
 	if err == nil || !strings.Contains(err.Error(), "duplicate ring name") {
 		t.Fatalf("expected duplicate ring error, got: %v", err)
+	}
+
+	_, err = ParseSnapshotJSON([]byte(`{"version":2,"servers":[],"rings":[],"skills":[{"name":"release","content":"# Release\n"}]}`))
+	if err == nil || !strings.Contains(err.Error(), "does not support skills") {
+		t.Fatalf("expected v2 skills error, got: %v", err)
+	}
+
+	_, err = ParseSnapshotJSON([]byte(`{"version":3,"servers":[],"rings":[],"skills":[{"name":"release","content":"# One\n"},{"name":"release","content":"# Two\n"}]}`))
+	if err == nil || !strings.Contains(err.Error(), "duplicate skill name") {
+		t.Fatalf("expected duplicate skill error, got: %v", err)
+	}
+
+	_, err = ParseSnapshotJSON([]byte(`{"version":3,"servers":[],"rings":[],"skills":[{"name":"release","content":"   "}]}`))
+	if err == nil || !strings.Contains(err.Error(), "skill content is required") {
+		t.Fatalf("expected empty skill content error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Added `Skill` as a standalone registry primitive with strict TOML metadata and managed Markdown content stored under `skills/<name>.toml` and `skills/<name>.md`.
- Added snapshot v3 support for portable skill export/import, including dry-run/apply summaries and backward compatibility for older snapshots.
- Added `madari skill add/update/remove/list/show/render`, JSON output for list/show, and exact Markdown stdout rendering.
- Updated README and docs to clarify the V1 boundary: skills are managed/rendered independently and are not ring members, client sync inputs, or run inputs yet.

## Why

This introduces skills as a core primitive without coupling them prematurely to rings, client adapters, or the future run command. It keeps the registry model simple while making skill content portable and reusable.

## Validation

- `go test ./internal/registry ./cmd/madari`
- `go test ./...`
- `make build`
- `git diff --check`