### PR TITLE
sync: conflict on raw MCP name mismatches

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,11 +142,13 @@ not run inputs yet.
 - Entries Madari does not manage keep their JSON value, including fields and
   server shapes Madari does not model (e.g. `type`/`url` remote entries);
   only managed or newly added entries are serialized from manifests. The
-  enclosing document is reformatted on write. If an unmanaged entry has the
-  same name as a desired manifest, Madari only treats it as an exact match
-  when its canonical raw JSON equals the manifest materialization; extra or
-  unmodeled fields are reported as a conflict instead of being silently
-  preserved under a trusted manifest name.
+  enclosing document is reformatted on write. For adapters with raw-match
+  validation (currently Claude Code and Claude Desktop), if an unmanaged entry
+  has the same name as a desired manifest, Madari only treats it as an exact
+  match when its canonical raw JSON, after normalizing empty modeled optional
+  fields, equals the manifest materialization; extra or unmodeled fields are
+  reported as a conflict instead of being silently preserved under a trusted
+  manifest name.
 - Keep managed entries isolated via per-target managed state tracking files
   (per scope for clients with both repo- and user-scoped configs).
 - Never adopt pre-existing entries Madari did not create, even when their

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,7 +142,11 @@ not run inputs yet.
 - Entries Madari does not manage keep their JSON value, including fields and
   server shapes Madari does not model (e.g. `type`/`url` remote entries);
   only managed or newly added entries are serialized from manifests. The
-  enclosing document is reformatted on write.
+  enclosing document is reformatted on write. If an unmanaged entry has the
+  same name as a desired manifest, Madari only treats it as an exact match
+  when its canonical raw JSON equals the manifest materialization; extra or
+  unmodeled fields are reported as a conflict instead of being silently
+  preserved under a trusted manifest name.
 - Keep managed entries isolated via per-target managed state tracking files
   (per scope for clients with both repo- and user-scoped configs).
 - Never adopt pre-existing entries Madari did not create, even when their

--- a/internal/clients/claude-desktop/sync.go
+++ b/internal/clients/claude-desktop/sync.go
@@ -328,27 +328,52 @@ func rawMatchesServer(raw json.RawMessage, server serverConfig) bool {
 	if err != nil {
 		return false
 	}
-	rawPayload, ok := canonicalJSON(raw)
+	rawPayload, ok := canonicalServerJSON(raw)
 	if !ok {
 		return false
 	}
-	desiredPayload, ok := canonicalJSON(desired)
+	desiredPayload, ok := canonicalServerJSON(desired)
 	if !ok {
 		return false
 	}
 	return string(rawPayload) == string(desiredPayload)
 }
 
