### PR TITLE
[codex] Add advisory ring contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,10 @@ supported clients or included in rings, where Madari materializes native
 `SKILL.md` files for the target.
 
 **Rings** are named capability sets. A ring can contain server members and skill
-members, then attach to a client as one unit. Ring ownership is reference
-counted, so overlapping rings and standalone entries detach cleanly in any
-order.
+members, then attach to a client as one unit. Rings can also carry an advisory
+contract for delegation: when to use the ring, what context to provide, and
+what outputs to expect. Ring ownership is reference counted, so overlapping
+rings and standalone entries detach cleanly in any order.
 
 **Sync** writes managed server entries into client config files. Madari backs up
 before writing, skips ineligible entries instead of aborting the whole sync, and

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ supported clients or included in rings, where Madari materializes native
 **Rings** are named capability sets. A ring can contain server members and skill
 members, then attach to a client as one unit. Rings can also carry an advisory
 contract for delegation: when to use the ring, what context to provide, and
-what outputs to expect. Ring ownership is reference counted, so overlapping
+what outputs to expect. Contracts can be managed from standalone TOML files with
+`madari ring contract`. Ring ownership is reference counted, so overlapping
 rings and standalone entries detach cleanly in any order.
 
 **Sync** writes managed server entries into client config files. Madari backs up

