### PR TITLE
[codex] Add skill client render and attach

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ go install github.com/ankitvg/madari/cmd/madari@latest
 - `madari skill remove <name>`
 - `madari skill list [--json]`
 - `madari skill show <name> [--json]`
-- `madari skill render <name>`
+- `madari skill render <name> [--client <target>]`
+- `madari skill attach <name> <client> [--scope project|user] [--skills-dir <dir>] [--dry-run]`
+- `madari skill detach <name> <client> [--scope project|user] [--skills-dir <dir>] [--dry-run]`
 - `madari clients`
 - `madari doctor [--client-config target=path ...] [--json]`
 - `madari status [--client-config target=path ...] [--json]`
@@ -62,17 +64,23 @@ Notes:
 - `ring attach` records reference-counted ownership (`ring:<name>` sources) and materializes eligible members; `ring detach` releases it, and an entry only leaves the client config when nothing owns it anymore. Overlapping rings and standalone+ring combinations resolve by refcount, in any order. Attaching onto an entry madari does not manage is refused — even when values match.
 - `ring delete` removes only unattached ring definitions. It refuses while any client scope still records `ring:<name>` ownership and prints scoped detach guidance; deletion never edits client configs or managed state.
 - `ring render` prints a self-contained MCP config to stdout for ephemeral use — `claude --mcp-config <(madari ring render research --client claude-code)` — mutating nothing; secret env values are never emitted. Render targets are independent from persistent sync support: Claude and Gemini emit JSON, while Codex and Vibe emit TOML. `ring status` shows attached rings and per-server ownership for every client and scope.
-- Skills are standalone Markdown instruction primitives (`madari skill …`). Madari stores skill metadata and a managed Markdown copy, and `skill render` prints that Markdown exactly to stdout. V1 skills are not ring members, are not synced to client configs, and are not consumed by `run`.
+- Skills are standalone Markdown instruction primitives (`madari skill …`). Madari stores skill metadata and a managed Markdown copy; plain `skill render` prints that Markdown exactly to stdout, while `skill render --client` and `skill attach` synthesize native `SKILL.md` frontmatter for supported skill clients. Skills are not ring members, are not written into MCP client configs, and are not consumed by `run`.
 - Codex sync writes static non-secret `[env]` values under `[mcp_servers.<name>.env]` and forwards `[required_env]` plus `[secret_env]` keys through `env_vars`; static secret values are not written into Codex config.
 - Vibe sync writes static `[env]` values into user-scoped `[[mcp_servers]]` entries and preserves unmanaged HTTP/streamable/manual entries.
 - Supported sync clients: `claude-desktop`, `claude-code`, `gemini`, `codex`, and `vibe`.
 - Supported render targets: `claude-code`, `claude-desktop`, `gemini`, `codex`, and `vibe`.
+- Supported skill targets: `claude-code`, `codex`, `gemini`, and `vibe`.
 - Default sync config paths:
   - `claude-desktop`: platform-specific Claude Desktop config path.
   - `claude-code`: `<current working directory>/.mcp.json`.
   - `gemini`: `<current working directory>/.gemini/settings.json`.
   - `codex`: `$CODEX_HOME/config.toml` or `~/.codex/config.toml`.
   - `vibe`: `$VIBE_HOME/config.toml` or `~/.vibe/config.toml`.
+- Default skill roots:
+  - `claude-code`: project `.claude/skills`, user `~/.claude/skills`.
+  - `codex`: project `.agents/skills`, user `~/.agents/skills`.
+  - `gemini`: project `.gemini/skills`, user `~/.gemini/skills`.
+  - `vibe`: project `.vibe/skills`, user `~/.vibe/skills`.
 - `install --config-path` can only be used when exactly one sync target is selected.
 - `export` writes a versioned JSON snapshot of server, ring, and skill manifests for backup/sharing (stdout by default).
 - `import` is dry-run by default and only adds/updates listed servers, rings, and skills (`--apply` persists). Existing entries absent from the snapshot are left unchanged; imported rings are not attached or synced.
@@ -135,6 +143,8 @@ madari sync codex --dry-run
 madari sync vibe --dry-run
 madari skill add release --file ./SKILL.md --description "Release workflow"
 madari skill render release
+madari skill render release --client codex
+madari skill attach release codex --dry-run
 madari export --file madari-snapshot.json
 madari import --file madari-snapshot.json
 madari import --file madari-snapshot.json --apply

--- a/cmd/madari/client_targets.go
+++ b/cmd/madari/client_targets.go
@@ -64,7 +64,7 @@ var clientTargets = []clientTarget{
 		ringConfigRenderer: renderVibeTOML,
 		skillRoots: skillTargetRoots{
 			project: defaultProjectSkillRoot(".vibe", "skills"),
-			user:    defaultHomeSkillRoot(".vibe", "skills"),
+			user:    defaultVibeUserSkillRoot(),
 		},
 	},
 }

--- a/cmd/madari/client_targets.go
+++ b/cmd/madari/client_targets.go
@@ -20,6 +20,7 @@ type clientTarget struct {
 	syncAdapter        clients.ClientAdapter
 	ringConfigRenderer func(io.Writer, map[string]renderedServer) error
 	userScope          bool
+	skillRoots         skillTargetRoots
 }
 
 var clientTargets = []clientTarget{
@@ -33,22 +34,38 @@ var clientTargets = []clientTarget{
 		syncAdapter:        claudecode.Adapter{},
 		ringConfigRenderer: renderMCPServersJSON,
 		userScope:          true,
+		skillRoots: skillTargetRoots{
+			project: defaultProjectSkillRoot(".claude", "skills"),
+			user:    defaultHomeSkillRoot(".claude", "skills"),
+		},
 	},
 	{
 		target:             codex.Target,
 		syncAdapter:        codex.Adapter{},
 		ringConfigRenderer: renderCodexTOML,
+		skillRoots: skillTargetRoots{
+			project: defaultProjectSkillRoot(".agents", "skills"),
+			user:    defaultHomeSkillRoot(".agents", "skills"),
+		},
 	},
 	{
 		target:             gemini.Target,
 		syncAdapter:        gemini.Adapter{},
 		ringConfigRenderer: renderMCPServersJSON,
 		userScope:          true,
+		skillRoots: skillTargetRoots{
+			project: defaultProjectSkillRoot(".gemini", "skills"),
+			user:    defaultHomeSkillRoot(".gemini", "skills"),
+		},
 	},
 	{
 		target:             vibe.Target,
 		syncAdapter:        vibe.Adapter{},
 		ringConfigRenderer: renderVibeTOML,
+		skillRoots: skillTargetRoots{
+			project: defaultProjectSkillRoot(".vibe", "skills"),
+			user:    defaultHomeSkillRoot(".vibe", "skills"),
+		},
 	},
 }
 
@@ -95,4 +112,15 @@ func sortedClientTargetNames() []string {
 	}
 	sort.Strings(names)
 	return names
+}
+
+func supportedSkillTargets() []string {
+	targets := []string{}
+	for _, ct := range clientTargets {
+		if ct.skillRoots.supported() {
+			targets = append(targets, ct.target)
+		}
+	}
+	sort.Strings(targets)
+	return targets
 }

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -1779,6 +1779,8 @@ func printHelp(out io.Writer) {
 	fmt.Fprintln(out, "  madari sync claude-code --dry-run")
 	fmt.Fprintln(out, "  madari skill add release --file SKILL.md")
 	fmt.Fprintln(out, "  madari skill render release")
+	fmt.Fprintln(out, "  madari skill render release --client codex")
+	fmt.Fprintln(out, "  madari skill attach release codex --dry-run")
 	fmt.Fprintln(out, "  madari export --file madari-snapshot.json")
 	fmt.Fprintln(out, "  madari import --file madari-snapshot.json")
 	fmt.Fprintln(out, "  madari import --file madari-snapshot.json --apply")

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -556,6 +556,133 @@ func TestRunWithStoreSkillAttachLifecycle(t *testing.T) {
 	}
 }
 