-func canonicalJSON(payload []byte) ([]byte, bool) {
-	var value any
-	if err := json.Unmarshal(payload, &value); err != nil {
+func canonicalServerJSON(payload []byte) ([]byte, bool) {
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &object); err != nil {
 		return nil, false
 	}
-	canonical, err := json.Marshal(value)
+	if !stripEmptyModeledServerFields(object) {
+		return nil, false
+	}
+	canonical, err := json.Marshal(object)
 	if err != nil {
 		return nil, false
 	}
 	return canonical, true
+}
+
+func stripEmptyModeledServerFields(object map[string]json.RawMessage) bool {
+	if raw, exists := object["args"]; exists {
+		var args []string
+		if err := json.Unmarshal(raw, &args); err != nil {
+			return false
+		}
+		if len(args) == 0 {
+			delete(object, "args")
+		}
+	}
+	if raw, exists := object["env"]; exists {
+		var env map[string]string
+		if err := json.Unmarshal(raw, &env); err != nil {
+			return false
+		}
+		if len(env) == 0 {
+			delete(object, "env")
+		}
+	}
+	return true
 }
 
 // loadClaudeConfig returns the config root plus two views of mcpServers:

--- a/internal/clients/claude-desktop/sync.go
+++ b/internal/clients/claude-desktop/sync.go
@@ -340,7 +340,7 @@ func rawMatchesServer(raw json.RawMessage, server serverConfig) bool {
 }
 
 func canonicalServerJSON(payload []byte) ([]byte, bool) {
-	var object map[string]json.RawMessage
+	var object map[string]any
 	if err := json.Unmarshal(payload, &object); err != nil {
 		return nil, false
 	}
@@ -354,19 +354,19 @@ func canonicalServerJSON(payload []byte) ([]byte, bool) {
 	return canonical, true
 }
 
-func stripEmptyModeledServerFields(object map[string]json.RawMessage) bool {
-	if raw, exists := object["args"]; exists {
-		var args []string
-		if err := json.Unmarshal(raw, &args); err != nil {
+func stripEmptyModeledServerFields(object map[string]any) bool {
+	if value, exists := object["args"]; exists {
+		args, ok := value.([]any)
+		if !ok {
 			return false
 		}
 		if len(args) == 0 {
 			delete(object, "args")
 		}
 	}
-	if raw, exists := object["env"]; exists {
-		var env map[string]string
-		if err := json.Unmarshal(raw, &env); err != nil {
+	if value, exists := object["env"]; exists {
+		env, ok := value.(map[string]any)
+		if !ok {
 			return false
 		}
 		if len(env) == 0 {

--- a/internal/clients/claude-desktop/sync.go
+++ b/internal/clients/claude-desktop/sync.go
@@ -328,15 +328,27 @@ func rawMatchesServer(raw json.RawMessage, server serverConfig) bool {
 	if err != nil {
 		return false
 	}
-	var rawCanonical any
-	if err := json.Unmarshal(raw, &rawCanonical); err != nil {
+	rawPayload, ok := canonicalJSON(raw)
+	if !ok {
 		return false
 	}
-	rawPayload, err := json.Marshal(rawCanonical)
+	desiredPayload, ok := canonicalJSON(desired)
+	if !ok {
+		return false
+	}
+	return string(rawPayload) == string(desiredPayload)
+}
+
+func canonicalJSON(payload []byte) ([]byte, bool) {
+	var value any
+	if err := json.Unmarshal(payload, &value); err != nil {
+		return nil, false
+	}
+	canonical, err := json.Marshal(value)
 	if err != nil {
-		return false
+		return nil, false
 	}
-	return string(rawPayload) == string(desired)
+	return canonical, true
 }
 
 // loadClaudeConfig returns the config root plus two views of mcpServers:

--- a/internal/clients/claude-desktop/sync.go
+++ b/internal/clients/claude-desktop/sync.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 
 	"github.com/ankitvg/madari/internal/clients"
@@ -46,7 +47,11 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 		return SyncResult{}, err
 	}
 
-	result, nextState, writeSet, err := syncshared.PlanSync(existingServers, managedState, entriesForTarget(manifests), opts.Rings, equalServer, ErrConflict)
+	entries := entriesForTarget(manifests)
+	if err := rejectRawMismatchedUnmanagedEntries(rawServers, existingServers, managedState, entries); err != nil {
+		return SyncResult{}, err
+	}
+	result, nextState, writeSet, err := syncshared.PlanSync(existingServers, managedState, entries, opts.Rings, equalServer, ErrConflict)
 	if err != nil {
 		return SyncResult{}, err
 	}
@@ -285,6 +290,53 @@ func equalServer(a, b serverConfig) bool {
 		}
 	}
 	return true
+}
+
+func rejectRawMismatchedUnmanagedEntries(
+	rawServers map[string]json.RawMessage,
+	existingServers map[string]serverConfig,
+	managedState map[string][]string,
+	entries map[string]syncshared.Entry[serverConfig],
+) error {
+	var conflicts []string
+	for name, entry := range entries {
+		if !entry.Eligible || len(managedState[name]) > 0 {
+			continue
+		}
+		raw, exists := rawServers[name]
+		if !exists {
+			continue
+		}
+		existing, exists := existingServers[name]
+		if !exists || !equalServer(existing, entry.Value) {
+			continue
+		}
+		if rawMatchesServer(raw, entry.Value) {
+			continue
+		}
+		conflicts = append(conflicts, name)
+	}
+	if len(conflicts) > 0 {
+		sort.Strings(conflicts)
+		return fmt.Errorf("%w: unmanaged entries already exist with different raw JSON: %s", ErrConflict, strings.Join(conflicts, ", "))
+	}
+	return nil
+}
+
+func rawMatchesServer(raw json.RawMessage, server serverConfig) bool {
+	desired, err := json.Marshal(server)
+	if err != nil {
+		return false
+	}
+	var rawCanonical any
+	if err := json.Unmarshal(raw, &rawCanonical); err != nil {
+		return false
+	}
+	rawPayload, err := json.Marshal(rawCanonical)
+	if err != nil {
+		return false
+	}
+	return string(rawPayload) == string(desired)
 }
 
 // loadClaudeConfig returns the config root plus two views of mcpServers:

--- a/internal/clients/claude-desktop/sync_test.go
+++ b/internal/clients/claude-desktop/sync_test.go
@@ -622,6 +622,49 @@ func TestSyncAllowsRawMatchedEqualUnmanagedEntryWithEmptyOptionalFields(t *testi
 	}
 }
 
+func TestSyncAllowsRawMatchedEqualUnmanagedEntryWithUnsortedEnv(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "claude_desktop_config.json")
+	statePath := filepath.Join(tmp, "state", "claude-desktop-managed.json")
+
+	config := []byte(`{
+  "mcpServers": {
+    "runner": {
+      "command": "npx",
+      "env": {
+        "B": "2",
+        "A": "1"
+      }
+    }
+  }
+}
+`)
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	manifest := newStewreadsManifest()
+	manifest.Name = "runner"
+	manifest.Command = "npx"
+	manifest.Args = nil
+	manifest.Env = map[string]string{"A": "1", "B": "2"}
+
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("expected raw-matched unmanaged entry with unsorted env to sync unchanged, got: %v", err)
+	}
+	if len(result.Unchanged) != 1 || result.Unchanged[0] != "runner" {
+		t.Fatalf("expected runner unchanged, got: %+v", result)
+	}
+	servers := readRawServerObjects(t, configPath)
+	if env, ok := servers["runner"]["env"].(map[string]any); !ok || env["A"] != "1" || env["B"] != "2" {
+		t.Fatalf("expected env to remain preserved, got: %#v", servers["runner"]["env"])
+	}
+}
+
 func readRawServerObjects(t *testing.T, configPath string) map[string]map[string]any {
 	t.Helper()
 	root := readRoot(t, configPath)

--- a/internal/clients/claude-desktop/sync_test.go
+++ b/internal/clients/claude-desktop/sync_test.go
@@ -542,6 +542,42 @@ func TestSyncConflictsOnRawMismatchedEqualUnmanagedEntry(t *testing.T) {
 	}
 }
 
+func TestSyncAllowsRawMatchedEqualUnmanagedEntryWithArgs(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "claude_desktop_config.json")
+	statePath := filepath.Join(tmp, "state", "claude-desktop-managed.json")
+
+	config := []byte(`{
+  "mcpServers": {
+    "runner": {
+      "command": "npx",
+      "args": ["-y", "example-runner"]
+    }
+  }
+}
+`)
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	manifest := newStewreadsManifest()
+	manifest.Name = "runner"
+	manifest.Command = "npx"
+	manifest.Args = []string{"-y", "example-runner"}
+	manifest.Env = nil
+
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("expected raw-matched unmanaged entry with args to sync unchanged, got: %v", err)
+	}
+	if len(result.Unchanged) != 1 || result.Unchanged[0] != "runner" {
+		t.Fatalf("expected runner unchanged, got: %+v", result)
+	}
+}
+
 func readRawServerObjects(t *testing.T, configPath string) map[string]map[string]any {
 	t.Helper()
 	root := readRoot(t, configPath)

--- a/internal/clients/claude-desktop/sync_test.go
+++ b/internal/clients/claude-desktop/sync_test.go
@@ -506,7 +506,7 @@ func TestSyncPreservesUnmanagedEntryFieldsAndShapes(t *testing.T) {
 	assertPreserved(readRawServerObjects(t, configPath))
 }
 
-func TestSyncKeepsExtraFieldsOnEqualUnmanagedEntry(t *testing.T) {
+func TestSyncConflictsOnRawMismatchedEqualUnmanagedEntry(t *testing.T) {
 	tmp := t.TempDir()
 	configPath := filepath.Join(tmp, "claude_desktop_config.json")
 	statePath := filepath.Join(tmp, "state", "claude-desktop-managed.json")
@@ -528,20 +528,17 @@ func TestSyncKeepsExtraFieldsOnEqualUnmanagedEntry(t *testing.T) {
 		t.Fatalf("write config fixture: %v", err)
 	}
 
-	result, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+	_, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
 		ConfigPath: configPath,
 		StatePath:  statePath,
 	})
-	if err != nil {
-		t.Fatalf("sync apply failed: %v", err)
-	}
-	if len(result.Unchanged) != 1 || result.Unchanged[0] != "stewreads" {
-		t.Fatalf("expected equal unmanaged entry to be unchanged, got: %+v", result)
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected ErrConflict for raw-mismatched equal unmanaged entry, got: %v", err)
 	}
 
 	servers := readRawServerObjects(t, configPath)
 	if servers["stewreads"]["note"] != "mine" {
-		t.Fatalf("expected unadopted equal entry to keep extra fields, got: %#v", servers["stewreads"])
+		t.Fatalf("expected conflicted unmanaged entry to remain untouched, got: %#v", servers["stewreads"])
 	}
 }
 

--- a/internal/clients/claude-desktop/sync_test.go
+++ b/internal/clients/claude-desktop/sync_test.go
@@ -578,6 +578,50 @@ func TestSyncAllowsRawMatchedEqualUnmanagedEntryWithArgs(t *testing.T) {
 	}
 }
 
+func TestSyncAllowsRawMatchedEqualUnmanagedEntryWithEmptyOptionalFields(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "claude_desktop_config.json")
+	statePath := filepath.Join(tmp, "state", "claude-desktop-managed.json")
+
+	config := []byte(`{
+  "mcpServers": {
+    "runner": {
+      "command": "npx",
+      "args": [],
+      "env": {}
+    }
+  }
+}
+`)
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	manifest := newStewreadsManifest()
+	manifest.Name = "runner"
+	manifest.Command = "npx"
+	manifest.Args = nil
+	manifest.Env = nil
+
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("expected raw-matched unmanaged entry with empty optional fields to sync unchanged, got: %v", err)
+	}
+	if len(result.Unchanged) != 1 || result.Unchanged[0] != "runner" {
+		t.Fatalf("expected runner unchanged, got: %+v", result)
+	}
+	servers := readRawServerObjects(t, configPath)
+	if args, ok := servers["runner"]["args"].([]any); !ok || len(args) != 0 {
+		t.Fatalf("expected empty args to remain preserved, got: %#v", servers["runner"]["args"])
+	}
+	if env, ok := servers["runner"]["env"].(map[string]any); !ok || len(env) != 0 {
+		t.Fatalf("expected empty env to remain preserved, got: %#v", servers["runner"]["env"])
+	}
+}
+
 func readRawServerObjects(t *testing.T, configPath string) map[string]map[string]any {
 	t.Helper()
 	root := readRoot(t, configPath)

--- a/internal/clients/claudecode/sync.go
+++ b/internal/clients/claudecode/sync.go
@@ -392,7 +392,7 @@ func rawMatchesServer(raw json.RawMessage, server serverConfig) bool {
 }
 
 func canonicalServerJSON(payload []byte) ([]byte, bool) {
-	var object map[string]json.RawMessage
+	var object map[string]any
 	if err := json.Unmarshal(payload, &object); err != nil {
 		return nil, false
 	}
@@ -406,19 +406,19 @@ func canonicalServerJSON(payload []byte) ([]byte, bool) {
 	return canonical, true
 }
 
-func stripEmptyModeledServerFields(object map[string]json.RawMessage) bool {
-	if raw, exists := object["args"]; exists {
-		var args []string
-		if err := json.Unmarshal(raw, &args); err != nil {
+func stripEmptyModeledServerFields(object map[string]any) bool {
+	if value, exists := object["args"]; exists {
+		args, ok := value.([]any)
+		if !ok {
 			return false
 		}
 		if len(args) == 0 {
 			delete(object, "args")
 		}
 	}
-	if raw, exists := object["env"]; exists {
-		var env map[string]string
-		if err := json.Unmarshal(raw, &env); err != nil {
+	if value, exists := object["env"]; exists {
+		env, ok := value.(map[string]any)
+		if !ok {
 			return false
 		}
 		if len(env) == 0 {

--- a/internal/clients/claudecode/sync.go
+++ b/internal/clients/claudecode/sync.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/ankitvg/madari/internal/clients"
@@ -57,7 +58,11 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 		return SyncResult{}, err
 	}
 
-	result, nextState, writeSet, err := syncshared.PlanSync(existingServers, managedState, entriesForTarget(manifests, userScope), opts.Rings, equalServer, ErrConflict)
+	entries := entriesForTarget(manifests, userScope)
+	if err := rejectRawMismatchedUnmanagedEntries(rawServers, existingServers, managedState, entries); err != nil {
+		return SyncResult{}, err
+	}
+	result, nextState, writeSet, err := syncshared.PlanSync(existingServers, managedState, entries, opts.Rings, equalServer, ErrConflict)
 	if err != nil {
 		return SyncResult{}, err
 	}
@@ -337,6 +342,53 @@ func equalServer(a, b serverConfig) bool {
 		}
 	}
 	return true
+}
+
+func rejectRawMismatchedUnmanagedEntries(
+	rawServers map[string]json.RawMessage,
+	existingServers map[string]serverConfig,
+	managedState map[string][]string,
+	entries map[string]syncshared.Entry[serverConfig],
+) error {
+	var conflicts []string
+	for name, entry := range entries {
+		if !entry.Eligible || len(managedState[name]) > 0 {
+			continue
+		}
+		raw, exists := rawServers[name]
+		if !exists {
+			continue
+		}
+		existing, exists := existingServers[name]
+		if !exists || !equalServer(existing, entry.Value) {
+			continue
+		}
+		if rawMatchesServer(raw, entry.Value) {
+			continue
+		}
+		conflicts = append(conflicts, name)
+	}
+	if len(conflicts) > 0 {
+		sort.Strings(conflicts)
+		return fmt.Errorf("%w: unmanaged entries already exist with different raw JSON: %s", ErrConflict, strings.Join(conflicts, ", "))
+	}
+	return nil
+}
+
+func rawMatchesServer(raw json.RawMessage, server serverConfig) bool {
+	desired, err := json.Marshal(server)
+	if err != nil {
+		return false
+	}
+	var rawCanonical any
+	if err := json.Unmarshal(raw, &rawCanonical); err != nil {
+		return false
+	}
+	rawPayload, err := json.Marshal(rawCanonical)
+	if err != nil {
+		return false
+	}
+	return string(rawPayload) == string(desired)
 }
 
 // loadClaudeCodeConfig returns the config root plus two views of mcpServers:

--- a/internal/clients/claudecode/sync.go
+++ b/internal/clients/claudecode/sync.go
@@ -380,27 +380,52 @@ func rawMatchesServer(raw json.RawMessage, server serverConfig) bool {
 	if err != nil {
 		return false
 	}
-	rawPayload, ok := canonicalJSON(raw)
+	rawPayload, ok := canonicalServerJSON(raw)
 	if !ok {
 		return false
 	}
-	desiredPayload, ok := canonicalJSON(desired)
+	desiredPayload, ok := canonicalServerJSON(desired)
 	if !ok {
 		return false
 	}
 	return string(rawPayload) == string(desiredPayload)
 }
 
-func canonicalJSON(payload []byte) ([]byte, bool) {
-	var value any
-	if err := json.Unmarshal(payload, &value); err != nil {
+func canonicalServerJSON(payload []byte) ([]byte, bool) {
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &object); err != nil {
 		return nil, false
 	}
-	canonical, err := json.Marshal(value)
+	if !stripEmptyModeledServerFields(object) {
+		return nil, false
+	}
+	canonical, err := json.Marshal(object)
 	if err != nil {
 		return nil, false
 	}
 	return canonical, true
+}
+
+func stripEmptyModeledServerFields(object map[string]json.RawMessage) bool {
+	if raw, exists := object["args"]; exists {
+		var args []string
+		if err := json.Unmarshal(raw, &args); err != nil {
+			return false
+		}
+		if len(args) == 0 {
+			delete(object, "args")
+		}
+	}
+	if raw, exists := object["env"]; exists {
+		var env map[string]string
+		if err := json.Unmarshal(raw, &env); err != nil {
+			return false
+		}
+		if len(env) == 0 {
+			delete(object, "env")
+		}
+	}
+	return true
 }
 
 // loadClaudeCodeConfig returns the config root plus two views of mcpServers:

--- a/internal/clients/claudecode/sync.go
+++ b/internal/clients/claudecode/sync.go
@@ -380,15 +380,27 @@ func rawMatchesServer(raw json.RawMessage, server serverConfig) bool {
 	if err != nil {
 		return false
 	}
-	var rawCanonical any
-	if err := json.Unmarshal(raw, &rawCanonical); err != nil {
+	rawPayload, ok := canonicalJSON(raw)
+	if !ok {
 		return false
 	}
-	rawPayload, err := json.Marshal(rawCanonical)
+	desiredPayload, ok := canonicalJSON(desired)
+	if !ok {
+		return false
+	}
+	return string(rawPayload) == string(desiredPayload)
+}
+
+func canonicalJSON(payload []byte) ([]byte, bool) {
+	var value any
+	if err := json.Unmarshal(payload, &value); err != nil {
+		return nil, false
+	}
+	canonical, err := json.Marshal(value)
 	if err != nil {
-		return false
+		return nil, false
 	}
-	return string(rawPayload) == string(desired)
+	return canonical, true
 }
 
 // loadClaudeCodeConfig returns the config root plus two views of mcpServers:

--- a/internal/clients/claudecode/sync_test.go
+++ b/internal/clients/claudecode/sync_test.go
@@ -1019,6 +1019,49 @@ func TestSyncAllowsRawMatchedEqualUnmanagedEntryWithEmptyOptionalFields(t *testi
 	}
 }
 
+func TestSyncAllowsRawMatchedEqualUnmanagedEntryWithUnsortedEnv(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".mcp.json")
+	statePath := filepath.Join(tmp, "state", "claude-code-managed.json")
+
+	config := []byte(`{
+  "mcpServers": {
+    "runner": {
+      "command": "npx",
+      "env": {
+        "B": "2",
+        "A": "1"
+      }
+    }
+  }
+}
+`)
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	manifest := newStewreadsManifest()
+	manifest.Name = "runner"
+	manifest.Command = "npx"
+	manifest.Args = nil
+	manifest.Env = map[string]string{"A": "1", "B": "2"}
+
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("expected raw-matched unmanaged entry with unsorted env to sync unchanged, got: %v", err)
+	}
+	if len(result.Unchanged) != 1 || result.Unchanged[0] != "runner" {
+		t.Fatalf("expected runner unchanged, got: %+v", result)
+	}
+	servers := readRawServerObjects(t, configPath)
+	if env, ok := servers["runner"]["env"].(map[string]any); !ok || env["A"] != "1" || env["B"] != "2" {
+		t.Fatalf("expected env to remain preserved, got: %#v", servers["runner"]["env"])
+	}
+}
+
 func readRawServerObjects(t *testing.T, configPath string) map[string]map[string]any {
 	t.Helper()
 	root := readRoot(t, configPath)

--- a/internal/clients/claudecode/sync_test.go
+++ b/internal/clients/claudecode/sync_test.go
@@ -975,6 +975,50 @@ func TestSyncAllowsRawMatchedEqualUnmanagedEntryWithArgs(t *testing.T) {
 	}
 }
 
+func TestSyncAllowsRawMatchedEqualUnmanagedEntryWithEmptyOptionalFields(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".mcp.json")
+	statePath := filepath.Join(tmp, "state", "claude-code-managed.json")
+
+	config := []byte(`{
+  "mcpServers": {
+    "runner": {
+      "command": "npx",
+      "args": [],
+      "env": {}
+    }
+  }
+}
+`)
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	manifest := newStewreadsManifest()
+	manifest.Name = "runner"
+	manifest.Command = "npx"
+	manifest.Args = nil
+	manifest.Env = nil
+
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("expected raw-matched unmanaged entry with empty optional fields to sync unchanged, got: %v", err)
+	}
+	if len(result.Unchanged) != 1 || result.Unchanged[0] != "runner" {
+		t.Fatalf("expected runner unchanged, got: %+v", result)
+	}
+	servers := readRawServerObjects(t, configPath)
+	if args, ok := servers["runner"]["args"].([]any); !ok || len(args) != 0 {
+		t.Fatalf("expected empty args to remain preserved, got: %#v", servers["runner"]["args"])
+	}
+	if env, ok := servers["runner"]["env"].(map[string]any); !ok || len(env) != 0 {
+		t.Fatalf("expected empty env to remain preserved, got: %#v", servers["runner"]["env"])
+	}
+}
+
 func readRawServerObjects(t *testing.T, configPath string) map[string]map[string]any {
 	t.Helper()
 	root := readRoot(t, configPath)

--- a/internal/clients/claudecode/sync_test.go
+++ b/internal/clients/claudecode/sync_test.go
@@ -903,7 +903,7 @@ func TestSyncPreservesUnmanagedEntryFieldsAndShapes(t *testing.T) {
 	assertPreserved(readRawServerObjects(t, configPath))
 }
 
-func TestSyncKeepsExtraFieldsOnEqualUnmanagedEntry(t *testing.T) {
+func TestSyncConflictsOnRawMismatchedEqualUnmanagedEntry(t *testing.T) {
 	tmp := t.TempDir()
 	configPath := filepath.Join(tmp, ".mcp.json")
 	statePath := filepath.Join(tmp, "state", "claude-code-managed.json")
@@ -925,20 +925,17 @@ func TestSyncKeepsExtraFieldsOnEqualUnmanagedEntry(t *testing.T) {
 		t.Fatalf("write config fixture: %v", err)
 	}
 
-	result, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+	_, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
 		ConfigPath: configPath,
 		StatePath:  statePath,
 	})
-	if err != nil {
-		t.Fatalf("sync apply failed: %v", err)
-	}
-	if len(result.Unchanged) != 1 || result.Unchanged[0] != "stewreads" {
-		t.Fatalf("expected equal unmanaged entry to be unchanged, got: %+v", result)
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected ErrConflict for raw-mismatched equal unmanaged entry, got: %v", err)
 	}
 
 	servers := readRawServerObjects(t, configPath)
 	if servers["stewreads"]["note"] != "mine" {
-		t.Fatalf("expected unadopted equal entry to keep extra fields, got: %#v", servers["stewreads"])
+		t.Fatalf("expected conflicted unmanaged entry to remain untouched, got: %#v", servers["stewreads"])
 	}
 }
 

--- a/internal/clients/claudecode/sync_test.go
+++ b/internal/clients/claudecode/sync_test.go
@@ -939,6 +939,42 @@ func TestSyncConflictsOnRawMismatchedEqualUnmanagedEntry(t *testing.T) {
 	}
 }
 
+func TestSyncAllowsRawMatchedEqualUnmanagedEntryWithArgs(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".mcp.json")
+	statePath := filepath.Join(tmp, "state", "claude-code-managed.json")
+
+	config := []byte(`{
+  "mcpServers": {
+    "runner": {
+      "command": "npx",
+      "args": ["-y", "example-runner"]
+    }
+  }
+}
+`)
+	if err := os.WriteFile(configPath, config, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	manifest := newStewreadsManifest()
+	manifest.Name = "runner"
+	manifest.Command = "npx"
+	manifest.Args = []string{"-y", "example-runner"}
+	manifest.Env = nil
+
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("expected raw-matched unmanaged entry with args to sync unchanged, got: %v", err)
+	}
+	if len(result.Unchanged) != 1 || result.Unchanged[0] != "runner" {
+		t.Fatalf("expected runner unchanged, got: %+v", result)
+	}
+}
+
 func readRawServerObjects(t *testing.T, configPath string) map[string]map[string]any {
 	t.Helper()
 	root := readRoot(t, configPath)


### PR DESCRIPTION
### Motivation
- Preserve the safety model that unmanaged entries are kept verbatim while preventing attacker-controlled unmodeled JSON fields from being silently preserved under a trusted manifest name, which could change client semantics (e.g. `type`/`url` remote entries).

### Description
- Add pre-plan validation `rejectRawMismatchedUnmanagedEntries` (and helper `rawMatchesServer`) to `claudecode` and `claude-desktop` so an unmanaged same-name entry that only typed-matches but has different canonical raw JSON is treated as a conflict.
- Invoke this check before `PlanSync` so typed-subset equality no longer permits silent preservation of extra/unmodeled fields for same-name desired entries.
- Update regression tests in `internal/clients/claudecode` and `internal/clients/claude-desktop` to expect `ErrConflict` for raw-mismatched equal unmanaged entries and ensure the existing raw JSON remains untouched on conflict.
- Document the stricter raw-match rule in `docs/architecture.md` to reflect the safety guarantee and the new behavior.

### Testing
- Ran unit tests for the affected packages with `go test ./internal/clients/claudecode ./internal/clients/claude-desktop ./internal/clients/syncshared`, which passed. 
- Ran the full test suite with `go test ./...`, which passed.
- Updated tests exercised the new conflict behavior and verified the config file is not mutated when a raw-mismatched unmanaged same-name entry is present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3aa6e84f54832e9ff2c281864dc4c5)