--- a/cmd/madari/json_output.go
+++ b/cmd/madari/json_output.go
@@ -176,11 +176,11 @@ type ringJSON struct {
 
 type ringContractJSON struct {
 	Summary         string   `json:"summary,omitempty"`
-	GoodFor         []string `json:"good_for,omitempty"`
-	NotFor          []string `json:"not_for,omitempty"`
-	RequiredContext []string `json:"required_context,omitempty"`
-	OptionalContext []string `json:"optional_context,omitempty"`
-	ExpectedOutputs []string `json:"expected_outputs,omitempty"`
+	GoodFor         []string `json:"good_for"`
+	NotFor          []string `json:"not_for"`
+	RequiredContext []string `json:"required_context"`
+	OptionalContext []string `json:"optional_context"`
+	ExpectedOutputs []string `json:"expected_outputs"`
 }
 
 func ringToJSON(ring registry.Ring) ringJSON {

--- a/cmd/madari/json_output.go
+++ b/cmd/madari/json_output.go
@@ -13,7 +13,7 @@ import (
 // jsonSchemaVersion identifies the envelope version shared by all --json
 // output. Field names and shapes below are a public contract: additions are
 // allowed, renames and removals require a version bump.
-const jsonSchemaVersion = 2
+const jsonSchemaVersion = 1
 
 type listJSON struct {
 	SchemaVersion int          `json:"schema_version"`

--- a/cmd/madari/json_output.go
+++ b/cmd/madari/json_output.go
@@ -13,7 +13,7 @@ import (
 // jsonSchemaVersion identifies the envelope version shared by all --json
 // output. Field names and shapes below are a public contract: additions are
 // allowed, renames and removals require a version bump.
-const jsonSchemaVersion = 1
+const jsonSchemaVersion = 2
 
 type listJSON struct {
 	SchemaVersion int          `json:"schema_version"`
@@ -167,10 +167,20 @@ type ringShowJSON struct {
 }
 
 type ringJSON struct {
-	Name        string   `json:"name"`
-	Members     []string `json:"members"`
-	Skills      []string `json:"skills"`
-	Description string   `json:"description"`
+	Name        string            `json:"name"`
+	Members     []string          `json:"members"`
+	Skills      []string          `json:"skills"`
+	Description string            `json:"description"`
+	Contract    *ringContractJSON `json:"contract,omitempty"`
+}
+
+type ringContractJSON struct {
+	Summary         string   `json:"summary,omitempty"`
+	GoodFor         []string `json:"good_for,omitempty"`
+	NotFor          []string `json:"not_for,omitempty"`
+	RequiredContext []string `json:"required_context,omitempty"`
+	OptionalContext []string `json:"optional_context,omitempty"`
+	ExpectedOutputs []string `json:"expected_outputs,omitempty"`
 }
 
 func ringToJSON(ring registry.Ring) ringJSON {
@@ -178,12 +188,23 @@ func ringToJSON(ring registry.Ring) ringJSON {
 	sort.Strings(members)
 	skills := append([]string(nil), ring.Skills...)
 	sort.Strings(skills)
-	return ringJSON{
+	out := ringJSON{
 		Name:        ring.Name,
 		Members:     nonNilStrings(members),
 		Skills:      nonNilStrings(skills),
 		Description: ring.Description,
 	}
+	if !ring.Contract.Empty() {
+		out.Contract = &ringContractJSON{
+			Summary:         ring.Contract.Summary,
+			GoodFor:         nonNilStrings(ring.Contract.GoodFor),
+			NotFor:          nonNilStrings(ring.Contract.NotFor),
+			RequiredContext: nonNilStrings(ring.Contract.RequiredContext),
+			OptionalContext: nonNilStrings(ring.Contract.OptionalContext),
+			ExpectedOutputs: nonNilStrings(ring.Contract.ExpectedOutputs),
+		}
+	}
+	return out
 }
 
 type ringStatusJSON struct {

--- a/cmd/madari/ring.go
+++ b/cmd/madari/ring.go
@@ -1106,7 +1106,33 @@ func (a cliApp) cmdRingShow(args []string) error {
 			fmt.Fprintf(a.stdout, "  - %s\n", skill)
 		}
 	}
+	printRingContract(a.stdout, ring.Contract)
 	return nil
+}
+
+func printRingContract(out io.Writer, contract *registry.RingContract) {
+	if contract.Empty() {
+		return
+	}
+	fmt.Fprintln(out, "contract:")
+	if strings.TrimSpace(contract.Summary) != "" {
+		fmt.Fprintf(out, "  summary: %s\n", contract.Summary)
+	}
+	printContractList(out, "good_for", contract.GoodFor)
+	printContractList(out, "not_for", contract.NotFor)
+	printContractList(out, "required_context", contract.RequiredContext)
+	printContractList(out, "optional_context", contract.OptionalContext)
+	printContractList(out, "expected_outputs", contract.ExpectedOutputs)
+}
+
+func printContractList(out io.Writer, label string, values []string) {
+	if len(values) == 0 {
+		return
+	}
+	fmt.Fprintf(out, "  %s:\n", label)
+	for _, value := range values {
+		fmt.Fprintf(out, "    - %s\n", value)
+	}
 }
 
 func printRingHelp(out io.Writer) {

--- a/cmd/madari/ring.go
+++ b/cmd/madari/ring.go
@@ -5,6 +5,8 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"slices"
 	"sort"
 	"strings"
@@ -16,7 +18,7 @@ import (
 
 func (a cliApp) cmdRing(args []string) error {
 	if len(args) == 0 {
-		return commandUsageError("ring", "madari ring <create|list|show|attach|detach|delete|render|status> [options]")
+		return commandUsageError("ring", "madari ring <create|list|show|contract|attach|detach|delete|render|status> [options]")
 	}
 	if isHelpToken(args[0]) {
 		printRingHelp(a.stdout)
@@ -31,6 +33,8 @@ func (a cliApp) cmdRing(args []string) error {
 		return a.cmdRingList(rest)
 	case "show":
 		return a.cmdRingShow(rest)
+	case "contract":
+		return a.cmdRingContract(rest)
 	case "attach":
 		return a.cmdRingAttach(rest)
 	case "detach":
@@ -42,7 +46,7 @@ func (a cliApp) cmdRing(args []string) error {
 	case "status":
 		return a.cmdRingStatus(rest)
 	default:
-		return commandInputError("ring", fmt.Sprintf("unknown ring subcommand %q (supported: create, list, show, attach, detach, delete, render, status)", sub))
+		return commandInputError("ring", fmt.Sprintf("unknown ring subcommand %q (supported: create, list, show, contract, attach, detach, delete, render, status)", sub))
 	}
 }
 
@@ -1135,6 +1139,168 @@ func printContractList(out io.Writer, label string, values []string) {
 	}
 }
 
+func (a cliApp) cmdRingContract(args []string) error {
+	if len(args) == 0 {
+		return commandUsageError("ring contract", "madari ring contract <show|set|clear> <name> [options]")
+	}
+	if isHelpToken(args[0]) {
+		printRingContractHelp(a.stdout)
+		return nil
+	}
+
+	sub, rest := args[0], args[1:]
+	switch sub {
+	case "show":
+		return a.cmdRingContractShow(rest)
+	case "set":
+		return a.cmdRingContractSet(rest)
+	case "clear":
+		return a.cmdRingContractClear(rest)
+	default:
+		return commandInputError("ring contract", fmt.Sprintf("unknown ring contract subcommand %q (supported: show, set, clear)", sub))
+	}
+}
+
+func (a cliApp) cmdRingContractShow(args []string) error {
+	if len(args) == 0 {
+		return commandUsageError("ring contract show", "madari ring contract show <name>")
+	}
+	if isHelpToken(args[0]) {
+		printRingContractShowHelp(a.stdout)
+		return nil
+	}
+	name := strings.TrimSpace(args[0])
+
+	fs := flag.NewFlagSet("ring contract show", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printRingContractShowHelp(a.stdout)
+			return nil
+		}
+		return commandInputError("ring contract show", err.Error())
+	}
+	if fs.NArg() != 0 {
+		return commandUnexpectedArgsError("ring contract show", fs.Args())
+	}
+
+	ring, err := a.store.GetRing(name)
+	if err != nil {
+		if errors.Is(err, registry.ErrRingNotFound) {
+			return fmt.Errorf("ring %q not found", name)
+		}
+		return err
+	}
+	if ring.Contract.Empty() {
+		return fmt.Errorf("ring %q has no contract", name)
+	}
+	payload, err := registry.MarshalRingContract(*ring.Contract)
+	if err != nil {
+		return err
+	}
+	_, err = a.stdout.Write(payload)
+	return err
+}
+
+func (a cliApp) cmdRingContractSet(args []string) error {
+	if len(args) == 0 {
+		return commandUsageError("ring contract set", "madari ring contract set <name> --file <path>")
+	}
+	if isHelpToken(args[0]) {
+		printRingContractSetHelp(a.stdout)
+		return nil
+	}
+	name := strings.TrimSpace(args[0])
+
+	fs := flag.NewFlagSet("ring contract set", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var filePath string
+	fs.StringVar(&filePath, "file", "", "Standalone contract TOML file to set (required)")
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printRingContractSetHelp(a.stdout)
+			return nil
+		}
+		return commandInputError("ring contract set", err.Error())
+	}
+	if fs.NArg() != 0 {
+		return commandUnexpectedArgsError("ring contract set", fs.Args())
+	}
+
+	contract, err := readRingContractFile(filePath)
+	if err != nil {
+		return err
+	}
+	ring, err := a.store.GetRing(name)
+	if err != nil {
+		if errors.Is(err, registry.ErrRingNotFound) {
+			return fmt.Errorf("ring %q not found", name)
+		}
+		return err
+	}
+	ring.Contract = &contract
+	if err := a.store.SaveRing(ring); err != nil {
+		return err
+	}
+	fmt.Fprintf(a.stdout, "set contract for ring %s\n", name)
+	return nil
+}
+
+func (a cliApp) cmdRingContractClear(args []string) error {
+	if len(args) == 0 {
+		return commandUsageError("ring contract clear", "madari ring contract clear <name>")
+	}
+	if isHelpToken(args[0]) {
+		printRingContractClearHelp(a.stdout)
+		return nil
+	}
+	name := strings.TrimSpace(args[0])
+
+	fs := flag.NewFlagSet("ring contract clear", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printRingContractClearHelp(a.stdout)
+			return nil
+		}
+		return commandInputError("ring contract clear", err.Error())
+	}
+	if fs.NArg() != 0 {
+		return commandUnexpectedArgsError("ring contract clear", fs.Args())
+	}
+
+	ring, err := a.store.GetRing(name)
+	if err != nil {
+		if errors.Is(err, registry.ErrRingNotFound) {
+			return fmt.Errorf("ring %q not found", name)
+		}
+		return err
+	}
+	ring.Contract = nil
+	if err := a.store.SaveRing(ring); err != nil {
+		return err
+	}
+	fmt.Fprintf(a.stdout, "cleared contract for ring %s\n", name)
+	return nil
+}
+
+func readRingContractFile(path string) (registry.RingContract, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return registry.RingContract{}, commandInputError("ring contract set", "--file is required")
+	}
+	cleanPath := filepath.Clean(path)
+	payload, err := os.ReadFile(cleanPath)
+	if err != nil {
+		return registry.RingContract{}, fmt.Errorf("read contract file %q: %w", cleanPath, err)
+	}
+	contract, err := registry.ParseRingContract(payload)
+	if err != nil {
+		return registry.RingContract{}, fmt.Errorf("parse contract file %q: %w", cleanPath, err)
+	}
+	return contract, nil
+}
+
 func printRingHelp(out io.Writer) {
 	fmt.Fprintln(out, "Usage:")
 	fmt.Fprintln(out, "  madari ring <subcommand> [options]")
@@ -1143,6 +1309,7 @@ func printRingHelp(out io.Writer) {
 	fmt.Fprintln(out, "  create    Create a ring from registry servers and skills")
 	fmt.Fprintln(out, "  list      List configured rings")
 	fmt.Fprintln(out, "  show      Show one ring's members")
+	fmt.Fprintln(out, "  contract  Show, set, or clear a ring contract")
 	fmt.Fprintln(out, "  attach    Attach a ring to a client (materialize members)")
 	fmt.Fprintln(out, "  detach    Detach a ring from a client")
 	fmt.Fprintln(out, "  delete    Delete an unattached ring")
@@ -1236,4 +1403,50 @@ func printRingShowHelp(out io.Writer) {
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Description:")
 	fmt.Fprintln(out, "  Show one ring's server members, skill members, and description.")
+}
+
+func printRingContractHelp(out io.Writer) {
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  madari ring contract <show|set|clear> <name> [options]")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Subcommands:")
+	fmt.Fprintln(out, "  show      Print a ring contract as standalone TOML")
+	fmt.Fprintln(out, "  set       Replace a ring contract from a standalone TOML file")
+	fmt.Fprintln(out, "  clear     Remove a ring contract")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Description:")
+	fmt.Fprintln(out, "  Ring contracts are advisory metadata. These commands operate only on")
+	fmt.Fprintln(out, "  standalone contract files and do not change ring members, skills,")
+	fmt.Fprintln(out, "  attach state, sync behavior, or render output.")
+}
+
+func printRingContractShowHelp(out io.Writer) {
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  madari ring contract show <name>")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Description:")
+	fmt.Fprintln(out, "  Print the ring contract as standalone TOML suitable for editing and")
+	fmt.Fprintln(out, "  passing back to `madari ring contract set --file`.")
+}
+
+func printRingContractSetHelp(out io.Writer) {
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  madari ring contract set <name> --file <path>")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Options:")
+	fmt.Fprintln(out, "  --file <path>              Standalone contract TOML file to set (required)")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Description:")
+	fmt.Fprintln(out, "  Replace the ring contract with the complete contract in the file.")
+	fmt.Fprintln(out, "  The file contains contract fields directly; do not include a")
+	fmt.Fprintln(out, "  [contract] section or ring name/member fields.")
+}
+
+func printRingContractClearHelp(out io.Writer) {
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  madari ring contract clear <name>")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Description:")
+	fmt.Fprintln(out, "  Remove the advisory contract from a ring. Members, skills, attach state,")
+	fmt.Fprintln(out, "  sync behavior, and render output are unchanged.")
 }

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -64,9 +64,14 @@ func writeTestExecutable(t *testing.T, dir, name string) string {
 
 func writeSkillFile(t *testing.T, dir, name, content string) string {
 	t.Helper()
+	return writeTextFile(t, dir, name, content)
+}
+
+func writeTextFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
 	path := filepath.Join(dir, name)
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatalf("write skill file: %v", err)
+		t.Fatalf("write text file: %v", err)
 	}
 	return path
 }
@@ -3167,6 +3172,74 @@ func TestRunWithStoreRingContractShowAndJSON(t *testing.T) {
 	listRing := rings[0].(map[string]any)
 	if _, ok := listRing["contract"]; !ok {
 		t.Fatalf("expected contract in ring list JSON: %v", listRing)
+	}
+}
+
+func TestRunWithStoreRingContractFileCommands(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+	if result := runCmd(store, "add", "logs", "--command", commandPath, "--client", "claude-code"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "ring", "create", "observe", "--member", "logs"); result.code != 0 {
+		t.Fatalf("ring create failed: %s", result.stderr)
+	}
+
+	contractPayload := `summary = "Observe production behavior"
+good_for = ["logs", "traces"]
+not_for = ["deployments"]
+required_context = ["service", "time window"]
+optional_context = ["request id"]
+expected_outputs = ["findings", "next check"]
+`
+	contractPath := writeTextFile(t, t.TempDir(), "contract.toml", contractPayload)
+	result := runCmd(store, "ring", "contract", "set", "observe", "--file", contractPath)
+	if result.code != 0 {
+		t.Fatalf("ring contract set failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "set contract for ring observe") {
+		t.Fatalf("unexpected set output: %s", result.stdout)
+	}
+
+	ring, err := store.GetRing("observe")
+	if err != nil {
+		t.Fatalf("load observe ring: %v", err)
+	}
+	if ring.Contract == nil || ring.Contract.Summary != "Observe production behavior" {
+		t.Fatalf("expected contract saved, got: %#v", ring.Contract)
+	}
+
+	result = runCmd(store, "ring", "contract", "show", "observe")
+	if result.code != 0 {
+		t.Fatalf("ring contract show failed: %s", result.stderr)
+	}
+	if result.stdout != contractPayload {
+		t.Fatalf("expected standalone contract TOML:\n%s\ngot:\n%s", contractPayload, result.stdout)
+	}
+
+	invalidPath := writeTextFile(t, t.TempDir(), "bad-contract.toml", "[contract]\nsummary = \"wrong shape\"\n")
+	result = runCmd(store, "ring", "contract", "set", "observe", "--file", invalidPath)
+	if result.code == 0 || !strings.Contains(result.stderr, "unknown section") {
+		t.Fatalf("expected invalid contract file error, got code=%d stdout=%s stderr=%s", result.code, result.stdout, result.stderr)
+	}
+
+	result = runCmd(store, "ring", "contract", "clear", "observe")
+	if result.code != 0 {
+		t.Fatalf("ring contract clear failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "cleared contract for ring observe") {
+		t.Fatalf("unexpected clear output: %s", result.stdout)
+	}
+	ring, err = store.GetRing("observe")
+	if err != nil {
+		t.Fatalf("load observe ring after clear: %v", err)
+	}
+	if ring.Contract != nil {
+		t.Fatalf("expected contract cleared, got: %#v", ring.Contract)
+	}
+	result = runCmd(store, "ring", "contract", "show", "observe")
+	if result.code == 0 || !strings.Contains(result.stderr, `ring "observe" has no contract`) {
+		t.Fatalf("expected no-contract error, got code=%d stdout=%s stderr=%s", result.code, result.stdout, result.stderr)
 	}
 }
 

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -2369,7 +2369,7 @@ func TestRunWithStoreListJSONEmpty(t *testing.T) {
 	}
 
 	expected := `{
-  "schema_version": 1,
+  "schema_version": 2,
   "command": "list",
   "servers": []
 }
@@ -2400,7 +2400,7 @@ func TestRunWithStoreListJSON(t *testing.T) {
 	}
 
 	expected := fmt.Sprintf(`{
-  "schema_version": 1,
+  "schema_version": 2,
   "command": "list",
   "servers": [
     {
@@ -2440,7 +2440,7 @@ func TestRunWithStoreSyncDryRunJSON(t *testing.T) {
 	}
 
 	expected := fmt.Sprintf(`{
-  "schema_version": 1,
+  "schema_version": 2,
   "command": "sync",
   "target": "claude-code",
   "config_path": %q,
@@ -2501,7 +2501,7 @@ func TestRunWithStoreStatusJSON(t *testing.T) {
 
 	payload := decodeJSONObject(t, result.stdout)
 	assertJSONKeys(t, payload, "schema_version", "command", "summary", "client_configs", "managed", "manifest_errors", "drift")
-	if payload["schema_version"].(float64) != 1 {
+	if payload["schema_version"].(float64) != 2 {
 		t.Fatalf("unexpected schema_version: %v", payload["schema_version"])
 	}
 	if payload["command"].(string) != "status" {
@@ -3049,7 +3049,7 @@ func TestRunWithStoreRingListJSON(t *testing.T) {
 		t.Fatalf("ring list --json failed: %s", result.stderr)
 	}
 	expectedEmpty := `{
-  "schema_version": 1,
+  "schema_version": 2,
   "command": "ring list",
   "rings": []
 }
@@ -3070,7 +3070,7 @@ func TestRunWithStoreRingListJSON(t *testing.T) {
 		t.Fatalf("ring list --json failed: %s", result.stderr)
 	}
 	expected := `{
-  "schema_version": 1,
+  "schema_version": 2,
   "command": "ring list",
   "rings": [
     {
@@ -3101,6 +3101,72 @@ func TestRunWithStoreRingListJSON(t *testing.T) {
 	assertJSONKeys(t, ring, "name", "members", "skills", "description")
 	if ring["name"] != "research" {
 		t.Fatalf("unexpected ring payload: %v", ring)
+	}
+}
+
+func TestRunWithStoreRingContractShowAndJSON(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	if result := runCmd(store, "add", "logs", "--command", commandPath, "--client", "claude-code"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+	if err := store.SaveRing(registry.Ring{
+		Name:    "observe",
+		Members: []string{"logs"},
+		Contract: &registry.RingContract{
+			Summary:         "Observe production behavior",
+			GoodFor:         []string{"logs", "traces"},
+			NotFor:          []string{"deployments"},
+			RequiredContext: []string{"service", "time window"},
+			OptionalContext: []string{"request id"},
+			ExpectedOutputs: []string{"findings", "next check"},
+		},
+	}); err != nil {
+		t.Fatalf("save ring with contract: %v", err)
+	}
+
+	result := runCmd(store, "ring", "show", "observe")
+	if result.code != 0 {
+		t.Fatalf("ring show failed: %s", result.stderr)
+	}
+	for _, want := range []string{
+		"contract:",
+		"  summary: Observe production behavior",
+		"  good_for:",
+		"    - logs",
+		"  required_context:",
+		"    - time window",
+		"  expected_outputs:",
+		"    - next check",
+	} {
+		if !strings.Contains(result.stdout, want) {
+			t.Fatalf("expected %q in ring show output, got: %s", want, result.stdout)
+		}
+	}
+
+	result = runCmd(store, "ring", "show", "observe", "--json")
+	if result.code != 0 {
+		t.Fatalf("ring show --json failed: %s", result.stderr)
+	}
+	payload := decodeJSONObject(t, result.stdout)
+	ring := payload["ring"].(map[string]any)
+	assertJSONKeys(t, ring, "name", "members", "skills", "description", "contract")
+	contract := ring["contract"].(map[string]any)
+	assertJSONKeys(t, contract, "summary", "good_for", "not_for", "required_context", "optional_context", "expected_outputs")
+	if contract["summary"] != "Observe production behavior" {
+		t.Fatalf("unexpected contract payload: %v", contract)
+	}
+
+	result = runCmd(store, "ring", "list", "--json")
+	if result.code != 0 {
+		t.Fatalf("ring list --json failed: %s", result.stderr)
+	}
+	payload = decodeJSONObject(t, result.stdout)
+	rings := payload["rings"].([]any)
+	listRing := rings[0].(map[string]any)
+	if _, ok := listRing["contract"]; !ok {
+		t.Fatalf("expected contract in ring list JSON: %v", listRing)
 	}
 }
 

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -3163,6 +3163,30 @@ func TestRunWithStoreRingContractShowAndJSON(t *testing.T) {
 		t.Fatalf("unexpected contract payload: %v", contract)
 	}
 
+	if err := store.SaveRing(registry.Ring{
+		Name:    "minimal",
+		Members: []string{"logs"},
+		Contract: &registry.RingContract{
+			Summary: "Minimal contract",
+		},
+	}); err != nil {
+		t.Fatalf("save minimal ring with contract: %v", err)
+	}
+	result = runCmd(store, "ring", "show", "minimal", "--json")
+	if result.code != 0 {
+		t.Fatalf("minimal ring show --json failed: %s", result.stderr)
+	}
+	payload = decodeJSONObject(t, result.stdout)
+	minimalRing := payload["ring"].(map[string]any)
+	minimalContract := minimalRing["contract"].(map[string]any)
+	assertJSONKeys(t, minimalContract, "summary", "good_for", "not_for", "required_context", "optional_context", "expected_outputs")
+	for _, key := range []string{"good_for", "not_for", "required_context", "optional_context", "expected_outputs"} {
+		values, ok := minimalContract[key].([]any)
+		if !ok || len(values) != 0 {
+			t.Fatalf("expected %s to be an empty array, got: %#v", key, minimalContract[key])
+		}
+	}
+
 	result = runCmd(store, "ring", "list", "--json")
 	if result.code != 0 {
 		t.Fatalf("ring list --json failed: %s", result.stderr)

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -2374,7 +2374,7 @@ func TestRunWithStoreListJSONEmpty(t *testing.T) {
 	}
 
 	expected := `{
-  "schema_version": 2,
+  "schema_version": 1,
   "command": "list",
   "servers": []
 }
@@ -2405,7 +2405,7 @@ func TestRunWithStoreListJSON(t *testing.T) {
 	}
 
 	expected := fmt.Sprintf(`{
-  "schema_version": 2,
+  "schema_version": 1,
   "command": "list",
   "servers": [
     {
@@ -2445,7 +2445,7 @@ func TestRunWithStoreSyncDryRunJSON(t *testing.T) {
 	}
 
 	expected := fmt.Sprintf(`{
-  "schema_version": 2,
+  "schema_version": 1,
   "command": "sync",
   "target": "claude-code",
   "config_path": %q,
@@ -2506,7 +2506,7 @@ func TestRunWithStoreStatusJSON(t *testing.T) {
 
 	payload := decodeJSONObject(t, result.stdout)
 	assertJSONKeys(t, payload, "schema_version", "command", "summary", "client_configs", "managed", "manifest_errors", "drift")
-	if payload["schema_version"].(float64) != 2 {
+	if payload["schema_version"].(float64) != 1 {
 		t.Fatalf("unexpected schema_version: %v", payload["schema_version"])
 	}
 	if payload["command"].(string) != "status" {
@@ -3054,7 +3054,7 @@ func TestRunWithStoreRingListJSON(t *testing.T) {
 		t.Fatalf("ring list --json failed: %s", result.stderr)
 	}
 	expectedEmpty := `{
-  "schema_version": 2,
+  "schema_version": 1,
   "command": "ring list",
   "rings": []
 }
@@ -3075,7 +3075,7 @@ func TestRunWithStoreRingListJSON(t *testing.T) {
 		t.Fatalf("ring list --json failed: %s", result.stderr)
 	}
 	expected := `{
-  "schema_version": 2,
+  "schema_version": 1,
   "command": "ring list",
   "rings": [
     {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,9 +12,9 @@ Madari keeps four concepts separate:
 
 - Server: an executable MCP capability with command, args, env, and target
   client metadata.
-- Ring: a named capability grouping. Persisted rings can contain server
-  members and skill members by name; the referenced server manifests and skill
-  files remain the source of truth.
+- Ring: a named capability grouping with optional advisory contract metadata.
+  Persisted rings can contain server members and skill members by name; the
+  referenced server manifests and skill files remain the source of truth.
 - Skill: procedural or domain instructions for how an agent should use
   capabilities. Skills are standalone Markdown primitives with their own
   metadata, managed content, and render surface.
@@ -40,7 +40,7 @@ not run inputs yet.
 - Snapshots (`export`/`import`) carry servers, rings, and skills as versioned
   JSON; export refuses rings that would not round-trip, import validates
   everything before writing anything and never attaches or syncs. Snapshot
-  version 4 adds ring skill membership.
+  version 4 added ring skill membership; version 5 adds ring contract metadata.
 
 2. Client Targets and Adapters
 - The command layer keeps a single client target registry for target-level
@@ -80,7 +80,11 @@ not run inputs yet.
 - Named capability sets (`rings/<name>.toml`). Server members are references by
   name only — the server manifest stays the single source of truth for command,
   args, and env. Skill members are references by name only — managed skill
-  metadata and Markdown stay the source of truth.
+  metadata and Markdown stay the source of truth. Optional `[contract]`
+  metadata describes when the ring is useful, what context a delegating agent
+  should provide, and what outputs to expect. Contracts are advisory only:
+  attach, detach, sync, render, status, ownership, and skill materialization do
+  not change when a contract changes.
 - Attachment is derived state: ring `R` is attached to a target+scope iff
   `ring:R` appears among server ownership sources or skill attachment sources
   there. Attach records the source on every server and skill member,
@@ -100,6 +104,9 @@ not run inputs yet.
   render-only output before persistent sync/attach support exists. `ring
   status` reports attachments, per-server and per-skill sources, and
   pending/stale reconciliation work.
+- Contracts are distinct from future run/session/context primitives. Future
+  execution may render the contract into subagent initialization, but the ring
+  definition does not embed task context or result transport.
 - `ring delete` refuses while any target/scope still records the ring as an
   ownership source, and never edits client configs or managed state.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -62,6 +62,9 @@ streamable HTTP, or hand-managed stdio entries are preserved and never adopted.
 madari ring create research --member stewreads --member arxiv --skill release --description "Research helpers"
 madari ring list
 madari ring show research
+madari ring contract show research
+madari ring contract set research --file contract.toml
+madari ring contract clear research
 madari ring attach research claude-code
 madari ring attach research claude-code --scope user
 madari ring attach research gemini
@@ -84,6 +87,21 @@ Rings are named capability sets of servers and skills stored at
 `<config-root>/rings/<name>.toml` (see the manifest spec). Server members
 reference server registry entries by name; skill members reference managed
 skill entries by name. Referenced entries must exist when the ring is created.
+
+Ring contracts are advisory metadata for delegation. `ring contract set`
+replaces the whole contract from a standalone TOML file, `ring contract show`
+prints that same standalone file shape, and `ring contract clear` removes the
+contract. Contract commands do not change members, skills, attach state, sync
+behavior, or render output.
+
+```toml
+summary = "Collect source context and prepare a research brief."
+good_for = ["source collection", "evidence review"]
+not_for = ["deployments", "database mutation"]
+required_context = ["research question"]
+optional_context = ["time window", "known source URLs"]
+expected_outputs = ["findings summary", "sources inspected"]
+```
 
 Attach records a `ring:<name>` ownership source for every server and skill
 member. Eligible servers are materialized into MCP client config; skill members

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -199,10 +199,11 @@ the next sync, attach, or detach.
 `list`, `status`, `doctor`, `sync --dry-run`, `ring list`, `ring show`,
 `ring status`, `skill list`, and `skill show` accept `--json` and emit a
 single JSON document on stdout with nothing else.
-Every payload carries the envelope fields `schema_version` (currently `1`)
+Every payload carries the envelope fields `schema_version` (currently `2`)
 and `command`. Field additions are backward-compatible; renames or removals
 bump `schema_version`. List-valued fields are always present (empty arrays,
-never `null`).
+never `null`) when their containing object is emitted. Optional objects such as
+ring `contract` are omitted when absent.
 
 ```bash
 madari list --json
@@ -219,13 +220,13 @@ madari skill show release --json
 `sync --json` requires `--dry-run`; the apply-mode output contract is not yet
 defined.
 
-### Schemas (schema_version 1)
+### Schemas (schema_version 2)
 
 `madari list --json`:
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "command": "list",
   "servers": [
     {
@@ -244,7 +245,7 @@ summaries cover every sync target):
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "command": "status",
   "summary": {"total": 1, "ready": 1, "warning": 0, "error": 0, "skipped": 0},
   "client_configs": [
@@ -289,7 +290,7 @@ itself.
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "command": "doctor",
   "servers_dir": "/path/to/madari/servers",
   "servers": [
@@ -340,7 +341,7 @@ itself.
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "command": "sync",
   "target": "claude-code",
   "config_path": "/path/to/.mcp.json",
@@ -362,14 +363,22 @@ itself.
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "command": "ring list",
   "rings": [
     {
       "name": "research",
       "members": ["arxiv", "stewreads"],
       "skills": ["release"],
-      "description": "Research helpers"
+      "description": "Research helpers",
+      "contract": {
+        "summary": "Collect source context and prepare a research brief.",
+        "good_for": ["source collection", "evidence review"],
+        "not_for": ["deployments", "database mutation"],
+        "required_context": ["research question"],
+        "optional_context": ["time window", "known source URLs"],
+        "expected_outputs": ["findings summary", "sources inspected"]
+      }
     }
   ]
 }
@@ -379,13 +388,21 @@ itself.
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "command": "ring show",
   "ring": {
     "name": "research",
     "members": ["arxiv", "stewreads"],
     "skills": ["release"],
-    "description": "Research helpers"
+    "description": "Research helpers",
+    "contract": {
+      "summary": "Collect source context and prepare a research brief.",
+      "good_for": ["source collection", "evidence review"],
+      "not_for": ["deployments", "database mutation"],
+      "required_context": ["research question"],
+      "optional_context": ["time window", "known source URLs"],
+      "expected_outputs": ["findings summary", "sources inspected"]
+    }
   }
 }
 ```
@@ -394,7 +411,7 @@ itself.
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "command": "skill list",
   "skills": [
     {
@@ -410,7 +427,7 @@ managed content path:
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "command": "skill show",
   "skill": {
     "name": "release",
@@ -424,7 +441,7 @@ managed content path:
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "command": "ring status",
   "targets": [
     {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -217,7 +217,7 @@ the next sync, attach, or detach.
 `list`, `status`, `doctor`, `sync --dry-run`, `ring list`, `ring show`,
 `ring status`, `skill list`, and `skill show` accept `--json` and emit a
 single JSON document on stdout with nothing else.
-Every payload carries the envelope fields `schema_version` (currently `2`)
+Every payload carries the envelope fields `schema_version` (currently `1`)
 and `command`. Field additions are backward-compatible; renames or removals
 bump `schema_version`. List-valued fields are always present (empty arrays,
 never `null`) when their containing object is emitted. Optional objects such as
@@ -238,13 +238,13 @@ madari skill show release --json
 `sync --json` requires `--dry-run`; the apply-mode output contract is not yet
 defined.
 
-### Schemas (schema_version 2)
+### Schemas (schema_version 1)
 
 `madari list --json`:
 
 ```json
 {
-  "schema_version": 2,
+  "schema_version": 1,
   "command": "list",
   "servers": [
     {
@@ -263,7 +263,7 @@ summaries cover every sync target):
 
 ```json
 {
-  "schema_version": 2,
+  "schema_version": 1,
   "command": "status",
   "summary": {"total": 1, "ready": 1, "warning": 0, "error": 0, "skipped": 0},
   "client_configs": [
@@ -308,7 +308,7 @@ itself.
 
 ```json
 {
-  "schema_version": 2,
+  "schema_version": 1,
   "command": "doctor",
   "servers_dir": "/path/to/madari/servers",
   "servers": [
@@ -359,7 +359,7 @@ itself.
 
 ```json
 {
-  "schema_version": 2,
+  "schema_version": 1,
   "command": "sync",
   "target": "claude-code",
   "config_path": "/path/to/.mcp.json",
@@ -381,7 +381,7 @@ itself.
 
 ```json
 {
-  "schema_version": 2,
+  "schema_version": 1,
   "command": "ring list",
   "rings": [
     {
@@ -406,7 +406,7 @@ itself.
 
 ```json
 {
-  "schema_version": 2,
+  "schema_version": 1,
   "command": "ring show",
   "ring": {
     "name": "research",
@@ -429,7 +429,7 @@ itself.
 
 ```json
 {
-  "schema_version": 2,
+  "schema_version": 1,
   "command": "skill list",
   "skills": [
     {
@@ -445,7 +445,7 @@ managed content path:
 
 ```json
 {
-  "schema_version": 2,
+  "schema_version": 1,
   "command": "skill show",
   "skill": {
     "name": "release",
@@ -459,7 +459,7 @@ managed content path:
 
 ```json
 {
-  "schema_version": 2,
+  "schema_version": 1,
   "command": "ring status",
   "targets": [
     {

--- a/docs/manifest-spec.md
+++ b/docs/manifest-spec.md
@@ -87,8 +87,26 @@ document per ring at
 
 At least one `members` or `skills` entry is required. Every referenced server
 and skill must exist in the registry when a ring is created or imported.
-Ring manifests have no sections; unknown keys are rejected. Files are
-written deterministically with sorted server and skill members.
+Ring manifests support only the top-level fields above plus the optional
+`[contract]` section. Unknown top-level keys, unknown sections, and unknown
+`[contract]` keys are rejected. Files are written deterministically with sorted
+server and skill members; contract arrays preserve authored order.
+
+### `[contract]`
+
+Ring contracts are advisory metadata for main-thread delegation and future
+subagent initialization. They do not affect attach, detach, sync, status, or
+render behavior.
+
+- `summary` (string, optional): what this ring is for.
+- `good_for` (array of strings, optional): task types this ring is suited to.
+- `not_for` (array of strings, optional): task types this ring should avoid.
+- `required_context` (array of strings, optional): conceptual inputs the main
+  thread should provide before delegating.
+- `optional_context` (array of strings, optional): useful but non-required
+  inputs.
+- `expected_outputs` (array of strings, optional): advisory response shape;
+  these are not filesystem paths.
 
 ### Example
 
@@ -97,6 +115,14 @@ name = "research"
 members = ["arxiv", "stewreads"]
 skills = ["release"]
 description = "Research helpers"
+
+[contract]
+summary = "Collect source context and prepare a research brief."
+good_for = ["source collection", "evidence review"]
+not_for = ["deployments", "database mutation"]
+required_context = ["research question"]
+optional_context = ["time window", "known source URLs"]
+expected_outputs = ["findings summary", "sources inspected", "recommended next check"]
 ```
 
 ## Skill Files

--- a/docs/manifest-spec.md
+++ b/docs/manifest-spec.md
@@ -108,6 +108,11 @@ render behavior.
 - `expected_outputs` (array of strings, optional): advisory response shape;
   these are not filesystem paths.
 
+`madari ring contract set <name> --file <path>` uses the same fields in a
+standalone contract file without the `[contract]` section. `madari ring
+contract show <name>` prints that standalone shape, and `madari ring contract
+clear <name>` removes the contract from the ring.
+
 ### Example
 
 ```toml

--- a/internal/registry/ring.go
+++ b/internal/registry/ring.go
@@ -109,6 +109,62 @@ func (r Ring) HasSkill(name string) bool {
 	return false
 }
 
+// ParseRingContract parses a standalone contract TOML file. The file contains
+// only contract fields, not a [contract] section.
+func ParseRingContract(data []byte) (RingContract, error) {
+	contract := RingContract{}
+
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		line = stripInlineComment(line)
+		if line == "" {
+			continue
+		}
+
+		if strings.HasPrefix(line, "[") {
+			if !strings.HasSuffix(line, "]") {
+				return RingContract{}, fmt.Errorf("line %d: invalid section header", lineNo)
+			}
+			name := strings.TrimSpace(line[1 : len(line)-1])
+			return RingContract{}, fmt.Errorf("line %d: unknown section %q", lineNo, name)
+		}
+
+		key, value, err := splitKeyValue(line)
+		if err != nil {
+			return RingContract{}, fmt.Errorf("line %d: %w", lineNo, err)
+		}
+		if err := parseRingContractKey(&contract, key, value, "contract file"); err != nil {
+			return RingContract{}, fmt.Errorf("line %d: %w", lineNo, err)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return RingContract{}, fmt.Errorf("scan ring contract: %w", err)
+	}
+	if contract.Empty() {
+		return RingContract{}, fmt.Errorf("contract file has no fields")
+	}
+	return contract, nil
+}
+
+// MarshalRingContract renders a standalone contract TOML file with fields in
+// the same deterministic order used by ring manifests.
+func MarshalRingContract(contract RingContract) ([]byte, error) {
+	if contract.Empty() {
+		return nil, fmt.Errorf("contract is empty")
+	}
+
+	var b strings.Builder
+	writeRingContractFields(&b, &contract)
+	return []byte(b.String()), nil
+}
+
 // ParseRing parses a constrained TOML ring manifest and rejects unknown
 // fields, mirroring ParseManifest's strictness.
 func ParseRing(data []byte) (Ring, error) {
@@ -210,6 +266,10 @@ func parseRingTopLevel(ring *Ring, key, value string) error {
 }
 
 func parseRingContract(contract *RingContract, key, value string) error {
+	return parseRingContractKey(contract, key, value, "[contract]")
+}
+
+func parseRingContractKey(contract *RingContract, key, value, context string) error {
 	switch key {
 	case "summary":
 		sv, err := parseString(value)
@@ -248,7 +308,7 @@ func parseRingContract(contract *RingContract, key, value string) error {
 		}
 		contract.ExpectedOutputs = av
 	default:
-		return fmt.Errorf("unknown key %q in [contract]", key)
+		return fmt.Errorf("unknown key %q in %s", key, context)
 	}
 	return nil
 }
@@ -276,24 +336,28 @@ func MarshalRing(ring Ring) ([]byte, error) {
 	}
 	if !ring.Contract.Empty() {
 		b.WriteString("\n[contract]\n")
-		if strings.TrimSpace(ring.Contract.Summary) != "" {
-			fmt.Fprintf(&b, "summary = %s\n", strconv.Quote(ring.Contract.Summary))
-		}
-		if len(ring.Contract.GoodFor) > 0 {
-			fmt.Fprintf(&b, "good_for = %s\n", formatStringArray(ring.Contract.GoodFor))
-		}
-		if len(ring.Contract.NotFor) > 0 {
-			fmt.Fprintf(&b, "not_for = %s\n", formatStringArray(ring.Contract.NotFor))
-		}
-		if len(ring.Contract.RequiredContext) > 0 {
-			fmt.Fprintf(&b, "required_context = %s\n", formatStringArray(ring.Contract.RequiredContext))
-		}
-		if len(ring.Contract.OptionalContext) > 0 {
-			fmt.Fprintf(&b, "optional_context = %s\n", formatStringArray(ring.Contract.OptionalContext))
-		}
-		if len(ring.Contract.ExpectedOutputs) > 0 {
-			fmt.Fprintf(&b, "expected_outputs = %s\n", formatStringArray(ring.Contract.ExpectedOutputs))
-		}
+		writeRingContractFields(&b, ring.Contract)
 	}
 	return []byte(b.String()), nil
+}
+
+func writeRingContractFields(b *strings.Builder, contract *RingContract) {
+	if strings.TrimSpace(contract.Summary) != "" {
+		fmt.Fprintf(b, "summary = %s\n", strconv.Quote(contract.Summary))
+	}
+	if len(contract.GoodFor) > 0 {
+		fmt.Fprintf(b, "good_for = %s\n", formatStringArray(contract.GoodFor))
+	}
+	if len(contract.NotFor) > 0 {
+		fmt.Fprintf(b, "not_for = %s\n", formatStringArray(contract.NotFor))
+	}
+	if len(contract.RequiredContext) > 0 {
+		fmt.Fprintf(b, "required_context = %s\n", formatStringArray(contract.RequiredContext))
+	}
+	if len(contract.OptionalContext) > 0 {
+		fmt.Fprintf(b, "optional_context = %s\n", formatStringArray(contract.OptionalContext))
+	}
+	if len(contract.ExpectedOutputs) > 0 {
+		fmt.Fprintf(b, "expected_outputs = %s\n", formatStringArray(contract.ExpectedOutputs))
+	}
 }

--- a/internal/registry/ring.go
+++ b/internal/registry/ring.go
@@ -13,10 +13,33 @@ import (
 // command, args, env, or skill content — those primitives stay the source of
 // truth.
 type Ring struct {
-	Name        string   `toml:"name" json:"name"`
-	Members     []string `toml:"members" json:"members"`
-	Skills      []string `toml:"skills,omitempty" json:"skills,omitempty"`
-	Description string   `toml:"description,omitempty" json:"description,omitempty"`
+	Name        string        `toml:"name" json:"name"`
+	Members     []string      `toml:"members" json:"members"`
+	Skills      []string      `toml:"skills,omitempty" json:"skills,omitempty"`
+	Description string        `toml:"description,omitempty" json:"description,omitempty"`
+	Contract    *RingContract `toml:"contract,omitempty" json:"contract,omitempty"`
+}
+
+// RingContract is advisory metadata that helps an orchestrating agent decide
+// when to use a ring, what context to provide, and what response shape to
+// expect. It does not affect sync, attach, render, or ownership behavior.
+type RingContract struct {
+	Summary         string   `toml:"summary,omitempty" json:"summary,omitempty"`
+	GoodFor         []string `toml:"good_for,omitempty" json:"good_for,omitempty"`
+	NotFor          []string `toml:"not_for,omitempty" json:"not_for,omitempty"`
+	RequiredContext []string `toml:"required_context,omitempty" json:"required_context,omitempty"`
+	OptionalContext []string `toml:"optional_context,omitempty" json:"optional_context,omitempty"`
+	ExpectedOutputs []string `toml:"expected_outputs,omitempty" json:"expected_outputs,omitempty"`
+}
+
+func (c *RingContract) Empty() bool {
+	return c == nil ||
+		strings.TrimSpace(c.Summary) == "" &&
+			len(c.GoodFor) == 0 &&
+			len(c.NotFor) == 0 &&
+			len(c.RequiredContext) == 0 &&
+			len(c.OptionalContext) == 0 &&
+			len(c.ExpectedOutputs) == 0
 }
 
 // Validate enforces ring-level invariants. Member existence in the registry
@@ -91,6 +114,7 @@ func (r Ring) HasSkill(name string) bool {
 func ParseRing(data []byte) (Ring, error) {
 	ring := Ring{Members: []string{}, Skills: []string{}}
 
+	section := sectionTop
 	scanner := bufio.NewScanner(strings.NewReader(string(data)))
 	lineNo := 0
 	for scanner.Scan() {
@@ -106,7 +130,20 @@ func ParseRing(data []byte) (Ring, error) {
 		}
 
 		if strings.HasPrefix(line, "[") {
-			return Ring{}, fmt.Errorf("line %d: ring manifests have no sections", lineNo)
+			if !strings.HasSuffix(line, "]") {
+				return Ring{}, fmt.Errorf("line %d: invalid section header", lineNo)
+			}
+			name := strings.TrimSpace(line[1 : len(line)-1])
+			switch name {
+			case "contract":
+				section = name
+				if ring.Contract == nil {
+					ring.Contract = &RingContract{}
+				}
+			default:
+				return Ring{}, fmt.Errorf("line %d: unknown section %q", lineNo, name)
+			}
+			continue
 		}
 
 		key, value, err := splitKeyValue(line)
@@ -114,33 +151,20 @@ func ParseRing(data []byte) (Ring, error) {
 			return Ring{}, fmt.Errorf("line %d: %w", lineNo, err)
 		}
 
-		switch key {
-		case "name":
-			sv, err := parseString(value)
-			if err != nil {
-				return Ring{}, fmt.Errorf("line %d: invalid name: %w", lineNo, err)
+		switch section {
+		case sectionTop:
+			if err := parseRingTopLevel(&ring, key, value); err != nil {
+				return Ring{}, fmt.Errorf("line %d: %w", lineNo, err)
 			}
-			ring.Name = sv
-		case "members":
-			av, err := parseStringArray(value)
-			if err != nil {
-				return Ring{}, fmt.Errorf("line %d: invalid members: %w", lineNo, err)
+		case "contract":
+			if ring.Contract == nil {
+				ring.Contract = &RingContract{}
 			}
-			ring.Members = av
-		case "skills":
-			av, err := parseStringArray(value)
-			if err != nil {
-				return Ring{}, fmt.Errorf("line %d: invalid skills: %w", lineNo, err)
+			if err := parseRingContract(ring.Contract, key, value); err != nil {
+				return Ring{}, fmt.Errorf("line %d: %w", lineNo, err)
 			}
-			ring.Skills = av
-		case "description":
-			sv, err := parseString(value)
-			if err != nil {
-				return Ring{}, fmt.Errorf("line %d: invalid description: %w", lineNo, err)
-			}
-			ring.Description = sv
 		default:
-			return Ring{}, fmt.Errorf("line %d: unknown key %q", lineNo, key)
+			return Ring{}, fmt.Errorf("line %d: unknown parse section", lineNo)
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -151,6 +175,82 @@ func ParseRing(data []byte) (Ring, error) {
 		return Ring{}, err
 	}
 	return ring, nil
+}
+
+func parseRingTopLevel(ring *Ring, key, value string) error {
+	switch key {
+	case "name":
+		sv, err := parseString(value)
+		if err != nil {
+			return fmt.Errorf("invalid name: %w", err)
+		}
+		ring.Name = sv
+	case "members":
+		av, err := parseStringArray(value)
+		if err != nil {
+			return fmt.Errorf("invalid members: %w", err)
+		}
+		ring.Members = av
+	case "skills":
+		av, err := parseStringArray(value)
+		if err != nil {
+			return fmt.Errorf("invalid skills: %w", err)
+		}
+		ring.Skills = av
+	case "description":
+		sv, err := parseString(value)
+		if err != nil {
+			return fmt.Errorf("invalid description: %w", err)
+		}
+		ring.Description = sv
+	default:
+		return fmt.Errorf("unknown top-level key %q", key)
+	}
+	return nil
+}
+
+func parseRingContract(contract *RingContract, key, value string) error {
+	switch key {
+	case "summary":
+		sv, err := parseString(value)
+		if err != nil {
+			return fmt.Errorf("invalid contract summary: %w", err)
+		}
+		contract.Summary = sv
+	case "good_for":
+		av, err := parseStringArray(value)
+		if err != nil {
+			return fmt.Errorf("invalid contract good_for: %w", err)
+		}
+		contract.GoodFor = av
+	case "not_for":
+		av, err := parseStringArray(value)
+		if err != nil {
+			return fmt.Errorf("invalid contract not_for: %w", err)
+		}
+		contract.NotFor = av
+	case "required_context":
+		av, err := parseStringArray(value)
+		if err != nil {
+			return fmt.Errorf("invalid contract required_context: %w", err)
+		}
+		contract.RequiredContext = av
+	case "optional_context":
+		av, err := parseStringArray(value)
+		if err != nil {
+			return fmt.Errorf("invalid contract optional_context: %w", err)
+		}
+		contract.OptionalContext = av
+	case "expected_outputs":
+		av, err := parseStringArray(value)
+		if err != nil {
+			return fmt.Errorf("invalid contract expected_outputs: %w", err)
+		}
+		contract.ExpectedOutputs = av
+	default:
+		return fmt.Errorf("unknown key %q in [contract]", key)
+	}
+	return nil
 }
 
 // MarshalRing renders a deterministic TOML ring manifest with sorted members.
@@ -173,6 +273,27 @@ func MarshalRing(ring Ring) ([]byte, error) {
 	}
 	if strings.TrimSpace(ring.Description) != "" {
 		fmt.Fprintf(&b, "description = %s\n", strconv.Quote(ring.Description))
+	}
+	if !ring.Contract.Empty() {
+		b.WriteString("\n[contract]\n")
+		if strings.TrimSpace(ring.Contract.Summary) != "" {
+			fmt.Fprintf(&b, "summary = %s\n", strconv.Quote(ring.Contract.Summary))
+		}
+		if len(ring.Contract.GoodFor) > 0 {
+			fmt.Fprintf(&b, "good_for = %s\n", formatStringArray(ring.Contract.GoodFor))
+		}
+		if len(ring.Contract.NotFor) > 0 {
+			fmt.Fprintf(&b, "not_for = %s\n", formatStringArray(ring.Contract.NotFor))
+		}
+		if len(ring.Contract.RequiredContext) > 0 {
+			fmt.Fprintf(&b, "required_context = %s\n", formatStringArray(ring.Contract.RequiredContext))
+		}
+		if len(ring.Contract.OptionalContext) > 0 {
+			fmt.Fprintf(&b, "optional_context = %s\n", formatStringArray(ring.Contract.OptionalContext))
+		}
+		if len(ring.Contract.ExpectedOutputs) > 0 {
+			fmt.Fprintf(&b, "expected_outputs = %s\n", formatStringArray(ring.Contract.ExpectedOutputs))
+		}
 	}
 	return []byte(b.String()), nil
 }

--- a/internal/registry/ring_test.go
+++ b/internal/registry/ring_test.go
@@ -12,6 +12,14 @@ func TestParseAndMarshalRingRoundTrip(t *testing.T) {
 		Members:     []string{"stewreads", "arxiv"},
 		Skills:      []string{"release", "review"},
 		Description: "Research helpers",
+		Contract: &RingContract{
+			Summary:         "Investigate research context",
+			GoodFor:         []string{"source collection", "evidence review"},
+			NotFor:          []string{"deployments", "database mutation"},
+			RequiredContext: []string{"question", "time window"},
+			OptionalContext: []string{"artifact id", "request id"},
+			ExpectedOutputs: []string{"findings summary", "recommended next check"},
+		},
 	}
 
 	encoded, err := MarshalRing(in)
@@ -32,6 +40,9 @@ func TestParseAndMarshalRingRoundTrip(t *testing.T) {
 	if !reflect.DeepEqual(out.Skills, []string{"release", "review"}) {
 		t.Fatalf("expected sorted skills to survive roundtrip, got: %#v", out.Skills)
 	}
+	if !ringContractsEqual(out.Contract, in.Contract) {
+		t.Fatalf("expected contract to survive roundtrip, got: %#v", out.Contract)
+	}
 }
 
 func TestMarshalRingIsDeterministic(t *testing.T) {
@@ -50,6 +61,51 @@ func TestMarshalRingIsDeterministic(t *testing.T) {
 	expected := "name = \"research\"\nmembers = [\"alpha\", \"beta\"]\nskills = [\"audit\", \"release\"]\n"
 	if string(a) != expected {
 		t.Fatalf("expected deterministic output:\n%s\ngot:\n%s", expected, a)
+	}
+}
+
+func TestMarshalRingPreservesContractOrder(t *testing.T) {
+	ring := Ring{
+		Name:    "observe",
+		Members: []string{"logs"},
+		Contract: &RingContract{
+			Summary:         "Observe production behavior",
+			GoodFor:         []string{"logs", "traces"},
+			NotFor:          []string{"deployments", "schema changes"},
+			RequiredContext: []string{"project", "region", "time window"},
+			OptionalContext: []string{"request id", "trace id"},
+			ExpectedOutputs: []string{"findings", "evidence", "next check"},
+		},
+	}
+
+	encoded, err := MarshalRing(ring)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	expected := `name = "observe"
+members = ["logs"]
+
+[contract]
+summary = "Observe production behavior"
+good_for = ["logs", "traces"]
+not_for = ["deployments", "schema changes"]
+required_context = ["project", "region", "time window"]
+optional_context = ["request id", "trace id"]
+expected_outputs = ["findings", "evidence", "next check"]
+`
+	if string(encoded) != expected {
+		t.Fatalf("expected contract order to be preserved:\n%s\ngot:\n%s", expected, encoded)
+	}
+}
+
+func TestMarshalRingOmitsEmptyContract(t *testing.T) {
+	encoded, err := MarshalRing(Ring{Name: "observe", Members: []string{"logs"}, Contract: &RingContract{}})
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	expected := "name = \"observe\"\nmembers = [\"logs\"]\n"
+	if string(encoded) != expected {
+		t.Fatalf("expected empty contract to be omitted:\n%s\ngot:\n%s", expected, encoded)
 	}
 }
 
@@ -74,12 +130,12 @@ command = "/bin/echo"
 	if err == nil {
 		t.Fatalf("expected parse error for unknown key")
 	}
-	if !strings.Contains(err.Error(), "unknown key") {
+	if !strings.Contains(err.Error(), "unknown top-level key") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
-func TestParseRingRejectsSections(t *testing.T) {
+func TestParseRingRejectsUnknownSections(t *testing.T) {
 	manifest := `
 name = "research"
 members = ["stewreads"]
@@ -91,7 +147,24 @@ KEY = "value"
 	if err == nil {
 		t.Fatalf("expected parse error for section")
 	}
-	if !strings.Contains(err.Error(), "no sections") {
+	if !strings.Contains(err.Error(), "unknown section") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestParseRingRejectsUnknownContractKey(t *testing.T) {
+	manifest := `
+name = "research"
+members = ["stewreads"]
+
+[contract]
+unknown = "value"
+`
+	_, err := ParseRing([]byte(manifest))
+	if err == nil {
+		t.Fatalf("expected parse error for unknown contract key")
+	}
+	if !strings.Contains(err.Error(), `unknown key "unknown" in [contract]`) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/registry/ring_test.go
+++ b/internal/registry/ring_test.go
@@ -109,6 +109,44 @@ func TestMarshalRingOmitsEmptyContract(t *testing.T) {
 	}
 }
 
+func TestParseAndMarshalRingContractFile(t *testing.T) {
+	payload := `summary = "Observe production behavior"
+good_for = ["logs", "traces"]
+not_for = ["deployments", "schema changes"]
+required_context = ["project", "region", "time window"]
+optional_context = ["request id", "trace id"]
+expected_outputs = ["findings", "evidence", "next check"]
+`
+
+	contract, err := ParseRingContract([]byte(payload))
+	if err != nil {
+		t.Fatalf("parse contract failed: %v", err)
+	}
+	if !reflect.DeepEqual(contract.GoodFor, []string{"logs", "traces"}) {
+		t.Fatalf("expected contract array order preserved, got: %#v", contract.GoodFor)
+	}
+
+	encoded, err := MarshalRingContract(contract)
+	if err != nil {
+		t.Fatalf("marshal contract failed: %v", err)
+	}
+	if string(encoded) != payload {
+		t.Fatalf("expected deterministic contract file:\n%s\ngot:\n%s", payload, encoded)
+	}
+}
+
+func TestParseRingContractRejectsUnknownKeysAndSections(t *testing.T) {
+	if _, err := ParseRingContract([]byte(`unknown = "value"`)); err == nil || !strings.Contains(err.Error(), `unknown key "unknown" in contract file`) {
+		t.Fatalf("expected unknown contract file key error, got: %v", err)
+	}
+	if _, err := ParseRingContract([]byte("[contract]\nsummary = \"value\"\n")); err == nil || !strings.Contains(err.Error(), "unknown section") {
+		t.Fatalf("expected contract file section error, got: %v", err)
+	}
+	if _, err := ParseRingContract([]byte("# empty\n")); err == nil || !strings.Contains(err.Error(), "contract file has no fields") {
+		t.Fatalf("expected empty contract file error, got: %v", err)
+	}
+}
+
 func TestMarshalRingAllowsSkillOnlyRing(t *testing.T) {
 	encoded, err := MarshalRing(Ring{Name: "workflow", Skills: []string{"release"}})
 	if err != nil {

--- a/internal/registry/snapshot.go
+++ b/internal/registry/snapshot.go
@@ -12,7 +12,8 @@ const (
 	snapshotVersionV1 = 1
 	snapshotVersionV2 = 2
 	snapshotVersionV3 = 3
-	SnapshotVersion   = 4
+	snapshotVersionV4 = 4
+	SnapshotVersion   = 5
 )
 
 type Snapshot struct {
@@ -294,7 +295,7 @@ func ImportSnapshot(store *Store, snapshot Snapshot, apply bool) (ImportResult, 
 }
 
 func (s Snapshot) Validate() error {
-	if s.Version != snapshotVersionV1 && s.Version != snapshotVersionV2 && s.Version != snapshotVersionV3 && s.Version != SnapshotVersion {
+	if s.Version != snapshotVersionV1 && s.Version != snapshotVersionV2 && s.Version != snapshotVersionV3 && s.Version != snapshotVersionV4 && s.Version != SnapshotVersion {
 		return fmt.Errorf("unsupported snapshot version %d (supported: %d)", s.Version, SnapshotVersion)
 	}
 	if s.Version == snapshotVersionV1 && len(s.Rings) > 0 {
@@ -303,8 +304,11 @@ func (s Snapshot) Validate() error {
 	if s.Version < snapshotVersionV3 && len(s.Skills) > 0 {
 		return fmt.Errorf("snapshot version %d does not support skills", s.Version)
 	}
-	if s.Version < SnapshotVersion && snapshotHasRingSkills(s) {
+	if s.Version < snapshotVersionV4 && snapshotHasRingSkills(s) {
 		return fmt.Errorf("snapshot version %d does not support ring skills", s.Version)
+	}
+	if s.Version < SnapshotVersion && snapshotHasRingContracts(s) {
+		return fmt.Errorf("snapshot version %d does not support ring contracts", s.Version)
 	}
 
 	seen := map[string]struct{}{}
@@ -427,7 +431,22 @@ func ringsEqual(a, b Ring) bool {
 	}
 	aSkills := normalizedRingSkills(a)
 	bSkills := normalizedRingSkills(b)
-	return slices.Equal(aSkills, bSkills)
+	return slices.Equal(aSkills, bSkills) && ringContractsEqual(a.Contract, b.Contract)
+}
+
+func ringContractsEqual(a, b *RingContract) bool {
+	if a.Empty() && b.Empty() {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return a.Summary == b.Summary &&
+		slices.Equal(a.GoodFor, b.GoodFor) &&
+		slices.Equal(a.NotFor, b.NotFor) &&
+		slices.Equal(a.RequiredContext, b.RequiredContext) &&
+		slices.Equal(a.OptionalContext, b.OptionalContext) &&
+		slices.Equal(a.ExpectedOutputs, b.ExpectedOutputs)
 }
 
 func skillsEqual(a, b SnapshotSkill) bool {
@@ -486,6 +505,15 @@ func normalizedRingSkills(r Ring) []string {
 func snapshotHasRingSkills(snapshot Snapshot) bool {
 	for _, ring := range snapshot.Rings {
 		if len(ring.Skills) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func snapshotHasRingContracts(snapshot Snapshot) bool {
+	for _, ring := range snapshot.Rings {
+		if ring.Contract != nil {
 			return true
 		}
 	}

--- a/internal/registry/snapshot_test.go
+++ b/internal/registry/snapshot_test.go
@@ -31,6 +31,12 @@ func TestSnapshotExportParseRoundTrip(t *testing.T) {
 		Members:     []string{"beta", "alpha"},
 		Skills:      []string{"release"},
 		Description: "Research helpers",
+		Contract: &RingContract{
+			Summary:         "Collect research evidence",
+			GoodFor:         []string{"source review", "fact checking"},
+			RequiredContext: []string{"research question"},
+			ExpectedOutputs: []string{"findings summary"},
+		},
 	}); err != nil {
 		t.Fatalf("save ring: %v", err)
 	}
@@ -73,6 +79,9 @@ func TestSnapshotExportParseRoundTrip(t *testing.T) {
 	if got := strings.Join(parsed.Rings[0].Skills, ","); got != "release" {
 		t.Fatalf("expected deterministic ring skills, got: %s", got)
 	}
+	if parsed.Rings[0].Contract == nil || parsed.Rings[0].Contract.Summary != "Collect research evidence" {
+		t.Fatalf("expected ring contract in parsed snapshot, got: %#v", parsed.Rings[0].Contract)
+	}
 	if len(parsed.Skills) != 1 || parsed.Skills[0].Name != "release" {
 		t.Fatalf("expected release skill in parsed snapshot, got: %#v", parsed.Skills)
 	}
@@ -102,6 +111,14 @@ func TestMarshalSnapshotUsesSnakeCaseKeys(t *testing.T) {
 				Members:     []string{"alpha"},
 				Skills:      []string{"release"},
 				Description: "Research helpers",
+				Contract: &RingContract{
+					Summary:         "Research contract",
+					GoodFor:         []string{"source review"},
+					NotFor:          []string{"deployments"},
+					RequiredContext: []string{"question"},
+					OptionalContext: []string{"time window"},
+					ExpectedOutputs: []string{"findings summary"},
+				},
 			},
 		},
 		Skills: []SnapshotSkill{
@@ -118,7 +135,7 @@ func TestMarshalSnapshotUsesSnakeCaseKeys(t *testing.T) {
 		t.Fatalf("marshal snapshot failed: %v", err)
 	}
 	text := string(payload)
-	for _, key := range []string{`"name"`, `"command"`, `"args"`, `"enabled"`, `"clients"`, `"required_env"`, `"keys"`, `"rings"`, `"members"`, `"skills"`, `"content"`, `"description"`} {
+	for _, key := range []string{`"name"`, `"command"`, `"args"`, `"enabled"`, `"clients"`, `"required_env"`, `"keys"`, `"rings"`, `"members"`, `"skills"`, `"content"`, `"description"`, `"contract"`, `"summary"`, `"good_for"`, `"not_for"`, `"required_context"`, `"optional_context"`, `"expected_outputs"`} {
 		if !strings.Contains(text, key) {
 			t.Fatalf("expected payload to contain key %s, payload=%s", key, text)
 		}
@@ -169,6 +186,14 @@ func TestParseSnapshotV3RejectsRingSkills(t *testing.T) {
 	_, err := ParseSnapshotJSON(payload)
 	if err == nil || !strings.Contains(err.Error(), "does not support ring skills") {
 		t.Fatalf("expected v3 ring-skills error, got: %v", err)
+	}
+}
+
+func TestParseSnapshotV4RejectsRingContracts(t *testing.T) {
+	payload := []byte(`{"version":4,"servers":[],"rings":[{"name":"research","members":["alpha"],"contract":{"summary":"Use me"}}]}`)
+	_, err := ParseSnapshotJSON(payload)
+	if err == nil || !strings.Contains(err.Error(), "does not support ring contracts") {
+		t.Fatalf("expected v4 ring-contract error, got: %v", err)
 	}
 }
 
@@ -374,6 +399,61 @@ func TestImportSnapshotRingsWithSkillsDryRunAndApply(t *testing.T) {
 	}
 	if strings.Join(afterApply.Skills, ",") != "release,review" || afterApply.Description != "new" {
 		t.Fatalf("expected workflow ring skills updated, got: %#v", afterApply)
+	}
+}
+
+func TestImportSnapshotRingsWithContractDryRunAndApply(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "servers"))
+	if err := store.Save(Manifest{Name: "alpha", Command: "/usr/bin/env", Enabled: true, Clients: []string{"claude-desktop"}}); err != nil {
+		t.Fatalf("save alpha manifest: %v", err)
+	}
+	if err := store.SaveRing(Ring{Name: "observe", Members: []string{"alpha"}, Description: "same"}); err != nil {
+		t.Fatalf("save ring: %v", err)
+	}
+
+	contract := &RingContract{
+		Summary:         "Observe runtime behavior",
+		GoodFor:         []string{"logs", "traces"},
+		NotFor:          []string{"deployments"},
+		RequiredContext: []string{"service", "time window"},
+		OptionalContext: []string{"request id"},
+		ExpectedOutputs: []string{"findings", "next check"},
+	}
+	snapshot := Snapshot{
+		Version: SnapshotVersion,
+		Rings: []Ring{
+			{Name: "observe", Members: []string{"alpha"}, Description: "same", Contract: contract},
+		},
+	}
+
+	dryRunResult, err := ImportSnapshot(store, snapshot, false)
+	if err != nil {
+		t.Fatalf("dry-run import failed: %v", err)
+	}
+	if len(dryRunResult.RingsUpdated) != 1 || dryRunResult.RingsUpdated[0] != "observe" {
+		t.Fatalf("expected observe ring updated in dry-run, got: %+v", dryRunResult)
+	}
+	afterDryRun, err := store.GetRing("observe")
+	if err != nil {
+		t.Fatalf("load observe after dry-run: %v", err)
+	}
+	if afterDryRun.Contract != nil {
+		t.Fatalf("expected dry-run not to change ring contract, got: %#v", afterDryRun.Contract)
+	}
+
+	applyResult, err := ImportSnapshot(store, snapshot, true)
+	if err != nil {
+		t.Fatalf("apply import failed: %v", err)
+	}
+	if len(applyResult.RingsUpdated) != 1 || applyResult.RingsUpdated[0] != "observe" {
+		t.Fatalf("expected observe ring updated in apply, got: %+v", applyResult)
+	}
+	afterApply, err := store.GetRing("observe")
+	if err != nil {
+		t.Fatalf("load observe after apply: %v", err)
+	}
+	if !ringContractsEqual(afterApply.Contract, contract) {
+		t.Fatalf("expected observe contract updated, got: %#v", afterApply.Contract)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Added optional advisory `[contract]` metadata to ring TOML with `summary`, `good_for`, `not_for`, `required_context`, `optional_context`, and `expected_outputs`.
- Bumped snapshot support to version 5 and CLI JSON output to schema version 2 so contracts are portable through import/export and visible through JSON surfaces.
- Added `madari ring contract show|set|clear` so agents and users can manage contracts through standalone contract TOML files instead of editing ring manifests directly.
- Updated manifest, CLI, architecture, and README docs with the contract semantics and file-level workflow.

## Why

Ring contracts give a delegating model a structured description of when a ring is useful, what context it expects, and what outputs it should produce, while keeping contracts advisory and separate from attach, sync, render, ownership, and future run/session/context primitives.

## Validation

- `go test ./internal/registry`
- `go test ./cmd/madari`
- `make build`
- `go test ./...`
- `go vet ./...`
- `git diff --check`