+func TestRunWithStoreSkillAttachAllowsSameSkillAcrossRoots(t *testing.T) {
+	store := newTestStore(t)
+	tmp := t.TempDir()
+	path := writeSkillFile(t, tmp, "release.md", "# Release\n")
+	if result := runCmd(store, "skill", "add", "release", "--file", path, "--description", "Release workflow"); result.code != 0 {
+		t.Fatalf("skill add failed: %s", result.stderr)
+	}
+
+	rootA := filepath.Join(tmp, "project-a", "skills")
+	rootB := filepath.Join(tmp, "project-b", "skills")
+	if result := runCmd(store, "skill", "attach", "release", "codex", "--skills-dir", rootA); result.code != 0 {
+		t.Fatalf("first skill attach failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "skill", "attach", "release", "codex", "--skills-dir", rootB); result.code != 0 {
+		t.Fatalf("second root skill attach failed: %s", result.stderr)
+	}
+
+	statePath := filepath.Join(filepath.Dir(store.ServersDir()), "state", "codex-skills-managed.json")
+	state, err := loadSkillAttachmentState(statePath)
+	if err != nil {
+		t.Fatalf("load skill attachment state: %v", err)
+	}
+	if got := len(skillAttachmentsByName(state, "release")); got != 2 {
+		t.Fatalf("expected two release attachments, got %d: %+v", got, state)
+	}
+
+	result := runCmd(store, "skill", "detach", "release", "codex", "--skills-dir", rootA)
+	if result.code != 0 {
+		t.Fatalf("detach first root failed: %s", result.stderr)
+	}
+	if _, err := os.Stat(filepath.Join(rootA, "release", "SKILL.md")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected first root skill removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(rootB, "release", "SKILL.md")); err != nil {
+		t.Fatalf("expected second root skill to remain: %v", err)
+	}
+}
+
+func TestRunWithStoreSkillAttachVibeUserHonorsVibeHome(t *testing.T) {
+	store := newTestStore(t)
+	tmp := t.TempDir()
+	vibeHome := filepath.Join(tmp, "vibe-home")
+	t.Setenv("VIBE_HOME", vibeHome)
+
+	path := writeSkillFile(t, tmp, "release.md", "# Release\n")
+	if result := runCmd(store, "skill", "add", "release", "--file", path, "--description", "Release workflow"); result.code != 0 {
+		t.Fatalf("skill add failed: %s", result.stderr)
+	}
+
+	result := runCmd(store, "skill", "attach", "release", "vibe", "--scope", "user", "--dry-run")
+	if result.code != 0 {
+		t.Fatalf("skill attach dry-run failed: %s", result.stderr)
+	}
+	want := "skills_dir: " + filepath.Join(vibeHome, "skills")
+	if !strings.Contains(result.stdout, want) {
+		t.Fatalf("expected VIBE_HOME skill root %q, got:\n%s", want, result.stdout)
+	}
+}
+
+func TestRunWithStoreSkillAttachRollsBackAddedFileWhenStateWriteFails(t *testing.T) {
+	store := newTestStore(t)
+	tmp := t.TempDir()
+	path := writeSkillFile(t, tmp, "release.md", "# Release\n")
+	if result := runCmd(store, "skill", "add", "release", "--file", path, "--description", "Release workflow"); result.code != 0 {
+		t.Fatalf("skill add failed: %s", result.stderr)
+	}
+
+	original := saveSkillAttachmentStateFunc
+	saveSkillAttachmentStateFunc = func(string, map[string]skillAttachmentEntry) error {
+		return errors.New("state save failed")
+	}
+	t.Cleanup(func() {
+		saveSkillAttachmentStateFunc = original
+	})
+
+	skillsDir := filepath.Join(tmp, "skills")
+	result := runCmd(store, "skill", "attach", "release", "codex", "--skills-dir", skillsDir)
+	if result.code == 0 || !strings.Contains(result.stderr, "state save failed") {
+		t.Fatalf("expected state save failure, code=%d stderr=%s", result.code, result.stderr)
+	}
+	if _, err := os.Stat(filepath.Join(skillsDir, "release", "SKILL.md")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected added skill file rolled back, stat err=%v", err)
+	}
+}
+
+func TestRunWithStoreSkillAttachRestoresUpdatedFileWhenStateWriteFails(t *testing.T) {
+	store := newTestStore(t)
+	tmp := t.TempDir()
+	path := writeSkillFile(t, tmp, "release.md", "# Release\n")
+	if result := runCmd(store, "skill", "add", "release", "--file", path, "--description", "Release workflow"); result.code != 0 {
+		t.Fatalf("skill add failed: %s", result.stderr)
+	}
+	skillsDir := filepath.Join(tmp, "skills")
+	if result := runCmd(store, "skill", "attach", "release", "codex", "--skills-dir", skillsDir); result.code != 0 {
+		t.Fatalf("initial skill attach failed: %s", result.stderr)
+	}
+	skillPath := filepath.Join(skillsDir, "release", "SKILL.md")
+	originalContent, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("read initial skill file: %v", err)
+	}
+
+	updatedPath := writeSkillFile(t, tmp, "release-updated.md", "# Release\n\nUpdated.\n")
+	if result := runCmd(store, "skill", "update", "release", "--file", updatedPath); result.code != 0 {
+		t.Fatalf("skill update failed: %s", result.stderr)
+	}
+	original := saveSkillAttachmentStateFunc
+	saveSkillAttachmentStateFunc = func(string, map[string]skillAttachmentEntry) error {
+		return errors.New("state save failed")
+	}
+	t.Cleanup(func() {
+		saveSkillAttachmentStateFunc = original
+	})
+
+	result := runCmd(store, "skill", "attach", "release", "codex", "--skills-dir", skillsDir)
+	if result.code == 0 || !strings.Contains(result.stderr, "state save failed") {
+		t.Fatalf("expected state save failure, code=%d stderr=%s", result.code, result.stderr)
+	}
+	restored, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("read restored skill file: %v", err)
+	}
+	if string(restored) != string(originalContent) {
+		t.Fatalf("expected original skill file restored:\nwant:\n%s\ngot:\n%s", originalContent, restored)
+	}
+}
+
 func TestRunWithStoreSkillAttachRefusesUnmanagedFile(t *testing.T) {
 	store := newTestStore(t)
 	path := writeSkillFile(t, t.TempDir(), "release.md", "# Release\n")

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -436,6 +436,223 @@ func TestRunWithStoreSkillJSONOutputs(t *testing.T) {
 	}
 }
 
+func TestRunWithStoreSkillClientRenderNormalizesFrontmatter(t *testing.T) {
+	store := newTestStore(t)
+	source := `---
+name: old-release
+description: Source release workflow
+allowed-tools:
+  - Read
+---
+
+# Release
+Cut a patch release.
+`
+	path := writeSkillFile(t, t.TempDir(), "release.md", source)
+	if result := runCmd(store, "skill", "add", "release", "--file", path); result.code != 0 {
+		t.Fatalf("skill add failed: %s", result.stderr)
+	}
+
+	result := runCmd(store, "skill", "render", "release", "--client", "codex")
+	if result.code != 0 {
+		t.Fatalf("skill render --client failed: %s", result.stderr)
+	}
+	for _, want := range []string{
+		`name: "release"`,
+		`description: "Source release workflow"`,
+		"allowed-tools:\n  - Read",
+		"# Release\nCut a patch release.",
+	} {
+		if !strings.Contains(result.stdout, want) {
+			t.Fatalf("expected %q in client render:\n%s", want, result.stdout)
+		}
+	}
+	if strings.Contains(result.stdout, "old-release") || strings.Count(result.stdout, "description:") != 1 {
+		t.Fatalf("expected normalized frontmatter, got:\n%s", result.stdout)
+	}
+
+	generic := runCmd(store, "skill", "render", "release")
+	if generic.code != 0 {
+		t.Fatalf("generic render failed: %s", generic.stderr)
+	}
+	if generic.stdout != source {
+		t.Fatalf("generic render should remain exact, got:\n%s", generic.stdout)
+	}
+}
+
+func TestRunWithStoreSkillAttachDryRunWritesNothing(t *testing.T) {
+	store := newTestStore(t)
+	path := writeSkillFile(t, t.TempDir(), "release.md", "# Release\n")
+	if result := runCmd(store, "skill", "add", "release", "--file", path, "--description", "Release workflow"); result.code != 0 {
+		t.Fatalf("skill add failed: %s", result.stderr)
+	}
+
+	skillsDir := filepath.Join(t.TempDir(), "skills")
+	result := runCmd(store, "skill", "attach", "release", "codex", "--skills-dir", skillsDir, "--dry-run")
+	if result.code != 0 {
+		t.Fatalf("skill attach --dry-run failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "dry-run: true") || !strings.Contains(result.stdout, "added: release") {
+		t.Fatalf("expected dry-run add summary, got:\n%s", result.stdout)
+	}
+	if _, err := os.Stat(filepath.Join(skillsDir, "release", "SKILL.md")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("dry-run should not write skill file, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(store.ServersDir()), "state", "codex-skills-managed.json")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("dry-run should not write state file, stat err=%v", err)
+	}
+}
+
+func TestRunWithStoreSkillAttachLifecycle(t *testing.T) {
+	store := newTestStore(t)
+	tmp := t.TempDir()
+	path := writeSkillFile(t, tmp, "release.md", "# Release\n")
+	if result := runCmd(store, "skill", "add", "release", "--file", path, "--description", "Release workflow"); result.code != 0 {
+		t.Fatalf("skill add failed: %s", result.stderr)
+	}
+
+	skillsDir := filepath.Join(tmp, "skills")
+	result := runCmd(store, "skill", "attach", "release", "codex", "--skills-dir", skillsDir)
+	if result.code != 0 {
+		t.Fatalf("skill attach failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "added: release") {
+		t.Fatalf("expected add summary, got:\n%s", result.stdout)
+	}
+	skillPath := filepath.Join(skillsDir, "release", "SKILL.md")
+	payload, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("expected attached skill file: %v", err)
+	}
+	if !strings.Contains(string(payload), `name: "release"`) || !strings.Contains(string(payload), "# Release") {
+		t.Fatalf("unexpected attached skill file:\n%s", payload)
+	}
+
+	result = runCmd(store, "skill", "attach", "release", "codex", "--skills-dir", skillsDir)
+	if result.code != 0 {
+		t.Fatalf("second skill attach failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "unchanged: release") {
+		t.Fatalf("expected unchanged summary, got:\n%s", result.stdout)
+	}
+
+	updatedPath := writeSkillFile(t, tmp, "release-updated.md", "# Release\n\nUpdated.\n")
+	if result := runCmd(store, "skill", "update", "release", "--file", updatedPath); result.code != 0 {
+		t.Fatalf("skill update failed: %s", result.stderr)
+	}
+	result = runCmd(store, "skill", "attach", "release", "codex", "--skills-dir", skillsDir)
+	if result.code != 0 {
+		t.Fatalf("skill attach update failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "updated: release") {
+		t.Fatalf("expected updated summary, got:\n%s", result.stdout)
+	}
+	payload, err = os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("read updated attached skill: %v", err)
+	}
+	if !strings.Contains(string(payload), "Updated.") {
+		t.Fatalf("expected attached skill update, got:\n%s", payload)
+	}
+}
+
+func TestRunWithStoreSkillAttachRefusesUnmanagedFile(t *testing.T) {
+	store := newTestStore(t)
+	path := writeSkillFile(t, t.TempDir(), "release.md", "# Release\n")
+	if result := runCmd(store, "skill", "add", "release", "--file", path, "--description", "Release workflow"); result.code != 0 {
+		t.Fatalf("skill add failed: %s", result.stderr)
+	}
+
+	skillsDir := filepath.Join(t.TempDir(), "skills")
+	skillPath := filepath.Join(skillsDir, "release", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(skillPath), 0o755); err != nil {
+		t.Fatalf("mkdir unmanaged skill dir: %v", err)
+	}
+	if err := os.WriteFile(skillPath, []byte("# Unmanaged\n"), 0o644); err != nil {
+		t.Fatalf("write unmanaged skill: %v", err)
+	}
+	result := runCmd(store, "skill", "attach", "release", "codex", "--skills-dir", skillsDir)
+	if result.code == 0 || !strings.Contains(result.stderr, "refusing to overwrite unmanaged skill file") {
+		t.Fatalf("expected unmanaged conflict, code=%d stderr=%s", result.code, result.stderr)
+	}
+}
+
+func TestRunWithStoreSkillDetachRemovesOwnedFileOnly(t *testing.T) {
+	store := newTestStore(t)
+	tmp := t.TempDir()
+	path := writeSkillFile(t, tmp, "release.md", "# Release\n")
+	if result := runCmd(store, "skill", "add", "release", "--file", path, "--description", "Release workflow"); result.code != 0 {
+		t.Fatalf("skill add failed: %s", result.stderr)
+	}
+	skillsDir := filepath.Join(tmp, "skills")
+	if result := runCmd(store, "skill", "attach", "release", "codex", "--skills-dir", skillsDir); result.code != 0 {
+		t.Fatalf("skill attach failed: %s", result.stderr)
+	}
+	skillDir := filepath.Join(skillsDir, "release")
+	skillPath := filepath.Join(skillDir, "SKILL.md")
+	assetPath := filepath.Join(skillDir, "reference.md")
+	if err := os.WriteFile(assetPath, []byte("supporting file\n"), 0o644); err != nil {
+		t.Fatalf("write supporting file: %v", err)
+	}
+
+	result := runCmd(store, "skill", "detach", "release", "codex", "--skills-dir", skillsDir)
+	if result.code != 0 {
+		t.Fatalf("skill detach failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "removed: release") {
+		t.Fatalf("expected removed summary, got:\n%s", result.stdout)
+	}
+	if _, err := os.Stat(skillPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected SKILL.md removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(assetPath); err != nil {
+		t.Fatalf("supporting file should remain: %v", err)
+	}
+
+	result = runCmd(store, "skill", "detach", "release", "codex", "--skills-dir", skillsDir)
+	if result.code != 0 || !strings.Contains(result.stdout, "unchanged: release") {
+		t.Fatalf("expected idempotent detach, code=%d stdout=%s stderr=%s", result.code, result.stdout, result.stderr)
+	}
+}
+
+func TestRunWithStoreSkillDetachRefusesModifiedFile(t *testing.T) {
+	store := newTestStore(t)
+	tmp := t.TempDir()
+	path := writeSkillFile(t, tmp, "release.md", "# Release\n")
+	if result := runCmd(store, "skill", "add", "release", "--file", path, "--description", "Release workflow"); result.code != 0 {
+		t.Fatalf("skill add failed: %s", result.stderr)
+	}
+	skillsDir := filepath.Join(tmp, "skills")
+	if result := runCmd(store, "skill", "attach", "release", "codex", "--skills-dir", skillsDir); result.code != 0 {
+		t.Fatalf("skill attach failed: %s", result.stderr)
+	}
+	skillPath := filepath.Join(skillsDir, "release", "SKILL.md")
+	if err := os.WriteFile(skillPath, []byte("# User edit\n"), 0o644); err != nil {
+		t.Fatalf("modify attached skill: %v", err)
+	}
+
+	result := runCmd(store, "skill", "detach", "release", "codex", "--skills-dir", skillsDir)
+	if result.code == 0 || !strings.Contains(result.stderr, "refusing to remove modified skill file") {
+		t.Fatalf("expected modified-file refusal, code=%d stderr=%s", result.code, result.stderr)
+	}
+}
+
+func TestRunWithStoreSkillRemoveRefusesAttachedSkill(t *testing.T) {
+	store := newTestStore(t)
+	path := writeSkillFile(t, t.TempDir(), "release.md", "# Release\n")
+	if result := runCmd(store, "skill", "add", "release", "--file", path, "--description", "Release workflow"); result.code != 0 {
+		t.Fatalf("skill add failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "skill", "attach", "release", "codex", "--skills-dir", filepath.Join(t.TempDir(), "skills")); result.code != 0 {
+		t.Fatalf("skill attach failed: %s", result.stderr)
+	}
+
+	result := runCmd(store, "skill", "remove", "release")
+	if result.code == 0 || !strings.Contains(result.stderr, "skill \"release\" is still attached") || !strings.Contains(result.stderr, "madari skill detach release codex") {
+		t.Fatalf("expected attached-skill removal refusal, code=%d stderr=%s", result.code, result.stderr)
+	}
+}
+
 func TestRunWithStoreSkillValidatesInputs(t *testing.T) {
 	store := newTestStore(t)
 	tmp := t.TempDir()
@@ -1518,6 +1735,9 @@ func TestClientTargetRegistryDefinesCurrentCapabilities(t *testing.T) {
 	}
 	if got := userScopedSyncTargets(); !reflect.DeepEqual(got, []string{"claude-code", "gemini"}) {
 		t.Fatalf("unexpected user-scoped targets: got %#v", got)
+	}
+	if got := supportedSkillTargets(); !reflect.DeepEqual(got, []string{"claude-code", "codex", "gemini", "vibe"}) {
+		t.Fatalf("unexpected skill targets: got %#v", got)
 	}
 	if got := defaultInstallClientTarget(); got != "claude-desktop" {
 		t.Fatalf("unexpected default install client target: %q", got)

--- a/cmd/madari/skill.go
+++ b/cmd/madari/skill.go
@@ -9,12 +9,13 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/ankitvg/madari/internal/clients"
 	"github.com/ankitvg/madari/internal/registry"
 )
 
 func (a cliApp) cmdSkill(args []string) error {
 	if len(args) == 0 {
-		return commandUsageError("skill", "madari skill <add|update|remove|list|show|render> [options]")
+		return commandUsageError("skill", "madari skill <add|update|remove|list|show|render|attach|detach> [options]")
 	}
 	if isHelpToken(args[0]) {
 		printSkillHelp(a.stdout)
@@ -35,8 +36,12 @@ func (a cliApp) cmdSkill(args []string) error {
 		return a.cmdSkillShow(rest)
 	case "render":
 		return a.cmdSkillRender(rest)
+	case "attach":
+		return a.cmdSkillAttach(rest)
+	case "detach":
+		return a.cmdSkillDetach(rest)
 	default:
-		return commandInputError("skill", fmt.Sprintf("unknown skill subcommand %q (supported: add, update, remove, list, show, render)", sub))
+		return commandInputError("skill", fmt.Sprintf("unknown skill subcommand %q (supported: add, update, remove, list, show, render, attach, detach)", sub))
 	}
 }
 
@@ -145,6 +150,9 @@ func (a cliApp) cmdSkillRemove(args []string) error {
 	}
 
 	name := strings.TrimSpace(fs.Arg(0))
+	if err := a.ensureSkillNotAttached(name); err != nil {
+		return err
+	}
 	if err := a.store.RemoveSkill(name); err != nil {
 		if errors.Is(err, registry.ErrSkillNotFound) {
 			return fmt.Errorf("skill %q not found", name)
@@ -258,7 +266,7 @@ func (a cliApp) cmdSkillShow(args []string) error {
 
 func (a cliApp) cmdSkillRender(args []string) error {
 	if len(args) == 0 {
-		return commandUsageError("skill render", "madari skill render <name>")
+		return commandUsageError("skill render", "madari skill render <name> [--client <target>]")
 	}
 	if isHelpToken(args[0]) {
 		printSkillRenderHelp(a.stdout)
@@ -268,6 +276,8 @@ func (a cliApp) cmdSkillRender(args []string) error {
 
 	fs := flag.NewFlagSet("skill render", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
+	var target string
+	fs.StringVar(&target, "client", "", "Render native SKILL.md for target client")
 	if err := fs.Parse(args[1:]); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			printSkillRenderHelp(a.stdout)
@@ -279,7 +289,8 @@ func (a cliApp) cmdSkillRender(args []string) error {
 		return commandUnexpectedArgsError("skill render", fs.Args())
 	}
 
-	if _, err := a.store.GetSkill(name); err != nil {
+	skill, err := a.store.GetSkill(name)
+	if err != nil {
 		if errors.Is(err, registry.ErrSkillNotFound) {
 			return fmt.Errorf("skill %q not found", name)
 		}
@@ -292,8 +303,102 @@ func (a cliApp) cmdSkillRender(args []string) error {
 		}
 		return err
 	}
+	target = strings.TrimSpace(target)
+	if target != "" {
+		if _, err := skillTargetByName(target); err != nil {
+			return err
+		}
+		rendered, err := renderClientSkill(skill, content)
+		if err != nil {
+			return err
+		}
+		_, err = a.stdout.Write(rendered.Content)
+		return err
+	}
 	_, err = a.stdout.Write(content)
 	return err
+}
+
+func (a cliApp) cmdSkillAttach(args []string) error {
+	name, target, scope, skillsDir, dryRun, err := a.parseSkillAttachArgs(
+		"skill attach",
+		args,
+		"madari skill attach <name> <client> [--scope project|user] [--skills-dir <dir>] [--dry-run]",
+		printSkillAttachHelp,
+	)
+	if errors.Is(err, errSkillHelpShown) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	result, err := a.attachSkill(name, target, scope, skillsDir, dryRun)
+	if err != nil {
+		return err
+	}
+	printSkillAttachSummary(a.stdout, target, scope, result)
+	return nil
+}
+
+func (a cliApp) cmdSkillDetach(args []string) error {
+	name, target, scope, skillsDir, dryRun, err := a.parseSkillAttachArgs(
+		"skill detach",
+		args,
+		"madari skill detach <name> <client> [--scope project|user] [--skills-dir <dir>] [--dry-run]",
+		printSkillDetachHelp,
+	)
+	if errors.Is(err, errSkillHelpShown) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	result, err := a.detachSkill(name, target, scope, skillsDir, dryRun)
+	if err != nil {
+		return err
+	}
+	printSkillAttachSummary(a.stdout, target, scope, result)
+	return nil
+}
+
+var errSkillHelpShown = errors.New("skill help shown")
+
+func (a cliApp) parseSkillAttachArgs(command string, args []string, usage string, printHelp func(io.Writer)) (name, target, scope, skillsDir string, dryRun bool, err error) {
+	if len(args) > 0 && isHelpToken(args[0]) {
+		printHelp(a.stdout)
+		return "", "", "", "", false, errSkillHelpShown
+	}
+	if len(args) < 2 {
+		return "", "", "", "", false, commandUsageError(command, usage)
+	}
+	name = strings.TrimSpace(args[0])
+	target = strings.TrimSpace(args[1])
+
+	fs := flag.NewFlagSet(command, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.StringVar(&scope, "scope", "", "Skill target scope: project (default) or user")
+	fs.StringVar(&skillsDir, "skills-dir", "", "Override skill root directory")
+	fs.BoolVar(&dryRun, "dry-run", false, "Preview changes without writing files")
+	if err := fs.Parse(args[2:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printHelp(a.stdout)
+			return "", "", "", "", false, errSkillHelpShown
+		}
+		return "", "", "", "", false, commandInputError(command, err.Error())
+	}
+	if fs.NArg() != 0 {
+		return "", "", "", "", false, commandUnexpectedArgsError(command, fs.Args())
+	}
+	scope = strings.TrimSpace(scope)
+	if scope != "" && scope != clients.ScopeProject && scope != clients.ScopeUser {
+		return "", "", "", "", false, commandInputError(command, fmt.Sprintf("unknown scope %q (supported: %s, %s)", scope, clients.ScopeProject, clients.ScopeUser))
+	}
+	if _, err := skillTargetByName(target); err != nil {
+		return "", "", "", "", false, err
+	}
+	return name, target, scope, skillsDir, dryRun, nil
 }
 
 func readSkillSourceFile(path string) ([]byte, error) {
@@ -333,11 +438,13 @@ func printSkillHelp(out io.Writer) {
 	fmt.Fprintln(out, "  list      List configured skills")
 	fmt.Fprintln(out, "  show      Show one skill's metadata")
 	fmt.Fprintln(out, "  render    Print one skill's Markdown instructions")
+	fmt.Fprintln(out, "  attach    Materialize a skill into a client skill directory")
+	fmt.Fprintln(out, "  detach    Remove a materialized Madari-owned client skill")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Description:")
 	fmt.Fprintln(out, "  Skills are standalone Markdown instructions that teach a model about")
-	fmt.Fprintln(out, "  a domain or workflow. V1 stores and renders skills only; rings, run,")
-	fmt.Fprintln(out, "  and client config writers do not consume skills yet.")
+	fmt.Fprintln(out, "  a domain or workflow. Generic render prints the managed Markdown exactly;")
+	fmt.Fprintln(out, "  client render and attach synthesize native SKILL.md frontmatter.")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Run `madari skill <subcommand> --help` for subcommand help.")
 }
@@ -373,7 +480,8 @@ func printSkillRemoveHelp(out io.Writer) {
 	fmt.Fprintln(out, "  madari skill remove <name>")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Description:")
-	fmt.Fprintln(out, "  Remove a standalone skill from Madari's registry.")
+	fmt.Fprintln(out, "  Remove a standalone skill from Madari's registry. Refuses while the")
+	fmt.Fprintln(out, "  skill is still attached to any client skill directory.")
 }
 
 func printSkillListHelp(out io.Writer) {
@@ -400,9 +508,44 @@ func printSkillShowHelp(out io.Writer) {
 
 func printSkillRenderHelp(out io.Writer) {
 	fmt.Fprintln(out, "Usage:")
-	fmt.Fprintln(out, "  madari skill render <name>")
+	fmt.Fprintln(out, "  madari skill render <name> [--client <target>]")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Options:")
+	fmt.Fprintln(out, "  --client <target>          Render native SKILL.md for a client")
+	fmt.Fprintf(out, "                            Supported skill targets: %s\n", strings.Join(supportedSkillTargets(), ", "))
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Description:")
 	fmt.Fprintln(out, "  Print the managed Markdown instructions for a standalone skill to")
-	fmt.Fprintln(out, "  stdout exactly. Render mutates no state and writes no client files.")
+	fmt.Fprintln(out, "  stdout exactly. With --client, synthesize native SKILL.md frontmatter")
+	fmt.Fprintln(out, "  for preview or piping. Render mutates no state and writes no client files.")
+}
+
+func printSkillAttachHelp(out io.Writer) {
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  madari skill attach <name> <client> [--scope project|user] [--skills-dir <dir>] [--dry-run]")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Options:")
+	fmt.Fprintln(out, "  --scope project|user       Skill scope (default: project)")
+	fmt.Fprintln(out, "  --skills-dir <dir>         Override skill root directory")
+	fmt.Fprintln(out, "  --dry-run                  Preview changes without writing files")
+	fmt.Fprintf(out, "                            Supported skill targets: %s\n", strings.Join(supportedSkillTargets(), ", "))
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Description:")
+	fmt.Fprintln(out, "  Materialize a managed skill as <skills-dir>/<name>/SKILL.md using")
+	fmt.Fprintln(out, "  client-native YAML frontmatter. Refuses to overwrite unmanaged files.")
+}
+
+func printSkillDetachHelp(out io.Writer) {
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  madari skill detach <name> <client> [--scope project|user] [--skills-dir <dir>] [--dry-run]")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Options:")
+	fmt.Fprintln(out, "  --scope project|user       Skill scope (default: project)")
+	fmt.Fprintln(out, "  --skills-dir <dir>         Override skill root directory")
+	fmt.Fprintln(out, "  --dry-run                  Preview changes without writing files")
+	fmt.Fprintf(out, "                            Supported skill targets: %s\n", strings.Join(supportedSkillTargets(), ", "))
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Description:")
+	fmt.Fprintln(out, "  Remove a Madari-owned materialized SKILL.md. Detach refuses to delete")
+	fmt.Fprintln(out, "  files modified since Madari last wrote them.")
 }

--- a/cmd/madari/skill_materialize.go
+++ b/cmd/madari/skill_materialize.go
@@ -1,0 +1,373 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/ankitvg/madari/internal/clients"
+	"github.com/ankitvg/madari/internal/clients/syncshared"
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+type skillRootResolver func() (string, error)
+
+type skillTargetRoots struct {
+	project skillRootResolver
+	user    skillRootResolver
+}
+
+func (r skillTargetRoots) supported() bool {
+	return r.project != nil && r.user != nil
+}
+
+func (r skillTargetRoots) resolve(scope, override string) (string, error) {
+	if strings.TrimSpace(override) != "" {
+		return syncshared.ResolvePath(override, nil)
+	}
+	switch strings.TrimSpace(scope) {
+	case "", clients.ScopeProject:
+		if r.project == nil {
+			return "", errors.New("project skill root is not configured")
+		}
+		return r.project()
+	case clients.ScopeUser:
+		if r.user == nil {
+			return "", errors.New("user skill root is not configured")
+		}
+		return r.user()
+	default:
+		return "", fmt.Errorf("unknown scope %q (supported: %s, %s)", scope, clients.ScopeProject, clients.ScopeUser)
+	}
+}
+
+func defaultProjectSkillRoot(parts ...string) skillRootResolver {
+	return func() (string, error) {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("resolve current directory: %w", err)
+		}
+		return filepath.Join(append([]string{cwd}, parts...)...), nil
+	}
+}
+
+func defaultHomeSkillRoot(parts ...string) skillRootResolver {
+	return func() (string, error) {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve user home: %w", err)
+		}
+		return filepath.Join(append([]string{home}, parts...)...), nil
+	}
+}
+
+type renderedSkill struct {
+	Content    []byte
+	SourceDesc string
+}
+
+func renderClientSkill(skill registry.Skill, content []byte) (renderedSkill, error) {
+	if err := skill.Validate(); err != nil {
+		return renderedSkill{}, err
+	}
+
+	fm, body := splitSkillFrontmatter(content)
+	sourceDescription := frontmatterDescription(fm)
+	description := strings.TrimSpace(skill.Description)
+	if description == "" {
+		description = sourceDescription
+	}
+	if strings.TrimSpace(description) == "" {
+		return renderedSkill{}, fmt.Errorf("skill %q requires a description for client-native render", skill.Name)
+	}
+
+	body = bytes.TrimLeft(body, "\r\n")
+	if strings.TrimSpace(string(body)) == "" {
+		return renderedSkill{}, fmt.Errorf("skill %q content is empty after frontmatter normalization", skill.Name)
+	}
+
+	extras := frontmatterExtraLines(fm)
+	var out bytes.Buffer
+	out.WriteString("---\n")
+	fmt.Fprintf(&out, "name: %s\n", yamlDoubleQuoted(skill.Name))
+	fmt.Fprintf(&out, "description: %s\n", yamlDoubleQuoted(description))
+	for _, line := range extras {
+		out.WriteString(line)
+		out.WriteByte('\n')
+	}
+	out.WriteString("---\n\n")
+	out.Write(body)
+	return renderedSkill{Content: out.Bytes(), SourceDesc: sourceDescription}, nil
+}
+
+func splitSkillFrontmatter(content []byte) ([]string, []byte) {
+	text := string(content)
+	if !strings.HasPrefix(text, "---\n") && !strings.HasPrefix(text, "---\r\n") {
+		return nil, content
+	}
+
+	lines := splitLinesWithEndings(text)
+	if len(lines) == 0 || strings.TrimRight(lines[0], "\r\n") != "---" {
+		return nil, content
+	}
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimRight(lines[i], "\r\n") != "---" {
+			continue
+		}
+		frontmatter := make([]string, 0, i-1)
+		for _, line := range lines[1:i] {
+			frontmatter = append(frontmatter, strings.TrimRight(line, "\r\n"))
+		}
+		body := []byte(strings.Join(lines[i+1:], ""))
+		return frontmatter, body
+	}
+	return nil, content
+}
+
+func splitLinesWithEndings(text string) []string {
+	if text == "" {
+		return nil
+	}
+	lines := []string{}
+	start := 0
+	for i := 0; i < len(text); i++ {
+		if text[i] != '\n' {
+			continue
+		}
+		lines = append(lines, text[start:i+1])
+		start = i + 1
+	}
+	if start < len(text) {
+		lines = append(lines, text[start:])
+	}
+	return lines
+}
+
+var yamlTopLevelKeyPattern = regexp.MustCompile(`^([A-Za-z0-9_-]+)\s*:(.*)$`)
+
+func frontmatterDescription(lines []string) string {
+	for i := 0; i < len(lines); i++ {
+		key, value, ok := yamlTopLevelKey(lines[i])
+		if !ok || key != "description" {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		switch value {
+		case "", "|", ">":
+			collected := collectIndentedYAMLValue(lines[i+1:])
+			if value == "|" {
+				return strings.TrimSpace(strings.Join(collected, "\n"))
+			}
+			return strings.TrimSpace(strings.Join(collected, " "))
+		default:
+			return strings.TrimSpace(unquoteYAMLScalar(value))
+		}
+	}
+	return ""
+}
+
+func frontmatterExtraLines(lines []string) []string {
+	extras := []string{}
+	for i := 0; i < len(lines); {
+		key, _, ok := yamlTopLevelKey(lines[i])
+		if ok && (key == "name" || key == "description") {
+			i++
+			for i < len(lines) {
+				if _, _, next := yamlTopLevelKey(lines[i]); next {
+					break
+				}
+				if strings.TrimSpace(lines[i]) == "" || strings.HasPrefix(lines[i], " ") || strings.HasPrefix(lines[i], "\t") || strings.HasPrefix(strings.TrimSpace(lines[i]), "#") {
+					i++
+					continue
+				}
+				break
+			}
+			continue
+		}
+		extras = append(extras, lines[i])
+		i++
+	}
+	for len(extras) > 0 && strings.TrimSpace(extras[0]) == "" {
+		extras = extras[1:]
+	}
+	for len(extras) > 0 && strings.TrimSpace(extras[len(extras)-1]) == "" {
+		extras = extras[:len(extras)-1]
+	}
+	return extras
+}
+
+func yamlTopLevelKey(line string) (key, value string, ok bool) {
+	if strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t") {
+		return "", "", false
+	}
+	match := yamlTopLevelKeyPattern.FindStringSubmatch(line)
+	if match == nil {
+		return "", "", false
+	}
+	return match[1], match[2], true
+}
+
+func collectIndentedYAMLValue(lines []string) []string {
+	values := []string{}
+	for _, line := range lines {
+		if _, _, ok := yamlTopLevelKey(line); ok {
+			break
+		}
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		values = append(values, strings.TrimSpace(line))
+	}
+	return values
+}
+
+func unquoteYAMLScalar(value string) string {
+	if len(value) >= 2 {
+		if value[0] == '"' && value[len(value)-1] == '"' {
+			if out, err := strconvUnquote(value); err == nil {
+				return out
+			}
+		}
+		if value[0] == '\'' && value[len(value)-1] == '\'' {
+			return strings.ReplaceAll(value[1:len(value)-1], "''", "'")
+		}
+	}
+	return value
+}
+
+func yamlDoubleQuoted(value string) string {
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range value {
+		switch r {
+		case '\\':
+			b.WriteString(`\\`)
+		case '"':
+			b.WriteString(`\"`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		default:
+			if r < 0x20 {
+				fmt.Fprintf(&b, `\u%04X`, r)
+				continue
+			}
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+func strconvUnquote(value string) (string, error) {
+	var out strings.Builder
+	escaped := false
+	for i := 1; i < len(value)-1; i++ {
+		ch := value[i]
+		if escaped {
+			switch ch {
+			case 'n':
+				out.WriteByte('\n')
+			case 'r':
+				out.WriteByte('\r')
+			case 't':
+				out.WriteByte('\t')
+			default:
+				out.WriteByte(ch)
+			}
+			escaped = false
+			continue
+		}
+		if ch == '\\' {
+			escaped = true
+			continue
+		}
+		out.WriteByte(ch)
+	}
+	if escaped {
+		out.WriteByte('\\')
+	}
+	return out.String(), nil
+}
+
+const skillAttachmentStateVersion = 1
+
+type skillAttachmentEntry struct {
+	Path string `json:"path"`
+	Hash string `json:"hash"`
+}
+
+type skillAttachmentStateFile struct {
+	Version int                             `json:"version"`
+	Skills  map[string]skillAttachmentEntry `json:"skills"`
+}
+
+func loadSkillAttachmentState(path string) (map[string]skillAttachmentEntry, error) {
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]skillAttachmentEntry{}, nil
+		}
+		return nil, fmt.Errorf("read skill attachment state %q: %w", path, err)
+	}
+	state := skillAttachmentStateFile{}
+	if err := json.Unmarshal(payload, &state); err != nil {
+		return nil, fmt.Errorf("parse skill attachment state JSON: %w", err)
+	}
+	if state.Version != skillAttachmentStateVersion {
+		return nil, fmt.Errorf("unsupported skill attachment state version %d in %q", state.Version, path)
+	}
+	return normalizeSkillAttachmentState(state.Skills), nil
+}
+
+func saveSkillAttachmentState(path string, skills map[string]skillAttachmentEntry) error {
+	state := skillAttachmentStateFile{
+		Version: skillAttachmentStateVersion,
+		Skills:  normalizeSkillAttachmentState(skills),
+	}
+	payload, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal skill attachment state JSON: %w", err)
+	}
+	payload = append(payload, '\n')
+	return syncshared.WriteFileAtomically(path, payload, 0o644)
+}
+
+func normalizeSkillAttachmentState(skills map[string]skillAttachmentEntry) map[string]skillAttachmentEntry {
+	normalized := make(map[string]skillAttachmentEntry, len(skills))
+	for name, entry := range skills {
+		name = strings.TrimSpace(name)
+		entry.Path = filepath.Clean(strings.TrimSpace(entry.Path))
+		entry.Hash = strings.TrimSpace(entry.Hash)
+		if name == "" || entry.Path == "." || entry.Hash == "" {
+			continue
+		}
+		normalized[name] = entry
+	}
+	return normalized
+}
+
+func skillContentHash(content []byte) string {
+	sum := sha256.Sum256(content)
+	return hex.EncodeToString(sum[:])
+}
+
+func sortedAttachedSkillNames(state map[string]skillAttachmentEntry) []string {
+	names := make([]string, 0, len(state))
+	for name := range state {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/cmd/madari/skill_materialize.go
+++ b/cmd/madari/skill_materialize.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -70,8 +71,260 @@ func defaultHomeSkillRoot(parts ...string) skillRootResolver {
 }
 
 type renderedSkill struct {
-	Content    []byte
-	SourceDesc string
+	Content []byte
+}
+
+type skillAttachResult struct {
+	SkillPath string
+	SkillsDir string
+	DryRun    bool
+	Added     []string
+	Updated   []string
+	Removed   []string
+	Unchanged []string
+}
+
+type skillAttachmentRef struct {
+	target string
+	scope  string
+	path   string
+}
+
+func skillTargetByName(target string) (clientTarget, error) {
+	ct, ok := clientTargetByName(target)
+	if !ok || !ct.skillRoots.supported() {
+		return clientTarget{}, commandInputError("skill", fmt.Sprintf("unsupported skill target %q (supported: %s)", target, strings.Join(supportedSkillTargets(), ", ")))
+	}
+	return ct, nil
+}
+
+func (a cliApp) skillAttachmentStatePath(target, scope string) string {
+	suffix := "-skills-managed.json"
+	if scope == clients.ScopeUser {
+		suffix = "-skills-user-managed.json"
+	}
+	return filepath.Join(filepath.Dir(a.store.ServersDir()), "state", target+suffix)
+}
+
+func (a cliApp) skillAttachmentRefs() []skillAttachmentRef {
+	refs := []skillAttachmentRef{}
+	for _, target := range supportedSkillTargets() {
+		refs = append(refs, skillAttachmentRef{
+			target: target,
+			path:   a.skillAttachmentStatePath(target, ""),
+		})
+		refs = append(refs, skillAttachmentRef{
+			target: target,
+			scope:  clients.ScopeUser,
+			path:   a.skillAttachmentStatePath(target, clients.ScopeUser),
+		})
+	}
+	return refs
+}
+
+func (a cliApp) ensureSkillNotAttached(name string) error {
+	holders := []skillAttachmentRef{}
+	for _, ref := range a.skillAttachmentRefs() {
+		state, err := loadSkillAttachmentState(ref.path)
+		if err != nil {
+			return err
+		}
+		if _, exists := state[name]; exists {
+			holders = append(holders, ref)
+		}
+	}
+	if len(holders) == 0 {
+		return nil
+	}
+
+	guidance := make([]string, 0, len(holders))
+	for _, holder := range holders {
+		command := fmt.Sprintf("madari skill detach %s %s", name, holder.target)
+		if holder.scope == clients.ScopeUser {
+			command += " --scope user"
+		}
+		guidance = append(guidance, command)
+	}
+	return fmt.Errorf("skill %q is still attached; detach first: %s", name, strings.Join(guidance, "; "))
+}
+
+func (a cliApp) attachSkill(name, target, scope, skillsDir string, dryRun bool) (skillAttachResult, error) {
+	ct, err := skillTargetByName(target)
+	if err != nil {
+		return skillAttachResult{}, err
+	}
+	skill, err := a.store.GetSkill(name)
+	if err != nil {
+		if errors.Is(err, registry.ErrSkillNotFound) {
+			return skillAttachResult{}, fmt.Errorf("skill %q not found", name)
+		}
+		return skillAttachResult{}, err
+	}
+	content, err := a.store.GetSkillContent(name)
+	if err != nil {
+		return skillAttachResult{}, err
+	}
+	rendered, err := renderClientSkill(skill, content)
+	if err != nil {
+		return skillAttachResult{}, err
+	}
+	root, err := ct.skillRoots.resolve(scope, skillsDir)
+	if err != nil {
+		return skillAttachResult{}, err
+	}
+	root = filepath.Clean(root)
+	skillPath := filepath.Join(root, name, "SKILL.md")
+	statePath := a.skillAttachmentStatePath(target, scope)
+	state, err := loadSkillAttachmentState(statePath)
+	if err != nil {
+		return skillAttachResult{}, err
+	}
+
+	desiredHash := skillContentHash(rendered.Content)
+	result := skillAttachResult{
+		SkillPath: skillPath,
+		SkillsDir: root,
+		DryRun:    dryRun,
+	}
+
+	entry, owned := state[name]
+	if owned {
+		if filepath.Clean(entry.Path) != skillPath {
+			return skillAttachResult{}, fmt.Errorf("skill %q is already attached to %s at %s; detach it before attaching to %s", name, target, entry.Path, skillPath)
+		}
+		current, readErr := os.ReadFile(skillPath)
+		switch {
+		case readErr == nil:
+			if skillContentHash(current) != entry.Hash {
+				return skillAttachResult{}, fmt.Errorf("refusing to update modified skill file %s; detach or restore it manually", skillPath)
+			}
+			if desiredHash == entry.Hash {
+				result.Unchanged = []string{name}
+			} else {
+				result.Updated = []string{name}
+			}
+		case errors.Is(readErr, os.ErrNotExist):
+			result.Added = []string{name}
+		default:
+			return skillAttachResult{}, fmt.Errorf("read skill file %s: %w", skillPath, readErr)
+		}
+	} else {
+		if _, statErr := os.Stat(skillPath); statErr == nil {
+			return skillAttachResult{}, fmt.Errorf("refusing to overwrite unmanaged skill file %s", skillPath)
+		} else if !errors.Is(statErr, os.ErrNotExist) {
+			return skillAttachResult{}, fmt.Errorf("inspect skill file %s: %w", skillPath, statErr)
+		}
+		result.Added = []string{name}
+	}
+
+	if dryRun || len(result.Unchanged) > 0 {
+		return result, nil
+	}
+	if err := syncshared.WriteFileAtomically(skillPath, rendered.Content, 0o644); err != nil {
+		return skillAttachResult{}, fmt.Errorf("write skill file %s: %w", skillPath, err)
+	}
+	state[name] = skillAttachmentEntry{Path: skillPath, Hash: desiredHash}
+	if err := saveSkillAttachmentState(statePath, state); err != nil {
+		return skillAttachResult{}, err
+	}
+	return result, nil
+}
+
+func (a cliApp) detachSkill(name, target, scope, skillsDir string, dryRun bool) (skillAttachResult, error) {
+	ct, err := skillTargetByName(target)
+	if err != nil {
+		return skillAttachResult{}, err
+	}
+	statePath := a.skillAttachmentStatePath(target, scope)
+	state, err := loadSkillAttachmentState(statePath)
+	if err != nil {
+		return skillAttachResult{}, err
+	}
+
+	entry, owned := state[name]
+	if !owned {
+		root, rootErr := ct.skillRoots.resolve(scope, skillsDir)
+		if rootErr != nil {
+			return skillAttachResult{}, rootErr
+		}
+		root = filepath.Clean(root)
+		return skillAttachResult{
+			SkillPath: filepath.Join(root, name, "SKILL.md"),
+			SkillsDir: root,
+			DryRun:    dryRun,
+			Unchanged: []string{name},
+		}, nil
+	}
+
+	skillPath := filepath.Clean(entry.Path)
+	if strings.TrimSpace(skillsDir) != "" {
+		root, err := ct.skillRoots.resolve(scope, skillsDir)
+		if err != nil {
+			return skillAttachResult{}, err
+		}
+		expected := filepath.Join(filepath.Clean(root), name, "SKILL.md")
+		if expected != skillPath {
+			return skillAttachResult{}, fmt.Errorf("skill %q is attached at %s, not %s", name, skillPath, expected)
+		}
+	}
+
+	root := filepath.Dir(filepath.Dir(skillPath))
+	result := skillAttachResult{
+		SkillPath: skillPath,
+		SkillsDir: root,
+		DryRun:    dryRun,
+		Removed:   []string{name},
+	}
+
+	current, readErr := os.ReadFile(skillPath)
+	switch {
+	case readErr == nil:
+		if skillContentHash(current) != entry.Hash {
+			return skillAttachResult{}, fmt.Errorf("refusing to remove modified skill file %s; remove it manually if desired", skillPath)
+		}
+	case errors.Is(readErr, os.ErrNotExist):
+		// Clear stale ownership state below.
+	default:
+		return skillAttachResult{}, fmt.Errorf("read skill file %s: %w", skillPath, readErr)
+	}
+
+	if dryRun {
+		return result, nil
+	}
+	if readErr == nil {
+		if err := os.Remove(skillPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return skillAttachResult{}, fmt.Errorf("remove skill file %s: %w", skillPath, err)
+		}
+		if err := os.Remove(filepath.Dir(skillPath)); err != nil && !errors.Is(err, os.ErrNotExist) && !isDirectoryNotEmpty(err) {
+			return skillAttachResult{}, fmt.Errorf("remove empty skill directory %s: %w", filepath.Dir(skillPath), err)
+		}
+	}
+	delete(state, name)
+	if err := saveSkillAttachmentState(statePath, state); err != nil {
+		return skillAttachResult{}, err
+	}
+	return result, nil
+}
+
+func isDirectoryNotEmpty(err error) bool {
+	return strings.Contains(err.Error(), "directory not empty") || strings.Contains(err.Error(), "not empty")
+}
+
+func printSkillAttachSummary(out io.Writer, target, scope string, result skillAttachResult) {
+	if scope == "" {
+		scope = clients.ScopeProject
+	}
+	fmt.Fprintf(out, "target: %s\n", target)
+	fmt.Fprintf(out, "scope: %s\n", scope)
+	fmt.Fprintf(out, "skills_dir: %s\n", result.SkillsDir)
+	fmt.Fprintf(out, "skill_file: %s\n", result.SkillPath)
+	if result.DryRun {
+		fmt.Fprintln(out, "dry-run: true")
+	}
+	fmt.Fprintf(out, "added: %s\n", formatNameList(result.Added))
+	fmt.Fprintf(out, "updated: %s\n", formatNameList(result.Updated))
+	fmt.Fprintf(out, "removed: %s\n", formatNameList(result.Removed))
+	fmt.Fprintf(out, "unchanged: %s\n", formatNameList(result.Unchanged))
 }
 
 func renderClientSkill(skill registry.Skill, content []byte) (renderedSkill, error) {
@@ -105,7 +358,7 @@ func renderClientSkill(skill registry.Skill, content []byte) (renderedSkill, err
 	}
 	out.WriteString("---\n\n")
 	out.Write(body)
-	return renderedSkill{Content: out.Bytes(), SourceDesc: sourceDescription}, nil
+	return renderedSkill{Content: out.Bytes()}, nil
 }
 
 func splitSkillFrontmatter(content []byte) ([]string, []byte) {

--- a/cmd/madari/skill_materialize.go
+++ b/cmd/madari/skill_materialize.go
@@ -70,6 +70,19 @@ func defaultHomeSkillRoot(parts ...string) skillRootResolver {
 	}
 }
 
+func defaultVibeUserSkillRoot() skillRootResolver {
+	return func() (string, error) {
+		if vibeHome := strings.TrimSpace(os.Getenv("VIBE_HOME")); vibeHome != "" {
+			resolved, err := syncshared.ExpandHome(vibeHome)
+			if err != nil {
+				return "", err
+			}
+			return filepath.Join(filepath.Clean(resolved), "skills"), nil
+		}
+		return defaultHomeSkillRoot(".vibe", "skills")()
+	}
+}
+
 type renderedSkill struct {
 	Content []byte
 }
@@ -129,8 +142,12 @@ func (a cliApp) ensureSkillNotAttached(name string) error {
 		if err != nil {
 			return err
 		}
-		if _, exists := state[name]; exists {
-			holders = append(holders, ref)
+		for _, entry := range skillAttachmentsByName(state, name) {
+			holders = append(holders, skillAttachmentRef{
+				target: ref.target,
+				scope:  ref.scope,
+				path:   entry.Path,
+			})
 		}
 	}
 	if len(holders) == 0 {
@@ -142,6 +159,9 @@ func (a cliApp) ensureSkillNotAttached(name string) error {
 		command := fmt.Sprintf("madari skill detach %s %s", name, holder.target)
 		if holder.scope == clients.ScopeUser {
 			command += " --scope user"
+		}
+		if holder.path != "" {
+			command += fmt.Sprintf(" --skills-dir %s", filepath.Dir(filepath.Dir(holder.path)))
 		}
 		guidance = append(guidance, command)
 	}
@@ -187,14 +207,15 @@ func (a cliApp) attachSkill(name, target, scope, skillsDir string, dryRun bool) 
 		DryRun:    dryRun,
 	}
 
-	entry, owned := state[name]
+	stateKey, entry, owned := findSkillAttachment(state, name, skillPath)
+	var previousContent []byte
+	hadPreviousContent := false
 	if owned {
-		if filepath.Clean(entry.Path) != skillPath {
-			return skillAttachResult{}, fmt.Errorf("skill %q is already attached to %s at %s; detach it before attaching to %s", name, target, entry.Path, skillPath)
-		}
 		current, readErr := os.ReadFile(skillPath)
 		switch {
 		case readErr == nil:
+			previousContent = append([]byte(nil), current...)
+			hadPreviousContent = true
 			if skillContentHash(current) != entry.Hash {
 				return skillAttachResult{}, fmt.Errorf("refusing to update modified skill file %s; detach or restore it manually", skillPath)
 			}
@@ -223,9 +244,12 @@ func (a cliApp) attachSkill(name, target, scope, skillsDir string, dryRun bool) 
 	if err := syncshared.WriteFileAtomically(skillPath, rendered.Content, 0o644); err != nil {
 		return skillAttachResult{}, fmt.Errorf("write skill file %s: %w", skillPath, err)
 	}
-	state[name] = skillAttachmentEntry{Path: skillPath, Hash: desiredHash}
-	if err := saveSkillAttachmentState(statePath, state); err != nil {
-		return skillAttachResult{}, err
+	state[stateKey] = skillAttachmentEntry{Name: name, Path: skillPath, Hash: desiredHash}
+	if err := saveSkillAttachmentStateFunc(statePath, state); err != nil {
+		if rollbackErr := rollbackSkillFileWrite(skillPath, previousContent, hadPreviousContent); rollbackErr != nil {
+			return skillAttachResult{}, fmt.Errorf("write skill attachment state: %w; rollback skill file %s: %v", err, skillPath, rollbackErr)
+		}
+		return skillAttachResult{}, fmt.Errorf("write skill attachment state: %w", err)
 	}
 	return result, nil
 }
@@ -241,15 +265,24 @@ func (a cliApp) detachSkill(name, target, scope, skillsDir string, dryRun bool) 
 		return skillAttachResult{}, err
 	}
 
-	entry, owned := state[name]
+	root, rootErr := ct.skillRoots.resolve(scope, skillsDir)
+	if rootErr != nil {
+		return skillAttachResult{}, rootErr
+	}
+	root = filepath.Clean(root)
+	expectedSkillPath := filepath.Join(root, name, "SKILL.md")
+
+	stateKey, entry, owned := findSkillAttachment(state, name, expectedSkillPath)
 	if !owned {
-		root, rootErr := ct.skillRoots.resolve(scope, skillsDir)
-		if rootErr != nil {
-			return skillAttachResult{}, rootErr
+		if matches := skillAttachmentsByName(state, name); len(matches) > 0 {
+			locations := make([]string, 0, len(matches))
+			for _, match := range matches {
+				locations = append(locations, match.Path)
+			}
+			return skillAttachResult{}, fmt.Errorf("skill %q is attached to %s, but not at %s; attached paths: %s", name, target, expectedSkillPath, strings.Join(locations, ", "))
 		}
-		root = filepath.Clean(root)
 		return skillAttachResult{
-			SkillPath: filepath.Join(root, name, "SKILL.md"),
+			SkillPath: expectedSkillPath,
 			SkillsDir: root,
 			DryRun:    dryRun,
 			Unchanged: []string{name},
@@ -257,18 +290,7 @@ func (a cliApp) detachSkill(name, target, scope, skillsDir string, dryRun bool) 
 	}
 
 	skillPath := filepath.Clean(entry.Path)
-	if strings.TrimSpace(skillsDir) != "" {
-		root, err := ct.skillRoots.resolve(scope, skillsDir)
-		if err != nil {
-			return skillAttachResult{}, err
-		}
-		expected := filepath.Join(filepath.Clean(root), name, "SKILL.md")
-		if expected != skillPath {
-			return skillAttachResult{}, fmt.Errorf("skill %q is attached at %s, not %s", name, skillPath, expected)
-		}
-	}
-
-	root := filepath.Dir(filepath.Dir(skillPath))
+	root = filepath.Dir(filepath.Dir(skillPath))
 	result := skillAttachResult{
 		SkillPath: skillPath,
 		SkillsDir: root,
@@ -299,8 +321,8 @@ func (a cliApp) detachSkill(name, target, scope, skillsDir string, dryRun bool) 
 			return skillAttachResult{}, fmt.Errorf("remove empty skill directory %s: %w", filepath.Dir(skillPath), err)
 		}
 	}
-	delete(state, name)
-	if err := saveSkillAttachmentState(statePath, state); err != nil {
+	delete(state, stateKey)
+	if err := saveSkillAttachmentStateFunc(statePath, state); err != nil {
 		return skillAttachResult{}, err
 	}
 	return result, nil
@@ -413,18 +435,33 @@ func frontmatterDescription(lines []string) string {
 			continue
 		}
 		value = strings.TrimSpace(value)
-		switch value {
-		case "", "|", ">":
+		if style, ok := yamlBlockScalarStyle(value); ok || value == "" {
 			collected := collectIndentedYAMLValue(lines[i+1:])
-			if value == "|" {
+			if style == "|" {
 				return strings.TrimSpace(strings.Join(collected, "\n"))
 			}
 			return strings.TrimSpace(strings.Join(collected, " "))
-		default:
-			return strings.TrimSpace(unquoteYAMLScalar(value))
 		}
+		return strings.TrimSpace(unquoteYAMLScalar(value))
 	}
 	return ""
+}
+
+func yamlBlockScalarStyle(value string) (string, bool) {
+	if value == "" {
+		return "", false
+	}
+	style := value[0]
+	if style != '|' && style != '>' {
+		return "", false
+	}
+	for _, r := range value[1:] {
+		if r == '-' || r == '+' || (r >= '0' && r <= '9') {
+			continue
+		}
+		return "", false
+	}
+	return string(style), true
 }
 
 func frontmatterExtraLines(lines []string) []string {
@@ -554,16 +591,19 @@ func strconvUnquote(value string) (string, error) {
 	return out.String(), nil
 }
 
-const skillAttachmentStateVersion = 1
+const skillAttachmentStateVersion = 2
+
+var saveSkillAttachmentStateFunc = saveSkillAttachmentState
 
 type skillAttachmentEntry struct {
+	Name string `json:"name"`
 	Path string `json:"path"`
 	Hash string `json:"hash"`
 }
 
 type skillAttachmentStateFile struct {
-	Version int                             `json:"version"`
-	Skills  map[string]skillAttachmentEntry `json:"skills"`
+	Version int                    `json:"version"`
+	Skills  []skillAttachmentEntry `json:"skills"`
 }
 
 func loadSkillAttachmentState(path string) (map[string]skillAttachmentEntry, error) {
@@ -574,20 +614,41 @@ func loadSkillAttachmentState(path string) (map[string]skillAttachmentEntry, err
 		}
 		return nil, fmt.Errorf("read skill attachment state %q: %w", path, err)
 	}
-	state := skillAttachmentStateFile{}
-	if err := json.Unmarshal(payload, &state); err != nil {
+
+	probe := struct {
+		Version int             `json:"version"`
+		Skills  json.RawMessage `json:"skills"`
+	}{}
+	if err := json.Unmarshal(payload, &probe); err != nil {
 		return nil, fmt.Errorf("parse skill attachment state JSON: %w", err)
 	}
-	if state.Version != skillAttachmentStateVersion {
-		return nil, fmt.Errorf("unsupported skill attachment state version %d in %q", state.Version, path)
+
+	switch probe.Version {
+	case 1:
+		legacy := map[string]skillAttachmentEntry{}
+		if len(probe.Skills) > 0 {
+			if err := json.Unmarshal(probe.Skills, &legacy); err != nil {
+				return nil, fmt.Errorf("parse skill attachment state v1 entries: %w", err)
+			}
+		}
+		return normalizeSkillAttachmentState(legacy), nil
+	case skillAttachmentStateVersion:
+		entries := []skillAttachmentEntry{}
+		if len(probe.Skills) > 0 {
+			if err := json.Unmarshal(probe.Skills, &entries); err != nil {
+				return nil, fmt.Errorf("parse skill attachment state v2 entries: %w", err)
+			}
+		}
+		return normalizeSkillAttachmentEntries(entries), nil
+	default:
+		return nil, fmt.Errorf("unsupported skill attachment state version %d in %q", probe.Version, path)
 	}
-	return normalizeSkillAttachmentState(state.Skills), nil
 }
 
 func saveSkillAttachmentState(path string, skills map[string]skillAttachmentEntry) error {
 	state := skillAttachmentStateFile{
 		Version: skillAttachmentStateVersion,
-		Skills:  normalizeSkillAttachmentState(skills),
+		Skills:  sortedSkillAttachmentEntries(normalizeSkillAttachmentState(skills)),
 	}
 	payload, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
@@ -599,16 +660,90 @@ func saveSkillAttachmentState(path string, skills map[string]skillAttachmentEntr
 
 func normalizeSkillAttachmentState(skills map[string]skillAttachmentEntry) map[string]skillAttachmentEntry {
 	normalized := make(map[string]skillAttachmentEntry, len(skills))
-	for name, entry := range skills {
-		name = strings.TrimSpace(name)
-		entry.Path = filepath.Clean(strings.TrimSpace(entry.Path))
-		entry.Hash = strings.TrimSpace(entry.Hash)
-		if name == "" || entry.Path == "." || entry.Hash == "" {
+	for key, entry := range skills {
+		if strings.TrimSpace(entry.Name) == "" {
+			entry.Name = strings.TrimSpace(key)
+		}
+		normalizedEntry, ok := normalizeSkillAttachmentEntry(entry)
+		if !ok {
 			continue
 		}
-		normalized[name] = entry
+		normalized[skillAttachmentKey(normalizedEntry.Name, normalizedEntry.Path)] = normalizedEntry
 	}
 	return normalized
+}
+
+func normalizeSkillAttachmentEntries(entries []skillAttachmentEntry) map[string]skillAttachmentEntry {
+	normalized := make(map[string]skillAttachmentEntry, len(entries))
+	for _, entry := range entries {
+		normalizedEntry, ok := normalizeSkillAttachmentEntry(entry)
+		if !ok {
+			continue
+		}
+		normalized[skillAttachmentKey(normalizedEntry.Name, normalizedEntry.Path)] = normalizedEntry
+	}
+	return normalized
+}
+
+func normalizeSkillAttachmentEntry(entry skillAttachmentEntry) (skillAttachmentEntry, bool) {
+	entry.Name = strings.TrimSpace(entry.Name)
+	entry.Path = filepath.Clean(strings.TrimSpace(entry.Path))
+	entry.Hash = strings.TrimSpace(entry.Hash)
+	if entry.Name == "" || entry.Path == "." || entry.Hash == "" {
+		return skillAttachmentEntry{}, false
+	}
+	return entry, true
+}
+
+func sortedSkillAttachmentEntries(state map[string]skillAttachmentEntry) []skillAttachmentEntry {
+	entries := make([]skillAttachmentEntry, 0, len(state))
+	for _, entry := range state {
+		entries = append(entries, entry)
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Name != entries[j].Name {
+			return entries[i].Name < entries[j].Name
+		}
+		return entries[i].Path < entries[j].Path
+	})
+	return entries
+}
+
+func skillAttachmentKey(name, path string) string {
+	return strings.TrimSpace(name) + "\x00" + filepath.Clean(strings.TrimSpace(path))
+}
+
+func findSkillAttachment(state map[string]skillAttachmentEntry, name, path string) (string, skillAttachmentEntry, bool) {
+	key := skillAttachmentKey(name, path)
+	entry, ok := state[key]
+	return key, entry, ok
+}
+
+func skillAttachmentsByName(state map[string]skillAttachmentEntry, name string) []skillAttachmentEntry {
+	name = strings.TrimSpace(name)
+	matches := []skillAttachmentEntry{}
+	for _, entry := range state {
+		if entry.Name == name {
+			matches = append(matches, entry)
+		}
+	}
+	sort.Slice(matches, func(i, j int) bool {
+		return matches[i].Path < matches[j].Path
+	})
+	return matches
+}
+
+func rollbackSkillFileWrite(path string, previous []byte, hadPrevious bool) error {
+	if hadPrevious {
+		return syncshared.WriteFileAtomically(path, previous, 0o644)
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := os.Remove(filepath.Dir(path)); err != nil && !errors.Is(err, os.ErrNotExist) && !isDirectoryNotEmpty(err) {
+		return err
+	}
+	return nil
 }
 
 func skillContentHash(content []byte) string {
@@ -617,8 +752,16 @@ func skillContentHash(content []byte) string {
 }
 
 func sortedAttachedSkillNames(state map[string]skillAttachmentEntry) []string {
-	names := make([]string, 0, len(state))
-	for name := range state {
+	seen := map[string]struct{}{}
+	for _, entry := range state {
+		name := strings.TrimSpace(entry.Name)
+		if name == "" {
+			continue
+		}
+		seen[name] = struct{}{}
+	}
+	names := make([]string, 0, len(seen))
+	for name := range seen {
 		names = append(names, name)
 	}
 	sort.Strings(names)

--- a/cmd/madari/skill_materialize_test.go
+++ b/cmd/madari/skill_materialize_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+func TestRenderClientSkillSynthesizesFrontmatter(t *testing.T) {
+	rendered, err := renderClientSkill(
+		registry.Skill{Name: "release", Description: "Release workflow"},
+		[]byte("# Release\n\nCut a patch release.\n"),
+	)
+	if err != nil {
+		t.Fatalf("render client skill: %v", err)
+	}
+
+	want := `---
+name: "release"
+description: "Release workflow"
+---
+
+# Release
+
+Cut a patch release.
+`
+	if string(rendered.Content) != want {
+		t.Fatalf("client skill render drift:\nwant:\n%s\ngot:\n%s", want, rendered.Content)
+	}
+}
+
+func TestRenderClientSkillNormalizesExistingFrontmatter(t *testing.T) {
+	content := `---
+name: old-name
+description: Source description
+allowed-tools:
+  - Read
+disable-model-invocation: true
+---
+
+# Release
+Use the release checklist.
+`
+	rendered, err := renderClientSkill(registry.Skill{Name: "release"}, []byte(content))
+	if err != nil {
+		t.Fatalf("render client skill: %v", err)
+	}
+
+	got := string(rendered.Content)
+	for _, want := range []string{
+		`name: "release"`,
+		`description: "Source description"`,
+		"allowed-tools:\n  - Read",
+		"disable-model-invocation: true",
+		"# Release\nUse the release checklist.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in rendered skill:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "old-name") {
+		t.Fatalf("expected old name to be replaced, got:\n%s", got)
+	}
+	if strings.Count(got, "description:") != 1 {
+		t.Fatalf("expected one description field, got:\n%s", got)
+	}
+}
+
+func TestRenderClientSkillRequiresDescriptionAndBody(t *testing.T) {
+	if _, err := renderClientSkill(registry.Skill{Name: "release"}, []byte("# Release\n")); err == nil || !strings.Contains(err.Error(), "requires a description") {
+		t.Fatalf("expected missing description error, got: %v", err)
+	}
+
+	frontmatterOnly := []byte("---\ndescription: Release workflow\n---\n\n")
+	if _, err := renderClientSkill(registry.Skill{Name: "release"}, frontmatterOnly); err == nil || !strings.Contains(err.Error(), "content is empty") {
+		t.Fatalf("expected empty body error, got: %v", err)
+	}
+}
+
+func TestSkillAttachmentStateRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state", "codex-skills-managed.json")
+	state := map[string]skillAttachmentEntry{
+		"release": {
+			Path: filepath.Join(t.TempDir(), ".agents", "skills", "release", "SKILL.md"),
+			Hash: "abc123",
+		},
+	}
+
+	if err := saveSkillAttachmentState(path, state); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+	got, err := loadSkillAttachmentState(path)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if got["release"] != state["release"] {
+		t.Fatalf("state roundtrip mismatch: got=%+v want=%+v", got, state)
+	}
+}

--- a/cmd/madari/skill_materialize_test.go
+++ b/cmd/madari/skill_materialize_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -68,6 +69,50 @@ Use the release checklist.
 	}
 }
 
+func TestRenderClientSkillNormalizesBlockScalarDescription(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+		want        string
+	}{
+		{
+			name: "folded chomp",
+			description: `description: >-
+  Source release
+  workflow`,
+			want: `description: "Source release workflow"`,
+		},
+		{
+			name: "literal chomp",
+			description: `description: |-
+  Source release
+  workflow`,
+			want: `description: "Source release\nworkflow"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := "---\nname: old-name\n" + tt.description + "\nallowed-tools:\n  - Read\n---\n\n# Release\nUse the release checklist.\n"
+			rendered, err := renderClientSkill(registry.Skill{Name: "release"}, []byte(content))
+			if err != nil {
+				t.Fatalf("render client skill: %v", err)
+			}
+
+			got := string(rendered.Content)
+			if !strings.Contains(got, tt.want) {
+				t.Fatalf("expected %q in rendered skill:\n%s", tt.want, got)
+			}
+			if strings.Contains(got, `description: ">`) || strings.Contains(got, `description: "|`) {
+				t.Fatalf("expected block scalar description to be parsed, got:\n%s", got)
+			}
+			if !strings.Contains(got, "allowed-tools:\n  - Read") {
+				t.Fatalf("expected unrelated frontmatter to be preserved, got:\n%s", got)
+			}
+		})
+	}
+}
+
 func TestRenderClientSkillRequiresDescriptionAndBody(t *testing.T) {
 	if _, err := renderClientSkill(registry.Skill{Name: "release"}, []byte("# Release\n")); err == nil || !strings.Contains(err.Error(), "requires a description") {
 		t.Fatalf("expected missing description error, got: %v", err)
@@ -81,9 +126,11 @@ func TestRenderClientSkillRequiresDescriptionAndBody(t *testing.T) {
 
 func TestSkillAttachmentStateRoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "state", "codex-skills-managed.json")
+	skillPath := filepath.Join(t.TempDir(), ".agents", "skills", "release", "SKILL.md")
 	state := map[string]skillAttachmentEntry{
-		"release": {
-			Path: filepath.Join(t.TempDir(), ".agents", "skills", "release", "SKILL.md"),
+		skillAttachmentKey("release", skillPath): {
+			Name: "release",
+			Path: skillPath,
 			Hash: "abc123",
 		},
 	}
@@ -95,7 +142,40 @@ func TestSkillAttachmentStateRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load state: %v", err)
 	}
-	if got["release"] != state["release"] {
+	if got[skillAttachmentKey("release", skillPath)] != state[skillAttachmentKey("release", skillPath)] {
 		t.Fatalf("state roundtrip mismatch: got=%+v want=%+v", got, state)
+	}
+}
+
+func TestSkillAttachmentStateLoadsV1NameKeys(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state", "codex-skills-managed.json")
+	skillPath := filepath.Join(t.TempDir(), ".agents", "skills", "release", "SKILL.md")
+	payload := `{
+  "version": 1,
+  "skills": {
+    "release": {
+      "path": "` + filepath.ToSlash(skillPath) + `",
+      "hash": "abc123"
+    }
+  }
+}
+`
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(payload), 0o644); err != nil {
+		t.Fatalf("write legacy state: %v", err)
+	}
+
+	got, err := loadSkillAttachmentState(path)
+	if err != nil {
+		t.Fatalf("load legacy state: %v", err)
+	}
+	entry, ok := got[skillAttachmentKey("release", skillPath)]
+	if !ok {
+		t.Fatalf("expected normalized legacy entry, got=%+v", got)
+	}
+	if entry.Name != "release" || entry.Path != filepath.Clean(skillPath) || entry.Hash != "abc123" {
+		t.Fatalf("unexpected legacy entry: %+v", entry)
 	}
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,9 +23,10 @@ Madari keeps four concepts separate:
   yet and should not be modeled as persistent client sync.
 
 Current behavior follows this boundary: `sync` and `ring attach` persist MCP
-server config, `ring render` emits MCP config only, and `skill render` emits
-Markdown instructions only. Skills do not write client config and are not ring
-members or run inputs yet.
+server config, `ring render` emits MCP config only, plain `skill render` emits
+managed Markdown only, and `skill attach` materializes client-native `SKILL.md`
+files without changing MCP client configs. Skills are not ring members or run
+inputs yet.
 
 ## Components
 
@@ -41,9 +42,8 @@ members or run inputs yet.
 
 2. Client Targets and Adapters
 - The command layer keeps a single client target registry for target-level
-  capabilities: sync adapter, ring config renderer, and scope support.
-  Future client-native skill render support should extend that registry
-  instead of adding another target-specific switch.
+  capabilities: sync adapter, ring config renderer, skill roots, and scope
+  support.
 - Translate registry entries into client-specific config.
 - Current adapters: Claude Desktop, Claude Code, Gemini, Codex, and Vibe.
 - Adapters own read/merge/write behavior for their client format.
@@ -104,10 +104,13 @@ members or run inputs yet.
 - `skill add` copies a non-empty Markdown file into Madari; `skill update`
   replaces that managed copy and preserves description unless a new one is
   provided.
-- `skill render` prints the managed Markdown exactly to stdout. It mutates no
-  state, writes no client files, and does not imply model restriction to that
-  workflow.
-- V1 skills are exported/imported in snapshots but are not consumed by rings,
+- Plain `skill render` prints the managed Markdown exactly to stdout. With
+  `--client`, render synthesizes native `SKILL.md` frontmatter without writing
+  files.
+- `skill attach` writes Madari-owned `SKILL.md` files into supported native
+  skill directories and records separate skill attachment state. It refuses to
+  overwrite unmanaged files or remove files modified after Madari wrote them.
+- Skills are exported/imported in snapshots but are not consumed by rings, MCP
   sync adapters, or run execution.
 
 7. Doctor Engine

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -133,6 +133,10 @@ madari skill update release --file ./SKILL.md --description "Updated workflow"
 madari skill list
 madari skill show release
 madari skill render release
+madari skill render release --client codex
+madari skill attach release codex
+madari skill attach release codex --scope user
+madari skill detach release codex
 madari skill remove release
 ```
 
@@ -142,9 +146,18 @@ metadata lives at `<config-root>/skills/<name>.toml`, and content lives at
 `skill update` fails if it does not. Updating preserves the existing
 description unless `--description` is passed.
 
-`skill render` prints the managed Markdown bytes exactly to stdout and
-mutates nothing. V1 skills are not ring members, are not synced into client
-configs, and are not consumed by `run`.
+Plain `skill render` prints the managed Markdown bytes exactly to stdout and
+mutates nothing. `skill render --client <target>` synthesizes a native
+`SKILL.md` with YAML frontmatter for `claude-code`, `codex`, `gemini`, or
+`vibe`; it still writes no files.
+
+`skill attach` writes `<skills-dir>/<name>/SKILL.md` and records ownership in
+Madari state. Project scope is the default; user scope writes to the target's
+user skill root. `--skills-dir` overrides the root. Attach refuses to overwrite
+unmanaged files. `skill detach` removes only Madari-owned `SKILL.md` files and
+refuses to delete files modified since Madari last wrote them. Skills are not
+ring members, are not written into MCP client configs, and are not consumed by
+`run`.
 
 ## Diagnostics
 
@@ -450,3 +463,8 @@ madari version
 - `claude-code`
 - `codex`
 - `gemini`
+- `vibe`
+
+Skill attach/render targets are `claude-code`, `codex`, `gemini`, and `vibe`.
+`claude-desktop` is not a skill target until it has a stable local skill
+directory contract.

--- a/docs/manifest-spec.md
+++ b/docs/manifest-spec.md
@@ -106,9 +106,11 @@ at `<config-root>/skills/<name>.md`.
 - `description` (string, optional): friendly description.
 
 Skill manifests have no sections; unknown keys are rejected. The Markdown
-body is arbitrary text, but it must be non-empty. V1 skills are managed and
-rendered independently: they are not ring members, are not synced into client
-configs, and are not consumed by `run`.
+body is arbitrary text, but it must be non-empty. Plain `skill render` emits
+that managed body exactly. Client-native render/attach synthesize a `SKILL.md`
+frontmatter block from the manifest metadata and the managed body. Skills are
+not ring members, are not written into MCP client configs, and are not consumed
+by `run`.
 
 ### Example
 


### PR DESCRIPTION
## What changed

- Added client-native skill rendering with `madari skill render <name> --client <target>`.
- Added `madari skill attach` and `madari skill detach` for `codex`, `claude-code`, `gemini`, and `vibe`.
- Added Madari-owned skill attachment state with hash-based update/remove safety.
- Updated help text, README, CLI reference, architecture docs, manifest docs, and CLI tests.

## Why

Skills were already a standalone Madari primitive, but users could not materialize them into clients' native skill discovery directories. This keeps plain render useful for ephemeral injection while adding owned native `SKILL.md` materialization for clients that support skills.

## Validation

- `go test ./cmd/madari ./internal/registry`
- `go test ./...`
- `make build`
- `git diff --check HEAD`