### PR TITLE
Model remote MCP server transports (http/sse)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ syntax.
 
 ## Core Concepts
 
-**Servers** are executable MCP servers. Madari stores their command, arguments,
-environment metadata, supported clients, and ownership state.
+**Servers** are MCP server capabilities. Madari stores stdio commands or remote
+HTTP/SSE URLs, environment or header metadata, supported clients, and ownership
+state.
 
 **Skills** are official Agent Skill packages: directories with `SKILL.md`
 frontmatter and optional bundled files such as `references/`, `scripts/`, and

--- a/cmd/madari/client_targets.go
+++ b/cmd/madari/client_targets.go
@@ -19,6 +19,7 @@ type clientTarget struct {
 	target             string
 	syncAdapter        clients.ClientAdapter
 	ringConfigRenderer func(io.Writer, map[string]renderedServer) error
+	ringRenderRemote   bool
 	userScope          bool
 	skillRoots         skillTargetRoots
 }
@@ -97,8 +98,9 @@ func ringRenderTargetsFromClientTargets() map[string]ringRenderTarget {
 	for _, ct := range clientTargets {
 		if ct.ringConfigRenderer != nil {
 			targets[ct.target] = ringRenderTarget{
-				target: ct.target,
-				render: ct.ringConfigRenderer,
+				target:         ct.target,
+				supportsRemote: ct.ringRenderRemote,
+				render:         ct.ringConfigRenderer,
 			}
 		}
 	}

--- a/cmd/madari/json_output.go
+++ b/cmd/madari/json_output.go
@@ -22,11 +22,13 @@ type listJSON struct {
 }
 
 type serverJSON struct {
-	Name    string   `json:"name"`
-	Enabled bool     `json:"enabled"`
-	Command string   `json:"command"`
-	Clients []string `json:"clients"`
-	Sources []string `json:"sources"`
+	Name      string   `json:"name"`
+	Enabled   bool     `json:"enabled"`
+	Transport string   `json:"transport"`
+	Command   string   `json:"command"`
+	URL       string   `json:"url,omitempty"`
+	Clients   []string `json:"clients"`
+	Sources   []string `json:"sources"`
 }
 
 type statusJSON struct {
@@ -109,12 +111,14 @@ type driftJSON struct {
 }
 
 type doctorServerJSON struct {
-	Name    string      `json:"name"`
-	Enabled bool        `json:"enabled"`
-	Clients []string    `json:"clients"`
-	Command string      `json:"command"`
-	Status  string      `json:"status"`
-	Issues  []issueJSON `json:"issues"`
+	Name      string      `json:"name"`
+	Enabled   bool        `json:"enabled"`
+	Transport string      `json:"transport"`
+	Clients   []string    `json:"clients"`
+	Command   string      `json:"command"`
+	URL       string      `json:"url,omitempty"`
+	Status    string      `json:"status"`
+	Issues    []issueJSON `json:"issues"`
 }
 
 type issueJSON struct {
@@ -137,21 +141,22 @@ type doctorConfigJSON struct {
 }
 
 type syncJSON struct {
-	SchemaVersion   int      `json:"schema_version"`
-	Command         string   `json:"command"`
-	Target          string   `json:"target"`
-	ConfigPath      string   `json:"config_path"`
-	DryRun          bool     `json:"dry_run"`
-	Added           []string `json:"added"`
-	Updated         []string `json:"updated"`
-	Removed         []string `json:"removed"`
-	Unchanged       []string `json:"unchanged"`
-	Skipped         []string `json:"skipped"`
-	Refused         []string `json:"refused"`
-	SkillsAdded     []string `json:"skills_added"`
-	SkillsUpdated   []string `json:"skills_updated"`
-	SkillsRemoved   []string `json:"skills_removed"`
-	SkillsUnchanged []string `json:"skills_unchanged"`
+	SchemaVersion     int      `json:"schema_version"`
+	Command           string   `json:"command"`
+	Target            string   `json:"target"`
+	ConfigPath        string   `json:"config_path"`
+	DryRun            bool     `json:"dry_run"`
+	Added             []string `json:"added"`
+	Updated           []string `json:"updated"`
+	Removed           []string `json:"removed"`
+	Unchanged         []string `json:"unchanged"`
+	Skipped           []string `json:"skipped"`
+	UnsupportedRemote []string `json:"unsupported_remote"`
+	Refused           []string `json:"refused"`
+	SkillsAdded       []string `json:"skills_added"`
+	SkillsUpdated     []string `json:"skills_updated"`
+	SkillsRemoved     []string `json:"skills_removed"`
+	SkillsUnchanged   []string `json:"skills_unchanged"`
 }
 
 type ringListJSON struct {

--- a/cmd/madari/render_targets.go
+++ b/cmd/madari/render_targets.go
@@ -9,15 +9,21 @@ import (
 
 // renderedServer is the self-contained client config entry ring render emits.
 type renderedServer struct {
-	Command        string            `json:"command"`
+	Transport      string            `json:"type,omitempty"`
+	Command        string            `json:"command,omitempty"`
 	Args           []string          `json:"args,omitempty"`
+	URL            string            `json:"url,omitempty"`
+	Headers        map[string]string `json:"headers,omitempty"`
+	TimeoutMS      int               `json:"timeout,omitempty"`
+	OAuthResource  string            `json:"-"`
 	Env            map[string]string `json:"env,omitempty"`
 	RuntimeEnvKeys []string          `json:"-"`
 }
 
 type ringRenderTarget struct {
-	target string
-	render func(io.Writer, map[string]renderedServer) error
+	target         string
+	supportsRemote bool
+	render         func(io.Writer, map[string]renderedServer) error
 }
 
 var ringRenderTargets = ringRenderTargetsFromClientTargets()
@@ -117,6 +123,17 @@ func sortedMapKeys(values map[string]string) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+func copyStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		out[key] = value
+	}
+	return out
 }
 
 func tomlKey(key string) string {

--- a/cmd/madari/ring.go
+++ b/cmd/madari/ring.go
@@ -576,7 +576,7 @@ func (a cliApp) cmdRingAttach(args []string) error {
 	}
 
 	a.warnRingMembers(ring, manifests, target)
-	syncable, skipped := filterSyncableManifests(manifests, target)
+	syncable, skipped, unsupportedRemote := filterSyncableManifests(manifests, target)
 
 	adapter := syncAdapters[target]
 	opts := clients.SyncOptions{
@@ -615,7 +615,7 @@ func (a cliApp) cmdRingAttach(args []string) error {
 	}
 	fmt.Fprintf(a.stdout, "ring: %s\n", ringName)
 	if len(ring.Members) > 0 {
-		printSyncSummary(a.stdout, a.stderr, target, result.ConfigPath, result.DryRun, result.Added, result.Updated, result.Removed, result.Unchanged, skipped, result.Refused)
+		printSyncSummary(a.stdout, a.stderr, target, result.ConfigPath, result.DryRun, result.Added, result.Updated, result.Removed, result.Unchanged, skipped, unsupportedRemote, result.Refused)
 	}
 	printRingSkillSummary(a.stdout, skillResult)
 	return nil
@@ -682,7 +682,7 @@ func (a cliApp) cmdRingDetach(args []string) error {
 	}
 	fmt.Fprintf(a.stdout, "ring: %s\n", ringName)
 	if serverAttached {
-		printSyncSummary(a.stdout, a.stderr, target, result.ConfigPath, result.DryRun, result.Added, result.Updated, result.Removed, result.Unchanged, nil, result.Refused)
+		printSyncSummary(a.stdout, a.stderr, target, result.ConfigPath, result.DryRun, result.Added, result.Updated, result.Removed, result.Unchanged, nil, nil, result.Refused)
 	}
 	printRingSkillSummary(a.stdout, skillResult)
 	return nil

--- a/cmd/madari/ring.go
+++ b/cmd/madari/ring.go
@@ -410,6 +410,26 @@ func (a cliApp) cmdRingRender(args []string) error {
 			fmt.Fprintf(a.stderr, "warning: ring member %s does not target %s; omitted\n", member, target)
 			continue
 		}
+		if manifest.IsRemote() {
+			if !renderTarget.supportsRemote {
+				fmt.Fprintf(a.stderr, "warning: ring member %s uses %s transport, which %s render does not support yet; omitted\n", member, manifest.TransportType(), target)
+				continue
+			}
+			if len(manifest.Headers) > 0 {
+				fmt.Fprintf(a.stderr, "warning: ring member %s: headers are not emitted for %s render\n", member, target)
+			}
+			if manifest.TimeoutMS > 0 {
+				fmt.Fprintf(a.stderr, "warning: ring member %s: timeout_ms is not emitted for %s render\n", member, target)
+			}
+			servers[member] = renderedServer{
+				Transport:     manifest.TransportType(),
+				URL:           manifest.URL,
+				Headers:       copyStringMap(manifest.Headers),
+				TimeoutMS:     manifest.TimeoutMS,
+				OAuthResource: manifest.OAuthResource,
+			}
+			continue
+		}
 		if err := clients.ValidateCommandPath(manifest.Command); err != nil {
 			fmt.Fprintf(a.stderr, "warning: ring member %s omitted: %s\n", member, err.Message)
 			continue

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -320,20 +320,30 @@ func (a cliApp) cmdAdd(args []string) error {
 	fs.SetOutput(io.Discard)
 
 	var command string
+	var transport string
+	var url string
+	var oauthResource string
 	var description string
 	var disabled bool
+	var timeoutMS int
 	var cmdArgs stringList
 	var clients stringList
 	var envPairs stringList
+	var headerPairs stringList
 	var requiredEnv stringList
 	var secretEnv stringList
 
 	fs.StringVar(&command, "command", "", "Server command")
+	fs.StringVar(&transport, "transport", "", "Server transport (stdio, http, or sse; default: stdio)")
+	fs.StringVar(&url, "url", "", "Remote MCP server URL for http/sse transports")
+	fs.StringVar(&oauthResource, "oauth-resource", "", "OAuth resource for remote MCP clients that support it")
 	fs.StringVar(&description, "description", "", "Server description")
+	fs.IntVar(&timeoutMS, "timeout-ms", 0, "Remote MCP timeout in milliseconds")
 	fs.BoolVar(&disabled, "disabled", false, "Create server in disabled state")
 	fs.Var(&cmdArgs, "arg", "Command argument (repeatable)")
 	fs.Var(&clients, "client", "Client id (repeatable)")
 	fs.Var(&envPairs, "env", "Environment variable KEY=VALUE (repeatable)")
+	fs.Var(&headerPairs, "header", "HTTP header KEY=VALUE for remote transports (repeatable)")
 	fs.Var(&requiredEnv, "required-env", "Required environment key (repeatable)")
 	fs.Var(&secretEnv, "secret-env", "Secret env key barred from repo-scoped configs (repeatable)")
 
@@ -347,9 +357,6 @@ func (a cliApp) cmdAdd(args []string) error {
 	if fs.NArg() != 0 {
 		return fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " "))
 	}
-	if strings.TrimSpace(command) == "" {
-		return fmt.Errorf("--command is required")
-	}
 	if len(clients) == 0 {
 		return fmt.Errorf("at least one --client is required")
 	}
@@ -358,21 +365,42 @@ func (a cliApp) cmdAdd(args []string) error {
 	if err != nil {
 		return err
 	}
-	resolvedCommand, err := resolveCommandPath(command)
+	headers, err := parseHeaderPairs(headerPairs)
 	if err != nil {
 		return err
 	}
 
+	transport = strings.TrimSpace(strings.ToLower(transport))
+	if transport == "" {
+		transport = registry.TransportStdio
+	}
+
+	resolvedCommand := strings.TrimSpace(command)
+	if transport == registry.TransportStdio {
+		if resolvedCommand == "" {
+			return fmt.Errorf("--command is required")
+		}
+		resolvedCommand, err = resolveCommandPath(command)
+		if err != nil {
+			return err
+		}
+	}
+
 	manifest := registry.Manifest{
-		Name:        name,
-		Command:     resolvedCommand,
-		Args:        append([]string(nil), cmdArgs...),
-		Enabled:     !disabled,
-		Clients:     append([]string(nil), clients...),
-		Description: description,
-		Env:         env,
-		RequiredEnv: registry.RequiredEnv{Keys: append([]string(nil), requiredEnv...)},
-		SecretEnv:   registry.SecretEnv{Keys: append([]string(nil), secretEnv...)},
+		Name:          name,
+		Transport:     transport,
+		Command:       resolvedCommand,
+		Args:          append([]string(nil), cmdArgs...),
+		URL:           strings.TrimSpace(url),
+		Headers:       headers,
+		TimeoutMS:     timeoutMS,
+		OAuthResource: strings.TrimSpace(oauthResource),
+		Enabled:       !disabled,
+		Clients:       append([]string(nil), clients...),
+		Description:   description,
+		Env:           env,
+		RequiredEnv:   registry.RequiredEnv{Keys: append([]string(nil), requiredEnv...)},
+		SecretEnv:     registry.SecretEnv{Keys: append([]string(nil), secretEnv...)},
 	}
 
 	if err := a.store.Add(manifest); err != nil {
@@ -1332,11 +1360,31 @@ func parseEnvPairs(pairs []string) (map[string]string, error) {
 	return env, nil
 }
 
+func parseHeaderPairs(pairs []string) (map[string]string, error) {
+	headers := map[string]string{}
+	for _, pair := range pairs {
+		key, value, ok := strings.Cut(pair, "=")
+		key = strings.TrimSpace(key)
+		if !ok || key == "" {
+			return nil, fmt.Errorf("invalid header assignment %q, expected KEY=VALUE", pair)
+		}
+		if _, exists := headers[key]; exists {
+			return nil, fmt.Errorf("duplicate header key %q", key)
+		}
+		headers[key] = value
+	}
+	return headers, nil
+}
+
 func filterSyncableManifests(manifests []registry.Manifest, target string) ([]registry.Manifest, []string) {
 	out := make([]registry.Manifest, 0, len(manifests))
 	var skipped []string
 	for _, manifest := range manifests {
 		if !manifest.Enabled || !manifest.HasClient(target) {
+			out = append(out, manifest)
+			continue
+		}
+		if manifest.IsRemote() {
 			out = append(out, manifest)
 			continue
 		}
@@ -1606,9 +1654,15 @@ func printVersionHelp(out io.Writer) {
 func printAddHelp(out io.Writer) {
 	fmt.Fprintln(out, "Usage:")
 	fmt.Fprintln(out, "  madari add <name> --command <cmd> --client <client> [options]")
+	fmt.Fprintln(out, "  madari add <name> --transport http --url <url> --client <client> [options]")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Options:")
-	fmt.Fprintln(out, "  --command <cmd>            Server command (required)")
+	fmt.Fprintln(out, "  --command <cmd>            Server command (required for stdio)")
+	fmt.Fprintln(out, "  --transport <transport>    Server transport: stdio, http, or sse (default: stdio)")
+	fmt.Fprintln(out, "  --url <url>                Remote MCP server URL for http/sse transports")
+	fmt.Fprintln(out, "  --header KEY=VALUE         HTTP header for remote transports (repeatable)")
+	fmt.Fprintln(out, "  --timeout-ms <ms>          Remote MCP timeout in milliseconds")
+	fmt.Fprintln(out, "  --oauth-resource <url>     OAuth resource for remote clients that support it")
 	fmt.Fprintln(out, "  --client <client>          Target client id (required, repeatable)")
 	fmt.Fprintln(out, "  --arg <value>              Command argument (repeatable)")
 	fmt.Fprintln(out, "  --env KEY=VALUE            Environment variable (repeatable)")
@@ -1620,6 +1674,7 @@ func printAddHelp(out io.Writer) {
 	fmt.Fprintln(out, "Examples:")
 	fmt.Fprintln(out, "  madari add stewreads --command stewreads-mcp --client claude-desktop")
 	fmt.Fprintln(out, "  madari add mailer --command ./bin/mailer --client claude-desktop --required-env SMTP_PASSWORD")
+	fmt.Fprintln(out, "  madari add cloud-sql --transport http --url https://sqladmin.googleapis.com/mcp --client codex --oauth-resource https://sqladmin.googleapis.com/")
 }
 
 func printInstallHelp(out io.Writer) {

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -454,17 +454,19 @@ func (a cliApp) cmdList(args []string) error {
 			clients := append([]string(nil), manifest.Clients...)
 			sort.Strings(clients)
 			payload.Servers = append(payload.Servers, serverJSON{
-				Name:    manifest.Name,
-				Enabled: manifest.Enabled,
-				Command: manifest.Command,
-				Clients: nonNilStrings(clients),
-				Sources: nonNilStrings(managedSources[manifest.Name]),
+				Name:      manifest.Name,
+				Enabled:   manifest.Enabled,
+				Transport: manifest.TransportType(),
+				Command:   manifest.Command,
+				URL:       manifest.URL,
+				Clients:   nonNilStrings(clients),
+				Sources:   nonNilStrings(managedSources[manifest.Name]),
 			})
 		}
 		return writeJSON(a.stdout, payload)
 	}
 
-	fmt.Fprintln(a.stdout, "NAME\tSTATUS\tCOMMAND\tCLIENTS\tSOURCES")
+	fmt.Fprintln(a.stdout, "NAME\tSTATUS\tTRANSPORT\tENDPOINT\tCLIENTS\tSOURCES")
 	for _, manifest := range manifests {
 		status := "disabled"
 		if manifest.Enabled {
@@ -476,7 +478,7 @@ func (a cliApp) cmdList(args []string) error {
 		if list := managedSources[manifest.Name]; len(list) > 0 {
 			sources = strings.Join(list, ",")
 		}
-		fmt.Fprintf(a.stdout, "%s\t%s\t%s\t%s\t%s\n", manifest.Name, status, manifest.Command, strings.Join(clients, ","), sources)
+		fmt.Fprintf(a.stdout, "%s\t%s\t%s\t%s\t%s\t%s\n", manifest.Name, status, manifest.TransportType(), manifestEndpoint(manifest), strings.Join(clients, ","), sources)
 	}
 	return nil
 }
@@ -691,7 +693,7 @@ func (a cliApp) cmdSync(args []string) error {
 	if err != nil {
 		return err
 	}
-	syncable, skipped := filterSyncableManifests(manifests, target)
+	syncable, skipped, unsupportedRemote := filterSyncableManifests(manifests, target)
 
 	rings, err := a.store.ListRings()
 	if err != nil {
@@ -731,24 +733,25 @@ func (a cliApp) cmdSync(args []string) error {
 	}
 	if jsonOut {
 		return writeJSON(a.stdout, syncJSON{
-			SchemaVersion:   jsonSchemaVersion,
-			Command:         "sync",
-			Target:          target,
-			ConfigPath:      result.ConfigPath,
-			DryRun:          result.DryRun,
-			Added:           nonNilStrings(result.Added),
-			Updated:         nonNilStrings(result.Updated),
-			Removed:         nonNilStrings(result.Removed),
-			Unchanged:       nonNilStrings(result.Unchanged),
-			Skipped:         nonNilStrings(skipped),
-			Refused:         nonNilStrings(result.Refused),
-			SkillsAdded:     nonNilStrings(skillResult.Added),
-			SkillsUpdated:   nonNilStrings(skillResult.Updated),
-			SkillsRemoved:   nonNilStrings(skillResult.Removed),
-			SkillsUnchanged: nonNilStrings(skillResult.Unchanged),
+			SchemaVersion:     jsonSchemaVersion,
+			Command:           "sync",
+			Target:            target,
+			ConfigPath:        result.ConfigPath,
+			DryRun:            result.DryRun,
+			Added:             nonNilStrings(result.Added),
+			Updated:           nonNilStrings(result.Updated),
+			Removed:           nonNilStrings(result.Removed),
+			Unchanged:         nonNilStrings(result.Unchanged),
+			Skipped:           nonNilStrings(skipped),
+			UnsupportedRemote: nonNilStrings(remoteSkipNames(unsupportedRemote)),
+			Refused:           nonNilStrings(result.Refused),
+			SkillsAdded:       nonNilStrings(skillResult.Added),
+			SkillsUpdated:     nonNilStrings(skillResult.Updated),
+			SkillsRemoved:     nonNilStrings(skillResult.Removed),
+			SkillsUnchanged:   nonNilStrings(skillResult.Unchanged),
 		})
 	}
-	printSyncSummary(a.stdout, a.stderr, target, result.ConfigPath, result.DryRun, result.Added, result.Updated, result.Removed, result.Unchanged, skipped, result.Refused)
+	printSyncSummary(a.stdout, a.stderr, target, result.ConfigPath, result.DryRun, result.Added, result.Updated, result.Removed, result.Unchanged, skipped, unsupportedRemote, result.Refused)
 	printRingSkillSummary(a.stdout, skillResult)
 	return nil
 }
@@ -886,12 +889,14 @@ func (a cliApp) cmdDoctor(args []string) error {
 				})
 			}
 			payload.Servers = append(payload.Servers, doctorServerJSON{
-				Name:    server.Name,
-				Enabled: server.Enabled,
-				Clients: nonNilStrings(server.Clients),
-				Command: server.Command,
-				Status:  string(server.Status),
-				Issues:  issues,
+				Name:      server.Name,
+				Enabled:   server.Enabled,
+				Transport: server.Transport,
+				Clients:   nonNilStrings(server.Clients),
+				Command:   server.Command,
+				URL:       server.URL,
+				Status:    string(server.Status),
+				Issues:    issues,
 			})
 		}
 		for _, manifestError := range report.ManifestErrors {
@@ -984,11 +989,12 @@ func (a cliApp) cmdDoctor(args []string) error {
 		for _, server := range report.Servers {
 			fmt.Fprintf(
 				a.stdout,
-				"  - %s [%s] enabled=%t command=%s clients=%s\n",
+				"  - %s [%s] enabled=%t transport=%s %s clients=%s\n",
 				server.Name,
 				server.Status,
 				server.Enabled,
-				server.Command,
+				server.Transport,
+				doctorEndpointDetail(server),
 				strings.Join(server.Clients, ","),
 			)
 			for _, issue := range server.Issues {
@@ -1376,15 +1382,50 @@ func parseHeaderPairs(pairs []string) (map[string]string, error) {
 	return headers, nil
 }
 
-func filterSyncableManifests(manifests []registry.Manifest, target string) ([]registry.Manifest, []string) {
+func manifestEndpoint(manifest registry.Manifest) string {
+	if manifest.IsRemote() {
+		return manifest.URL
+	}
+	return manifest.Command
+}
+
+func doctorEndpointDetail(server doctor.ServerReport) string {
+	switch server.Transport {
+	case registry.TransportHTTP, registry.TransportSSE:
+		return fmt.Sprintf("url=%s sync=pending", server.URL)
+	default:
+		return fmt.Sprintf("command=%s", server.Command)
+	}
+}
+
+type unsupportedRemoteManifest struct {
+	Name      string
+	Transport string
+}
+
+func remoteSkipNames(skips []unsupportedRemoteManifest) []string {
+	names := make([]string, 0, len(skips))
+	for _, skip := range skips {
+		names = append(names, skip.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func filterSyncableManifests(manifests []registry.Manifest, target string) ([]registry.Manifest, []string, []unsupportedRemoteManifest) {
 	out := make([]registry.Manifest, 0, len(manifests))
 	var skipped []string
+	var unsupportedRemote []unsupportedRemoteManifest
 	for _, manifest := range manifests {
 		if !manifest.Enabled || !manifest.HasClient(target) {
 			out = append(out, manifest)
 			continue
 		}
 		if manifest.IsRemote() {
+			unsupportedRemote = append(unsupportedRemote, unsupportedRemoteManifest{
+				Name:      manifest.Name,
+				Transport: manifest.TransportType(),
+			})
 			out = append(out, manifest)
 			continue
 		}
@@ -1395,7 +1436,10 @@ func filterSyncableManifests(manifests []registry.Manifest, target string) ([]re
 		out = append(out, manifest)
 	}
 	sort.Strings(skipped)
-	return out, skipped
+	sort.Slice(unsupportedRemote, func(i, j int) bool {
+		return unsupportedRemote[i].Name < unsupportedRemote[j].Name
+	})
+	return out, skipped, unsupportedRemote
 }
 
 func syncTargetsForClients(manifest registry.Manifest) []string {
@@ -1538,7 +1582,7 @@ func formatNameList(names []string) string {
 	return strings.Join(names, ",")
 }
 
-func printSyncSummary(stdout, stderr io.Writer, target, configPath string, dryRun bool, added, updated, removed, unchanged, skipped, refused []string) {
+func printSyncSummary(stdout, stderr io.Writer, target, configPath string, dryRun bool, added, updated, removed, unchanged, skipped []string, unsupportedRemote []unsupportedRemoteManifest, refused []string) {
 	mode := "applied"
 	if dryRun {
 		mode = "dry-run"
@@ -1554,6 +1598,12 @@ func printSyncSummary(stdout, stderr io.Writer, target, configPath string, dryRu
 		fmt.Fprintf(stdout, "skipped: %s\n", formatNameList(skipped))
 		for _, name := range skipped {
 			fmt.Fprintf(stderr, "warning: skipped %s because command path is not an executable file\n", name)
+		}
+	}
+	if len(unsupportedRemote) > 0 {
+		fmt.Fprintf(stdout, "unsupported remote: %s\n", formatNameList(remoteSkipNames(unsupportedRemote)))
+		for _, remote := range unsupportedRemote {
+			fmt.Fprintf(stderr, "warning: remote %s uses %s transport; stored in registry, but %s sync does not materialize remote transports yet\n", remote.Name, remote.Transport, target)
 		}
 	}
 	if len(refused) > 0 {

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -2805,8 +2805,11 @@ func TestRunWithStoreSecretEnvPlacementFlow(t *testing.T) {
 	if !strings.Contains(result.stderr, "refused vault") || !strings.Contains(result.stderr, "--scope user") {
 		t.Fatalf("expected refusal warning with user-scope guidance, got: %s", result.stderr)
 	}
+	// A refused-only plan against a fresh config is a no-op, so the repo
+	// config may legitimately not exist; if it does, it must not hold the
+	// secret value.
 	payload, err := os.ReadFile(projectConfig)
-	if err != nil {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("read project config: %v", err)
 	}
 	if strings.Contains(string(payload), "shhh") {

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -184,6 +184,47 @@ func TestRunWithStoreAddArgumentCoverage(t *testing.T) {
 	}
 }
 
+func TestRunWithStoreAddRemoteHTTP(t *testing.T) {
+	store := newTestStore(t)
+
+	result := runCmd(
+		store,
+		"add", "cloud-sql",
+		"--transport", "http",
+		"--url", "https://sqladmin.googleapis.com/mcp",
+		"--client", "codex",
+		"--oauth-resource", "https://sqladmin.googleapis.com/",
+		"--timeout-ms", "30000",
+		"--header", "x-goog-user-project=example-project",
+	)
+	if result.code != 0 {
+		t.Fatalf("add remote command failed with code %d, stderr=%s", result.code, result.stderr)
+	}
+
+	manifest, err := store.Get("cloud-sql")
+	if err != nil {
+		t.Fatalf("expected manifest to exist: %v", err)
+	}
+	if !manifest.IsRemote() || manifest.TransportType() != registry.TransportHTTP {
+		t.Fatalf("expected HTTP remote manifest, got: %#v", manifest)
+	}
+	if manifest.Command != "" || len(manifest.Args) != 0 {
+		t.Fatalf("expected remote manifest to have no command/args, got command=%q args=%#v", manifest.Command, manifest.Args)
+	}
+	if manifest.URL != "https://sqladmin.googleapis.com/mcp" {
+		t.Fatalf("unexpected remote URL: %q", manifest.URL)
+	}
+	if manifest.OAuthResource != "https://sqladmin.googleapis.com/" {
+		t.Fatalf("unexpected oauth resource: %q", manifest.OAuthResource)
+	}
+	if manifest.TimeoutMS != 30000 {
+		t.Fatalf("unexpected timeout: %d", manifest.TimeoutMS)
+	}
+	if manifest.Headers["x-goog-user-project"] != "example-project" {
+		t.Fatalf("expected header to be persisted, got: %#v", manifest.Headers)
+	}
+}
+
 func TestRunWithStoreAddResolvesCommandFromPATH(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("PATH executable test is for unix-like environments")
@@ -286,6 +327,59 @@ func TestRunWithStoreAddValidatesEnvAssignments(t *testing.T) {
 				"--env", "A=1", "--env", "A=2",
 			},
 			expected: "duplicate env key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := runCmd(store, tt.args...)
+			if result.code == 0 {
+				t.Fatalf("expected command to fail")
+			}
+			if !strings.Contains(result.stderr, tt.expected) {
+				t.Fatalf("expected stderr to contain %q, got: %s", tt.expected, result.stderr)
+			}
+		})
+	}
+}
+
+func TestRunWithStoreAddValidatesHeaderAssignments(t *testing.T) {
+	store := newTestStore(t)
+
+	tests := []struct {
+		name     string
+		args     []string
+		expected string
+	}{
+		{
+			name: "invalid header assignment",
+			args: []string{
+				"add", "cloud-sql", "--transport", "http", "--url", "https://sqladmin.googleapis.com/mcp", "--client", "codex",
+				"--header", "BROKEN",
+			},
+			expected: "invalid header assignment",
+		},
+		{
+			name: "duplicate header key",
+			args: []string{
+				"add", "cloud-sql", "--transport", "http", "--url", "https://sqladmin.googleapis.com/mcp", "--client", "codex",
+				"--header", "x-goog-user-project=a", "--header", "x-goog-user-project=b",
+			},
+			expected: "duplicate header key",
+		},
+		{
+			name: "remote missing url",
+			args: []string{
+				"add", "cloud-sql", "--transport", "http", "--client", "codex",
+			},
+			expected: "url is required",
+		},
+		{
+			name: "remote rejects command",
+			args: []string{
+				"add", "cloud-sql", "--transport", "http", "--url", "https://sqladmin.googleapis.com/mcp", "--command", "cloud-sql", "--client", "codex",
+			},
+			expected: "command is not supported",
 		},
 	}
 
@@ -4142,6 +4236,31 @@ env_vars = ["VAULT_ACCOUNT", "VAULT_TOKEN"]
 	}
 	if !strings.Contains(result.stderr, "secret env values omitted (VAULT_TOKEN)") {
 		t.Fatalf("expected secret omission warning, got: %s", result.stderr)
+	}
+}
+
+func TestRunWithStoreRingRenderRemoteUnsupportedTarget(t *testing.T) {
+	store := newTestStore(t)
+
+	if result := runCmd(store, "add", "cloud-sql",
+		"--transport", "http",
+		"--url", "https://sqladmin.googleapis.com/mcp",
+		"--client", "claude-code"); result.code != 0 {
+		t.Fatalf("setup add cloud-sql failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "ring", "create", "cloudsql-readonly", "--member", "cloud-sql"); result.code != 0 {
+		t.Fatalf("ring create failed: %s", result.stderr)
+	}
+
+	result := runCmd(store, "ring", "render", "cloudsql-readonly", "--client", "claude-code")
+	if result.code != 0 {
+		t.Fatalf("ring render claude-code failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, `"mcpServers": {}`) {
+		t.Fatalf("expected empty MCP config for unsupported remote target, got:\n%s", result.stdout)
+	}
+	if !strings.Contains(result.stderr, "uses http transport") || !strings.Contains(result.stderr, "does not support yet") {
+		t.Fatalf("expected unsupported remote warning, got: %s", result.stderr)
 	}
 }
 

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -2488,7 +2488,7 @@ func TestRunWithStoreListAndStatusShowManagedSources(t *testing.T) {
 	if !strings.Contains(result.stdout, "SOURCES") {
 		t.Fatalf("expected SOURCES column header, got: %s", result.stdout)
 	}
-	if !strings.Contains(result.stdout, "stewreads\tenabled\t"+commandPath+"\tclaude-desktop\t-") {
+	if !strings.Contains(result.stdout, "stewreads\tenabled\tstdio\t"+commandPath+"\tclaude-desktop\t-") {
 		t.Fatalf("expected unsynced server to show '-' sources, got: %s", result.stdout)
 	}
 
@@ -2504,7 +2504,7 @@ func TestRunWithStoreListAndStatusShowManagedSources(t *testing.T) {
 	if result.code != 0 {
 		t.Fatalf("list after sync failed: %s", result.stderr)
 	}
-	if !strings.Contains(result.stdout, "stewreads\tenabled\t"+commandPath+"\tclaude-desktop\tstandalone") {
+	if !strings.Contains(result.stdout, "stewreads\tenabled\tstdio\t"+commandPath+"\tclaude-desktop\tstandalone") {
 		t.Fatalf("expected synced server to show standalone source, got: %s", result.stdout)
 	}
 
@@ -2586,6 +2586,7 @@ func TestRunWithStoreListJSON(t *testing.T) {
     {
       "name": "stewreads",
       "enabled": true,
+      "transport": "stdio",
       "command": %q,
       "clients": [
         "claude-desktop"
@@ -2599,6 +2600,51 @@ func TestRunWithStoreListJSON(t *testing.T) {
 `, commandPath)
 	if result.stdout != expected {
 		t.Fatalf("list --json schema drift:\nwant:\n%s\ngot:\n%s", expected, result.stdout)
+	}
+}
+
+func TestRunWithStoreListShowsRemoteEndpoint(t *testing.T) {
+	store := newTestStore(t)
+
+	if result := runCmd(store, "add", "cloud-sql",
+		"--transport", "http",
+		"--url", "https://sqladmin.googleapis.com/mcp",
+		"--client", "codex"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+
+	result := runCmd(store, "list")
+	if result.code != 0 {
+		t.Fatalf("list failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, "cloud-sql\tenabled\thttp\thttps://sqladmin.googleapis.com/mcp\tcodex\t-") {
+		t.Fatalf("expected remote server endpoint in list output, got: %s", result.stdout)
+	}
+
+	result = runCmd(store, "list", "--json")
+	if result.code != 0 {
+		t.Fatalf("list --json failed: %s", result.stderr)
+	}
+	expected := `{
+  "schema_version": 1,
+  "command": "list",
+  "servers": [
+    {
+      "name": "cloud-sql",
+      "enabled": true,
+      "transport": "http",
+      "command": "",
+      "url": "https://sqladmin.googleapis.com/mcp",
+      "clients": [
+        "codex"
+      ],
+      "sources": []
+    }
+  ]
+}
+`
+	if result.stdout != expected {
+		t.Fatalf("list --json remote schema drift:\nwant:\n%s\ngot:\n%s", expected, result.stdout)
 	}
 }
 
@@ -2632,6 +2678,7 @@ func TestRunWithStoreSyncDryRunJSON(t *testing.T) {
   "removed": [],
   "unchanged": [],
   "skipped": [],
+  "unsupported_remote": [],
   "refused": [],
   "skills_added": [],
   "skills_updated": [],
@@ -2641,6 +2688,60 @@ func TestRunWithStoreSyncDryRunJSON(t *testing.T) {
 `, configPath)
 	if result.stdout != expected {
 		t.Fatalf("sync --json schema drift:\nwant:\n%s\ngot:\n%s", expected, result.stdout)
+	}
+}
+
+func TestRunWithStoreSyncReportsUnsupportedRemote(t *testing.T) {
+	store := newTestStore(t)
+
+	if result := runCmd(store, "add", "cloud-sql",
+		"--transport", "http",
+		"--url", "https://sqladmin.googleapis.com/mcp",
+		"--client", "codex"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	result := runCmd(store, "sync", "codex", "--dry-run", "--config-path", configPath)
+	if result.code != 0 {
+		t.Fatalf("sync dry-run failed: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	if !strings.Contains(result.stdout, "unsupported remote: cloud-sql") {
+		t.Fatalf("expected unsupported remote summary, got: %s", result.stdout)
+	}
+	if !strings.Contains(result.stderr, "cloud-sql uses http transport") ||
+		!strings.Contains(result.stderr, "stored in registry") ||
+		!strings.Contains(result.stderr, "codex sync does not materialize remote transports yet") {
+		t.Fatalf("expected unsupported remote warning, got: %s", result.stderr)
+	}
+
+	result = runCmd(store, "sync", "codex", "--dry-run", "--json", "--config-path", configPath)
+	if result.code != 0 {
+		t.Fatalf("sync dry-run --json failed: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	expected := fmt.Sprintf(`{
+  "schema_version": 1,
+  "command": "sync",
+  "target": "codex",
+  "config_path": %q,
+  "dry_run": true,
+  "added": [],
+  "updated": [],
+  "removed": [],
+  "unchanged": [],
+  "skipped": [],
+  "unsupported_remote": [
+    "cloud-sql"
+  ],
+  "refused": [],
+  "skills_added": [],
+  "skills_updated": [],
+  "skills_removed": [],
+  "skills_unchanged": []
+}
+`, configPath)
+	if result.stdout != expected {
+		t.Fatalf("sync --json unsupported remote schema drift:\nwant:\n%s\ngot:\n%s", expected, result.stdout)
 	}
 }
 
@@ -2756,7 +2857,7 @@ func TestRunWithStoreDoctorJSONReportsErrorsAndExitCode(t *testing.T) {
 	if len(servers) != 1 {
 		t.Fatalf("expected one server entry, got: %v", servers)
 	}
-	assertJSONKeys(t, servers[0].(map[string]any), "name", "enabled", "clients", "command", "status", "issues")
+	assertJSONKeys(t, servers[0].(map[string]any), "name", "enabled", "transport", "clients", "command", "status", "issues")
 
 	configs := payload["client_configs"].([]any)
 	if len(configs) == 0 {
@@ -2826,7 +2927,7 @@ func TestRunWithStoreSecretEnvPlacementFlow(t *testing.T) {
 	if result.code != 0 {
 		t.Fatalf("list failed: %s", result.stderr)
 	}
-	if !strings.Contains(result.stdout, "vault\tenabled\t"+commandPath+"\tclaude-code\tstandalone") {
+	if !strings.Contains(result.stdout, "vault\tenabled\tstdio\t"+commandPath+"\tclaude-code\tstandalone") {
 		t.Fatalf("expected user-scope managed sources in list, got: %s", result.stdout)
 	}
 
@@ -3445,6 +3546,39 @@ expected_outputs = ["findings", "next check"]
 	}
 }
 
+func TestRunWithStoreRingAttachReportsUnsupportedRemote(t *testing.T) {
+	store := newTestStore(t)
+
+	if result := runCmd(store, "add", "cloud-sql",
+		"--transport", "http",
+		"--url", "https://sqladmin.googleapis.com/mcp",
+		"--client", "codex"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "ring", "create", "cloudsql-readonly", "--member", "cloud-sql"); result.code != 0 {
+		t.Fatalf("ring create failed: %s", result.stderr)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	result := runCmd(store, "ring", "attach", "cloudsql-readonly", "codex", "--dry-run", "--config-path", configPath)
+	if result.code != 0 {
+		t.Fatalf("ring attach dry-run failed: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	for _, want := range []string{
+		"ring: cloudsql-readonly",
+		"unsupported remote: cloud-sql",
+	} {
+		if !strings.Contains(result.stdout, want) {
+			t.Fatalf("expected %q in ring attach output, got: %s", want, result.stdout)
+		}
+	}
+	if !strings.Contains(result.stderr, "cloud-sql uses http transport") ||
+		!strings.Contains(result.stderr, "stored in registry") ||
+		!strings.Contains(result.stderr, "codex sync does not materialize remote transports yet") {
+		t.Fatalf("expected unsupported remote warning, got: %s", result.stderr)
+	}
+}
+
 func TestRunWithStoreRingAttachDetachFlow(t *testing.T) {
 	store := newTestStore(t)
 	commandPath := mustCurrentExecutable(t)
@@ -3487,7 +3621,7 @@ func TestRunWithStoreRingAttachDetachFlow(t *testing.T) {
 
 	// list shows ring sources.
 	result = runCmd(store, "list")
-	if !strings.Contains(result.stdout, "stewreads\tenabled\t"+commandPath+"\tclaude-code\tring:r1,ring:r2") {
+	if !strings.Contains(result.stdout, "stewreads\tenabled\tstdio\t"+commandPath+"\tclaude-code\tring:r1,ring:r2") {
 		t.Fatalf("expected overlapping ring sources in list, got: %s", result.stdout)
 	}
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,8 +142,10 @@ Skills are not run inputs yet.
 - Never overwrite unknown config blocks.
 - Entries Madari does not manage keep their JSON value, including fields and
   server shapes Madari does not model (e.g. `type`/`url` remote entries);
-  only managed or newly added entries are serialized from manifests. The
-  enclosing document is reformatted on write. For adapters with raw-match
+  only managed or newly added entries are serialized from manifests. Managed
+  remote `http`/`sse` manifests are modeled in the registry but kept
+  ineligible by every sync adapter until per-client remote materialization
+  lands. The enclosing document is reformatted on write. For adapters with raw-match
   validation (currently Claude Code and Claude Desktop), if an unmanaged entry
   has the same name as a desired manifest, Madari only treats it as an exact
   match when its canonical raw JSON, after normalizing empty modeled optional

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -18,7 +18,8 @@ to an absolute executable path. Remote manifests use `--transport http` or
 `--transport sse` with `--url`; optional remote metadata includes `--header`,
 `--timeout-ms`, and `--oauth-resource`. Remote manifests are stored and
 validated, but sync and render targets skip them until per-client support
-lands.
+lands. `madari list` and `madari doctor` show each server's transport and
+endpoint so remote entries are visible while materialization is pending.
 
 ## Install Workflow
 
@@ -267,6 +268,7 @@ defined.
     {
       "name": "stewreads",
       "enabled": true,
+      "transport": "stdio",
       "command": "/abs/path/stewreads-mcp",
       "clients": ["claude-desktop"],
       "sources": ["standalone"]
@@ -332,6 +334,7 @@ itself.
     {
       "name": "stewreads",
       "enabled": true,
+      "transport": "stdio",
       "clients": ["claude-desktop"],
       "command": "/abs/path/stewreads-mcp",
       "status": "warn",
@@ -386,6 +389,7 @@ itself.
   "removed": [],
   "unchanged": [],
   "skipped": [],
+  "unsupported_remote": [],
   "refused": [],
   "skills_added": [],
   "skills_updated": [],

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -6,11 +6,19 @@ Quick command reference for day-to-day Madari usage.
 
 ```bash
 madari add <name> --command /abs/path/to/server --client <client>
+madari add <name> --transport http --url https://example.com/mcp --client codex
 madari list
 madari enable <name>
 madari disable <name>
 madari remove <name>
 ```
+
+`madari add` defaults to `stdio`, where `--command` is required and is resolved
+to an absolute executable path. Remote manifests use `--transport http` or
+`--transport sse` with `--url`; optional remote metadata includes `--header`,
+`--timeout-ms`, and `--oauth-resource`. Remote manifests are stored and
+validated, but sync and render targets skip them until per-client support
+lands.
 
 ## Install Workflow
 
@@ -132,6 +140,8 @@ Render targets are independent from sync adapters. `claude-code`,
 `[[mcp_servers]]` entries with `transport = "stdio"`.
 Codex render output also emits `env_vars = [...]` for `[required_env]` and
 `[secret_env]` keys so runtime-provided environment values can be forwarded.
+Remote `http`/`sse` ring members are omitted with warnings; no render target
+materializes remote transports yet.
 Ring skill members are not embedded in MCP render output; use `ring attach`
 for native skill materialization.
 Ephemeral-session recipe:

--- a/docs/manifest-spec.md
+++ b/docs/manifest-spec.md
@@ -39,8 +39,10 @@ their auth and config behavior is validated per client.
 
 ### `[headers]`
 
-Key/value static HTTP headers for remote transports. Headers are stored in the
-manifest but emitted only for clients that support header configuration.
+Key/value static HTTP headers for remote transports. Header names are limited
+to letters, digits, `-`, and `_` so they round-trip through the manifest
+format. Headers are stored in the manifest but emitted only for clients that
+support header configuration.
 
 ### `[env]`
 

--- a/docs/manifest-spec.md
+++ b/docs/manifest-spec.md
@@ -9,8 +9,16 @@ Each managed server is stored as a TOML document.
 ## Fields
 
 - `name` (string, required): stable logical ID.
-- `command` (string, required): absolute executable path for reliable sync behavior.
-- `args` (array of strings, optional): command arguments.
+- `transport` (string, optional): `stdio`, `http`, or `sse`. Empty means
+  `stdio` for legacy manifests.
+- `command` (string, required for `stdio`): absolute executable path for
+  reliable sync behavior.
+- `args` (array of strings, optional for `stdio`): command arguments.
+- `url` (string, required for `http`/`sse`): remote MCP server URL.
+- `timeout_ms` (integer, optional for `http`/`sse`): remote MCP timeout in
+  milliseconds. Emitted only for clients that support it.
+- `oauth_resource` (string, optional for `http`/`sse`): OAuth resource value
+  for clients that support it.
 - `enabled` (bool, required): whether this server should be synced into clients.
 - `clients` (array of strings, required): client IDs.
 - `description` (string, optional): friendly description.
@@ -25,10 +33,18 @@ Known client IDs:
 
 `claude-desktop`, `claude-code`, `gemini`, `codex`, and `vibe` are
 sync-capable today. All are also render targets for `madari ring render`.
+Remote `http`/`sse` manifests are stored and validated, but no sync or render
+target materializes them yet; adapters keep remote entries ineligible until
+their auth and config behavior is validated per client.
+
+### `[headers]`
+
+Key/value static HTTP headers for remote transports. Headers are stored in the
+manifest but emitted only for clients that support header configuration.
 
 ### `[env]`
 
-Key/value static environment variables.
+Key/value static environment variables for stdio transports.
 
 ### `[required_env]`
 
@@ -47,6 +63,8 @@ Key/value static environment variables.
 
 ## Example
 
+Stdio server:
+
 ```toml
 name = "stewreads"
 command = "/Users/me/.local/bin/stewreads-mcp"
@@ -62,12 +80,27 @@ STEWREADS_CONFIG_PATH = "~/.config/stewreads/config.toml"
 keys = ["STEWREADS_GMAIL_APP_PASSWORD"]
 ```
 
+Remote HTTP server:
+
+```toml
+name = "cloud-sql"
+transport = "http"
+url = "https://sqladmin.googleapis.com/mcp"
+oauth_resource = "https://sqladmin.googleapis.com/"
+enabled = true
+clients = ["codex"]
+description = "Official Cloud SQL remote MCP server"
+```
+
 ## Validation Rules
 
 - `name` must be lowercase alphanumeric with `-` and `.` allowed as separators.
 - `clients` must contain unique values.
 - Unknown top-level keys are rejected.
-- Empty `command` is invalid.
+- Empty `command` is invalid for `stdio`.
+- `url` is required for `http` and `sse`.
+- Remote transports reject `command`, `args`, `[env]`, `[required_env]`, and
+  `[secret_env]` because they are local process settings.
 
 ## Ring Files
 

--- a/internal/clients/claude-desktop/sync.go
+++ b/internal/clients/claude-desktop/sync.go
@@ -58,7 +58,7 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 	result.ConfigPath = configPath
 	result.DryRun = opts.DryRun
 
-	if opts.DryRun {
+	if opts.DryRun || (!configExists && syncshared.PlanIsNoOp(result, managedState, nextState)) {
 		return result, nil
 	}
 

--- a/internal/clients/claude-desktop/sync.go
+++ b/internal/clients/claude-desktop/sync.go
@@ -246,7 +246,7 @@ func entriesForTarget(manifests []registry.Manifest) map[string]syncshared.Entry
 			continue
 		}
 		entry := syncshared.Entry[serverConfig]{}
-		if manifest.Enabled {
+		if manifest.Enabled && !manifest.IsRemote() {
 			entry.Eligible = true
 			entry.Value = materializeServer(manifest)
 		}

--- a/internal/clients/claude-desktop/sync_test.go
+++ b/internal/clients/claude-desktop/sync_test.go
@@ -771,6 +771,36 @@ func TestSyncSkipsManagedRemoteManifest(t *testing.T) {
 	}
 }
 
+func TestSyncRemoteOnlyDoesNotCreateFiles(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "claude_desktop_config.json")
+	statePath := filepath.Join(tmp, "state", "claude-desktop-managed.json")
+
+	remote := registry.Manifest{
+		Name:      "cloud-sql",
+		Transport: registry.TransportHTTP,
+		URL:       "https://example.com/mcp",
+		Enabled:   true,
+		Clients:   []string{Target},
+	}
+	result, err := Sync([]registry.Manifest{remote}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	if len(result.Added)+len(result.Updated)+len(result.Removed) != 0 {
+		t.Fatalf("expected no-op sync result, got: %+v", result)
+	}
+	if _, err := os.Stat(configPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected no config file for remote-only no-op sync, got err=%v", err)
+	}
+	if _, err := os.Stat(statePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected no state file for remote-only no-op sync, got err=%v", err)
+	}
+}
+
 func newStewreadsManifest() registry.Manifest {
 	return registry.Manifest{
 		Name:    "stewreads",

--- a/internal/clients/claude-desktop/sync_test.go
+++ b/internal/clients/claude-desktop/sync_test.go
@@ -727,6 +727,50 @@ func assertJSONEqual(t *testing.T, want, got []byte) {
 	}
 }
 
+func TestSyncSkipsManagedRemoteManifest(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "claude_desktop_config.json")
+	statePath := filepath.Join(tmp, "state", "claude-desktop-managed.json")
+	original := []byte(`{
+  "mcpServers": {
+    "weather": {
+      "command": "uv",
+      "args": ["run", "weather.py"]
+    }
+  }
+}
+`)
+	if err := os.WriteFile(configPath, original, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	remote := registry.Manifest{
+		Name:      "cloud-sql",
+		Transport: registry.TransportHTTP,
+		URL:       "https://example.com/mcp",
+		Enabled:   true,
+		Clients:   []string{Target},
+	}
+	result, err := Sync([]registry.Manifest{remote}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	if len(result.Added) != 0 || len(result.Updated) != 0 || len(result.Removed) != 0 {
+		t.Fatalf("expected remote manifest to be ineligible until the adapter supports it, got: %+v", result)
+	}
+
+	servers := readServers(t, configPath)
+	if _, exists := servers["cloud-sql"]; exists {
+		t.Fatalf("expected remote manifest not to be materialized, got: %#v", servers)
+	}
+	if _, ok := servers["weather"]; !ok {
+		t.Fatalf("expected unmanaged weather entry to be preserved")
+	}
+}
+
 func newStewreadsManifest() registry.Manifest {
 	return registry.Manifest{
 		Name:    "stewreads",

--- a/internal/clients/claudecode/sync.go
+++ b/internal/clients/claudecode/sync.go
@@ -69,7 +69,7 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 	result.ConfigPath = configPath
 	result.DryRun = opts.DryRun
 
-	if opts.DryRun {
+	if opts.DryRun || (!configExists && syncshared.PlanIsNoOp(result, managedState, nextState)) {
 		return result, nil
 	}
 

--- a/internal/clients/claudecode/sync.go
+++ b/internal/clients/claudecode/sync.go
@@ -307,6 +307,8 @@ func entriesForTarget(manifests []registry.Manifest, userScope bool) map[string]
 		switch {
 		case !manifest.Enabled:
 			// ineligible
+		case manifest.IsRemote():
+			// Remote transports are not materialized by this adapter yet.
 		case !userScope && manifest.HasSecretValue():
 			entry.Refused = true
 		default:

--- a/internal/clients/claudecode/sync_test.go
+++ b/internal/clients/claudecode/sync_test.go
@@ -1189,6 +1189,50 @@ func assertJSONEqual(t *testing.T, want, got []byte) {
 	}
 }
 
+func TestSyncSkipsManagedRemoteManifest(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".mcp.json")
+	statePath := filepath.Join(tmp, "state", "claude-code-managed.json")
+	original := []byte(`{
+  "mcpServers": {
+    "weather": {
+      "command": "uv",
+      "args": ["run", "weather.py"]
+    }
+  }
+}
+`)
+	if err := os.WriteFile(configPath, original, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	remote := registry.Manifest{
+		Name:      "cloud-sql",
+		Transport: registry.TransportHTTP,
+		URL:       "https://example.com/mcp",
+		Enabled:   true,
+		Clients:   []string{Target},
+	}
+	result, err := Sync([]registry.Manifest{remote}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	if len(result.Added) != 0 || len(result.Updated) != 0 || len(result.Removed) != 0 {
+		t.Fatalf("expected remote manifest to be ineligible until the adapter supports it, got: %+v", result)
+	}
+
+	servers := readServers(t, configPath)
+	if _, exists := servers["cloud-sql"]; exists {
+		t.Fatalf("expected remote manifest not to be materialized, got: %#v", servers)
+	}
+	if _, ok := servers["weather"]; !ok {
+		t.Fatalf("expected unmanaged weather entry to be preserved")
+	}
+}
+
 func newStewreadsManifest() registry.Manifest {
 	return registry.Manifest{
 		Name:    "stewreads",

--- a/internal/clients/claudecode/sync_test.go
+++ b/internal/clients/claudecode/sync_test.go
@@ -1233,6 +1233,36 @@ func TestSyncSkipsManagedRemoteManifest(t *testing.T) {
 	}
 }
 
+func TestSyncRemoteOnlyDoesNotCreateFiles(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".mcp.json")
+	statePath := filepath.Join(tmp, "state", "claude-code-managed.json")
+
+	remote := registry.Manifest{
+		Name:      "cloud-sql",
+		Transport: registry.TransportHTTP,
+		URL:       "https://example.com/mcp",
+		Enabled:   true,
+		Clients:   []string{Target},
+	}
+	result, err := Sync([]registry.Manifest{remote}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	if len(result.Added)+len(result.Updated)+len(result.Removed) != 0 {
+		t.Fatalf("expected no-op sync result, got: %+v", result)
+	}
+	if _, err := os.Stat(configPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected no config file for remote-only no-op sync, got err=%v", err)
+	}
+	if _, err := os.Stat(statePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected no state file for remote-only no-op sync, got err=%v", err)
+	}
+}
+
 func newStewreadsManifest() registry.Manifest {
 	return registry.Manifest{
 		Name:    "stewreads",

--- a/internal/clients/codex/sync.go
+++ b/internal/clients/codex/sync.go
@@ -241,7 +241,7 @@ func entriesForTarget(manifests []registry.Manifest) map[string]syncshared.Entry
 			continue
 		}
 		entry := syncshared.Entry[serverConfig]{}
-		if manifest.Enabled {
+		if manifest.Enabled && !manifest.IsRemote() {
 			entry.Eligible = true
 			entry.Value = materializeServer(manifest)
 		}

--- a/internal/clients/codex/sync.go
+++ b/internal/clients/codex/sync.go
@@ -59,7 +59,7 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 	result.ConfigPath = configPath
 	result.DryRun = opts.DryRun
 
-	if opts.DryRun {
+	if opts.DryRun || (!configExists && syncshared.PlanIsNoOp(result, managedState, nextState)) {
 		return result, nil
 	}
 

--- a/internal/clients/codex/sync_test.go
+++ b/internal/clients/codex/sync_test.go
@@ -580,6 +580,47 @@ STEWREADS_CONFIG_PATH = "~/.config/stewreads/config.toml"
 	}
 }
 
+func TestSyncSkipsManagedRemoteManifest(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "codex-managed.json")
+	original := []byte(`model = "gpt-5"
+
+[mcp_servers.weather]
+command = "uv"
+args = ["run", "weather.py"]
+`)
+	if err := os.WriteFile(configPath, original, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	remote := registry.Manifest{
+		Name:      "cloud-sql",
+		Transport: registry.TransportHTTP,
+		URL:       "https://example.com/mcp",
+		Enabled:   true,
+		Clients:   []string{Target},
+	}
+	result, err := Sync([]registry.Manifest{remote}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	if len(result.Added) != 0 || len(result.Updated) != 0 || len(result.Removed) != 0 {
+		t.Fatalf("expected remote manifest to be ineligible until the adapter supports it, got: %+v", result)
+	}
+
+	servers := readServers(t, configPath)
+	if _, exists := servers["cloud-sql"]; exists {
+		t.Fatalf("expected remote manifest not to be materialized, got: %#v", servers)
+	}
+	if _, ok := servers["weather"]; !ok {
+		t.Fatalf("expected unmanaged weather entry to be preserved")
+	}
+}
+
 func newStewreadsManifest() registry.Manifest {
 	return registry.Manifest{
 		Name:    "stewreads",

--- a/internal/clients/codex/sync_test.go
+++ b/internal/clients/codex/sync_test.go
@@ -621,6 +621,36 @@ args = ["run", "weather.py"]
 	}
 }
 
+func TestSyncRemoteOnlyDoesNotCreateFiles(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "codex-managed.json")
+
+	remote := registry.Manifest{
+		Name:      "cloud-sql",
+		Transport: registry.TransportHTTP,
+		URL:       "https://example.com/mcp",
+		Enabled:   true,
+		Clients:   []string{Target},
+	}
+	result, err := Sync([]registry.Manifest{remote}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	if len(result.Added)+len(result.Updated)+len(result.Removed) != 0 {
+		t.Fatalf("expected no-op sync result, got: %+v", result)
+	}
+	if _, err := os.Stat(configPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected no config file for remote-only no-op sync, got err=%v", err)
+	}
+	if _, err := os.Stat(statePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected no state file for remote-only no-op sync, got err=%v", err)
+	}
+}
+
 func newStewreadsManifest() registry.Manifest {
 	return registry.Manifest{
 		Name:    "stewreads",

--- a/internal/clients/gemini/sync.go
+++ b/internal/clients/gemini/sync.go
@@ -59,7 +59,7 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 	result.ConfigPath = configPath
 	result.DryRun = opts.DryRun
 
-	if opts.DryRun {
+	if opts.DryRun || (!configExists && syncshared.PlanIsNoOp(result, managedState, nextState)) {
 		return result, nil
 	}
 

--- a/internal/clients/gemini/sync.go
+++ b/internal/clients/gemini/sync.go
@@ -280,6 +280,8 @@ func entriesForTarget(manifests []registry.Manifest, userScope bool) map[string]
 		switch {
 		case !manifest.Enabled:
 			// ineligible
+		case manifest.IsRemote():
+			// Remote transports are not materialized by this adapter yet.
 		case !userScope && manifest.HasSecretValue():
 			entry.Refused = true
 		default:

--- a/internal/clients/gemini/sync_test.go
+++ b/internal/clients/gemini/sync_test.go
@@ -557,6 +557,53 @@ func TestAttachRingConflictsOnEqualUnmanagedEntry(t *testing.T) {
 	}
 }
 
+func TestSyncSkipsManagedRemoteManifest(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".gemini", "settings.json")
+	statePath := filepath.Join(tmp, "state", "gemini-managed.json")
+	original := []byte(`{
+  "mcpServers": {
+    "weather": {
+      "command": "uv",
+      "args": ["run", "weather.py"]
+    }
+  }
+}
+`)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, original, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	remote := registry.Manifest{
+		Name:      "cloud-sql",
+		Transport: registry.TransportHTTP,
+		URL:       "https://example.com/mcp",
+		Enabled:   true,
+		Clients:   []string{Target},
+	}
+	result, err := Sync([]registry.Manifest{remote}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	if len(result.Added) != 0 || len(result.Updated) != 0 || len(result.Removed) != 0 {
+		t.Fatalf("expected remote manifest to be ineligible until the adapter supports it, got: %+v", result)
+	}
+
+	servers := readServers(t, configPath)
+	if _, exists := servers["cloud-sql"]; exists {
+		t.Fatalf("expected remote manifest not to be materialized, got: %#v", servers)
+	}
+	if _, ok := servers["weather"]; !ok {
+		t.Fatalf("expected unmanaged weather entry to be preserved")
+	}
+}
+
 func newStewreadsManifest() registry.Manifest {
 	return registry.Manifest{
 		Name:    "stewreads",

--- a/internal/clients/gemini/sync_test.go
+++ b/internal/clients/gemini/sync_test.go
@@ -604,6 +604,36 @@ func TestSyncSkipsManagedRemoteManifest(t *testing.T) {
 	}
 }
 
+func TestSyncRemoteOnlyDoesNotCreateFiles(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".gemini", "settings.json")
+	statePath := filepath.Join(tmp, "state", "gemini-managed.json")
+
+	remote := registry.Manifest{
+		Name:      "cloud-sql",
+		Transport: registry.TransportHTTP,
+		URL:       "https://example.com/mcp",
+		Enabled:   true,
+		Clients:   []string{Target},
+	}
+	result, err := Sync([]registry.Manifest{remote}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	if len(result.Added)+len(result.Updated)+len(result.Removed) != 0 {
+		t.Fatalf("expected no-op sync result, got: %+v", result)
+	}
+	if _, err := os.Stat(configPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected no config file for remote-only no-op sync, got err=%v", err)
+	}
+	if _, err := os.Stat(statePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected no state file for remote-only no-op sync, got err=%v", err)
+	}
+}
+
 func newStewreadsManifest() registry.Manifest {
 	return registry.Manifest{
 		Name:    "stewreads",

--- a/internal/clients/syncshared/plan.go
+++ b/internal/clients/syncshared/plan.go
@@ -2,6 +2,7 @@ package syncshared
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -21,6 +22,39 @@ type Entry[T any] struct {
 	// Refused marks a would-be-eligible entry excluded by the secrets
 	// placement policy; reported via SyncResult.Refused.
 	Refused bool
+}
+
+// PlanIsNoOp reports whether applying a sync plan would change neither the
+// client config nor the managed state. Adapters use it to skip applying when
+// the config file does not exist yet, so a sync with nothing to do (for
+// example only remote manifests, which no adapter materializes) never creates
+// config or state files. Existing configs still go through applyPlan for its
+// side effects (formatting normalization, permission tightening).
+func PlanIsNoOp(result clients.SyncResult, prev, next map[string][]string) bool {
+	if len(result.Added)+len(result.Updated)+len(result.Removed) > 0 {
+		return false
+	}
+	return managedStatesEqual(prev, next)
+}
+
+func managedStatesEqual(a, b map[string][]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for name, aSources := range a {
+		bSources, ok := b[name]
+		if !ok || len(aSources) != len(bSources) {
+			return false
+		}
+		as := append([]string(nil), aSources...)
+		bs := append([]string(nil), bSources...)
+		sort.Strings(as)
+		sort.Strings(bs)
+		if !slices.Equal(as, bs) {
+			return false
+		}
+	}
+	return true
 }
 
 // PlanSync computes a sync plan and the post-sync ownership state under the

--- a/internal/clients/vibe/sync.go
+++ b/internal/clients/vibe/sync.go
@@ -261,7 +261,7 @@ func entriesForTarget(manifests []registry.Manifest) map[string]syncshared.Entry
 			continue
 		}
 		entry := syncshared.Entry[serverConfig]{}
-		if manifest.Enabled {
+		if manifest.Enabled && !manifest.IsRemote() {
 			entry.Eligible = true
 			entry.Value = materializeServer(manifest)
 		}

--- a/internal/clients/vibe/sync.go
+++ b/internal/clients/vibe/sync.go
@@ -59,7 +59,7 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 	result.ConfigPath = configPath
 	result.DryRun = opts.DryRun
 
-	if opts.DryRun {
+	if opts.DryRun || (!configExists && syncshared.PlanIsNoOp(result, managedState, nextState)) {
 		return result, nil
 	}
 

--- a/internal/clients/vibe/sync_test.go
+++ b/internal/clients/vibe/sync_test.go
@@ -605,6 +605,36 @@ args = ["run", "weather.py"]
 	}
 }
 
+func TestSyncRemoteOnlyDoesNotCreateFiles(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "vibe-managed.json")
+
+	remote := registry.Manifest{
+		Name:      "cloud-sql",
+		Transport: registry.TransportHTTP,
+		URL:       "https://example.com/mcp",
+		Enabled:   true,
+		Clients:   []string{Target},
+	}
+	result, err := Sync([]registry.Manifest{remote}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	if len(result.Added)+len(result.Updated)+len(result.Removed) != 0 {
+		t.Fatalf("expected no-op sync result, got: %+v", result)
+	}
+	if _, err := os.Stat(configPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected no config file for remote-only no-op sync, got err=%v", err)
+	}
+	if _, err := os.Stat(statePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected no state file for remote-only no-op sync, got err=%v", err)
+	}
+}
+
 func newStewreadsManifest() registry.Manifest {
 	return registry.Manifest{
 		Name:    "stewreads",

--- a/internal/clients/vibe/sync_test.go
+++ b/internal/clients/vibe/sync_test.go
@@ -562,6 +562,49 @@ env = { STEWREADS_CONFIG_PATH = "~/.config/stewreads/config.toml" }
 	}
 }
 
+func TestSyncSkipsManagedRemoteManifest(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "vibe-managed.json")
+	original := []byte(`active_model = "mistral-large"
+
+[[mcp_servers]]
+name = "weather"
+transport = "stdio"
+command = "uv"
+args = ["run", "weather.py"]
+`)
+	if err := os.WriteFile(configPath, original, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	remote := registry.Manifest{
+		Name:      "cloud-sql",
+		Transport: registry.TransportHTTP,
+		URL:       "https://example.com/mcp",
+		Enabled:   true,
+		Clients:   []string{Target},
+	}
+	result, err := Sync([]registry.Manifest{remote}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	if len(result.Added) != 0 || len(result.Updated) != 0 || len(result.Removed) != 0 {
+		t.Fatalf("expected remote manifest to be ineligible until the adapter supports it, got: %+v", result)
+	}
+
+	servers := readServers(t, configPath)
+	if _, exists := servers["cloud-sql"]; exists {
+		t.Fatalf("expected remote manifest not to be materialized, got: %#v", servers)
+	}
+	if _, ok := servers["weather"]; !ok {
+		t.Fatalf("expected unmanaged weather entry to be preserved")
+	}
+}
+
 func newStewreadsManifest() registry.Manifest {
 	return registry.Manifest{
 		Name:    "stewreads",

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -648,6 +648,11 @@ func hasTarget(manifest registry.Manifest, targets []string) bool {
 
 func hasTargetInManifests(manifests []registry.Manifest, target string) bool {
 	for _, manifest := range manifests {
+		// No adapter materializes remote transports yet, so remote manifests
+		// alone don't warrant a client config on disk.
+		if manifest.IsRemote() {
+			continue
+		}
 		if manifest.HasClient(target) {
 			return true
 		}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -38,12 +38,14 @@ type Issue struct {
 }
 
 type ServerReport struct {
-	Name    string
-	Enabled bool
-	Clients []string
-	Command string
-	Status  Status
-	Issues  []Issue
+	Name      string
+	Enabled   bool
+	Clients   []string
+	Transport string
+	Command   string
+	URL       string
+	Status    Status
+	Issues    []Issue
 }
 
 type ManifestError struct {
@@ -368,12 +370,14 @@ func summarize(report Report) Summary {
 
 func inspectServer(manifest registry.Manifest, envLookup func(string) string, targets []string) ServerReport {
 	report := ServerReport{
-		Name:    manifest.Name,
-		Enabled: manifest.Enabled,
-		Clients: append([]string(nil), manifest.Clients...),
-		Command: manifest.Command,
-		Status:  StatusSkipped,
-		Issues:  []Issue{},
+		Name:      manifest.Name,
+		Enabled:   manifest.Enabled,
+		Clients:   append([]string(nil), manifest.Clients...),
+		Transport: manifest.TransportType(),
+		Command:   manifest.Command,
+		URL:       manifest.URL,
+		Status:    StatusSkipped,
+		Issues:    []Issue{},
 	}
 
 	if !manifest.Enabled || !hasTarget(manifest, targets) {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -316,7 +316,7 @@ func checkDrift(manifests []registry.Manifest, targets []DriftTarget, rings []re
 func syncableForTarget(manifests []registry.Manifest, target string) []registry.Manifest {
 	out := make([]registry.Manifest, 0, len(manifests))
 	for _, manifest := range manifests {
-		if manifest.Enabled && manifest.HasClient(target) {
+		if manifest.Enabled && manifest.HasClient(target) && !manifest.IsRemote() {
 			if issue := validateAbsoluteExecutablePath(manifest.Command); issue != nil {
 				continue
 			}
@@ -381,8 +381,19 @@ func inspectServer(manifest registry.Manifest, envLookup func(string) string, ta
 	}
 
 	report.Status = StatusReady
-	if issue := validateAbsoluteExecutablePath(manifest.Command); issue != nil {
-		report.Issues = append(report.Issues, *issue)
+	if !manifest.IsRemote() {
+		if issue := validateAbsoluteExecutablePath(manifest.Command); issue != nil {
+			report.Issues = append(report.Issues, *issue)
+			report.Status = StatusError
+		}
+	}
+
+	if manifest.IsRemote() && strings.TrimSpace(manifest.URL) == "" {
+		report.Issues = append(report.Issues, Issue{
+			Severity: SeverityError,
+			Code:     "missing_remote_url",
+			Message:  "remote transport requires url",
+		})
 		report.Status = StatusError
 	}
 

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -244,6 +244,41 @@ func TestRunSkipsClientConfigWhenTargetUnused(t *testing.T) {
 	}
 }
 
+func TestRunSkipsClientConfigForRemoteOnlyTarget(t *testing.T) {
+	tmp := t.TempDir()
+	store := registry.NewStore(filepath.Join(tmp, "servers"))
+
+	if err := store.Save(registry.Manifest{
+		Name:      "cloud-sql",
+		Transport: registry.TransportHTTP,
+		URL:       "https://example.com/mcp",
+		Enabled:   true,
+		Clients:   []string{"claude-desktop"},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+
+	adapter := testAdapter{
+		target:     "claude-desktop",
+		configPath: filepath.Join(tmp, "claude_desktop_config.json"),
+	}
+	report, err := Run(store, Options{Adapters: []clients.ClientAdapter{adapter}})
+	if err != nil {
+		t.Fatalf("doctor run failed: %v", err)
+	}
+
+	cc, ok := findClientConfig(report, "claude-desktop")
+	if !ok {
+		t.Fatalf("expected claude-desktop client config report, got: %+v", report.ClientConfigs)
+	}
+	if cc.Status != StatusSkipped {
+		t.Fatalf("expected remote-only target to skip the config check, got: %+v", cc)
+	}
+	if len(report.Servers) != 1 || report.Servers[0].Status != StatusReady {
+		t.Fatalf("expected remote manifest to report ready, got: %+v", report.Servers)
+	}
+}
+
 func TestRunUsesConfigPathOverride(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("unix fixture mode bits are used in this test")

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -277,6 +277,9 @@ func TestRunSkipsClientConfigForRemoteOnlyTarget(t *testing.T) {
 	if len(report.Servers) != 1 || report.Servers[0].Status != StatusReady {
 		t.Fatalf("expected remote manifest to report ready, got: %+v", report.Servers)
 	}
+	if report.Servers[0].Transport != registry.TransportHTTP || report.Servers[0].URL != "https://example.com/mcp" {
+		t.Fatalf("expected remote transport details in report, got: %+v", report.Servers[0])
+	}
 }
 
 func TestRunUsesConfigPathOverride(t *testing.T) {

--- a/internal/registry/manifest.go
+++ b/internal/registry/manifest.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"fmt"
+	"net/url"
 	"regexp"
 	"strings"
 )
@@ -11,17 +12,28 @@ var (
 	envKeyPattern       = regexp.MustCompile(`^[A-Z_][A-Z0-9_]*$`)
 )
 
+const (
+	TransportStdio = "stdio"
+	TransportHTTP  = "http"
+	TransportSSE   = "sse"
+)
+
 // Manifest is the canonical configuration for one local MCP server.
 type Manifest struct {
-	Name        string            `toml:"name" json:"name"`
-	Command     string            `toml:"command" json:"command"`
-	Args        []string          `toml:"args" json:"args"`
-	Enabled     bool              `toml:"enabled" json:"enabled"`
-	Clients     []string          `toml:"clients" json:"clients"`
-	Description string            `toml:"description,omitempty" json:"description,omitempty"`
-	Env         map[string]string `toml:"env,omitempty" json:"env,omitempty"`
-	RequiredEnv RequiredEnv       `toml:"required_env,omitempty" json:"required_env,omitempty"`
-	SecretEnv   SecretEnv         `toml:"secret_env,omitempty" json:"secret_env,omitempty"`
+	Name          string            `toml:"name" json:"name"`
+	Transport     string            `toml:"transport,omitempty" json:"transport,omitempty"`
+	Command       string            `toml:"command" json:"command"`
+	Args          []string          `toml:"args" json:"args"`
+	URL           string            `toml:"url,omitempty" json:"url,omitempty"`
+	Headers       map[string]string `toml:"headers,omitempty" json:"headers,omitempty"`
+	TimeoutMS     int               `toml:"timeout_ms,omitempty" json:"timeout_ms,omitempty"`
+	OAuthResource string            `toml:"oauth_resource,omitempty" json:"oauth_resource,omitempty"`
+	Enabled       bool              `toml:"enabled" json:"enabled"`
+	Clients       []string          `toml:"clients" json:"clients"`
+	Description   string            `toml:"description,omitempty" json:"description,omitempty"`
+	Env           map[string]string `toml:"env,omitempty" json:"env,omitempty"`
+	RequiredEnv   RequiredEnv       `toml:"required_env,omitempty" json:"required_env,omitempty"`
+	SecretEnv     SecretEnv         `toml:"secret_env,omitempty" json:"secret_env,omitempty"`
 }
 
 // RequiredEnv describes environment variables that must be present at runtime.
@@ -60,6 +72,25 @@ func (m Manifest) HasClient(target string) bool {
 	return false
 }
 
+// TransportType returns the effective transport. An empty transport preserves
+// legacy manifests and means stdio.
+func (m Manifest) TransportType() string {
+	transport := strings.TrimSpace(strings.ToLower(m.Transport))
+	if transport == "" {
+		return TransportStdio
+	}
+	return transport
+}
+
+func (m Manifest) IsRemote() bool {
+	switch m.TransportType() {
+	case TransportHTTP, TransportSSE:
+		return true
+	default:
+		return false
+	}
+}
+
 // Validate enforces manifest-level invariants.
 func (m Manifest) Validate() error {
 	var errs []string
@@ -68,8 +99,57 @@ func (m Manifest) Validate() error {
 		errs = append(errs, err.Error())
 	}
 
-	if strings.TrimSpace(m.Command) == "" {
-		errs = append(errs, "command is required")
+	transport := m.TransportType()
+	switch transport {
+	case TransportStdio:
+		if strings.TrimSpace(m.Command) == "" {
+			errs = append(errs, "command is required")
+		}
+		if strings.TrimSpace(m.URL) != "" {
+			errs = append(errs, "url is only supported for remote transports")
+		}
+		if len(m.Headers) > 0 {
+			errs = append(errs, "headers are only supported for remote transports")
+		}
+		if m.TimeoutMS != 0 {
+			errs = append(errs, "timeout_ms is only supported for remote transports")
+		}
+		if strings.TrimSpace(m.OAuthResource) != "" {
+			errs = append(errs, "oauth_resource is only supported for remote transports")
+		}
+	case TransportHTTP, TransportSSE:
+		if strings.TrimSpace(m.URL) == "" {
+			errs = append(errs, "url is required for remote transports")
+		} else if err := validateRemoteURL(m.URL); err != nil {
+			errs = append(errs, err.Error())
+		}
+		if strings.TrimSpace(m.Command) != "" {
+			errs = append(errs, "command is not supported for remote transports")
+		}
+		if len(m.Args) > 0 {
+			errs = append(errs, "args are not supported for remote transports")
+		}
+		if len(m.Env) > 0 {
+			errs = append(errs, "env is not supported for remote transports")
+		}
+		if len(m.RequiredEnv.Keys) > 0 {
+			errs = append(errs, "required_env is not supported for remote transports")
+		}
+		if len(m.SecretEnv.Keys) > 0 {
+			errs = append(errs, "secret_env is not supported for remote transports")
+		}
+	default:
+		errs = append(errs, fmt.Sprintf("transport must be one of %q, %q, or %q", TransportStdio, TransportHTTP, TransportSSE))
+	}
+
+	if m.TimeoutMS < 0 {
+		errs = append(errs, "timeout_ms must be positive")
+	}
+
+	for key := range m.Headers {
+		if !validHeaderName(key) {
+			errs = append(errs, fmt.Sprintf("invalid header name %q", key))
+		}
 	}
 
 	if len(m.Clients) == 0 {
@@ -146,4 +226,31 @@ func validateServerName(name string) error {
 		return fmt.Errorf("name must match %q", manifestNamePattern.String())
 	}
 	return nil
+}
+
+func validateRemoteURL(raw string) error {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return fmt.Errorf("invalid url: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("url must use http or https")
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("url must include a host")
+	}
+	return nil
+}
+
+func validHeaderName(name string) bool {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return false
+	}
+	for _, r := range name {
+		if r <= 32 || r >= 127 || r == ':' {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/registry/manifest.go
+++ b/internal/registry/manifest.go
@@ -120,6 +120,8 @@ func (m Manifest) Validate() error {
 	case TransportHTTP, TransportSSE:
 		if strings.TrimSpace(m.URL) == "" {
 			errs = append(errs, "url is required for remote transports")
+		} else if m.URL != strings.TrimSpace(m.URL) {
+			errs = append(errs, "url must not have leading or trailing whitespace")
 		} else if err := validateRemoteURL(m.URL); err != nil {
 			errs = append(errs, err.Error())
 		}
@@ -148,7 +150,7 @@ func (m Manifest) Validate() error {
 
 	for key := range m.Headers {
 		if !validHeaderName(key) {
-			errs = append(errs, fmt.Sprintf("invalid header name %q", key))
+			errs = append(errs, fmt.Sprintf("invalid header name %q (allowed: letters, digits, '-', '_')", key))
 		}
 	}
 
@@ -229,7 +231,7 @@ func validateServerName(name string) error {
 }
 
 func validateRemoteURL(raw string) error {
-	parsed, err := url.Parse(strings.TrimSpace(raw))
+	parsed, err := url.Parse(raw)
 	if err != nil {
 		return fmt.Errorf("invalid url: %w", err)
 	}
@@ -242,15 +244,18 @@ func validateRemoteURL(raw string) error {
 	return nil
 }
 
+// validHeaderName restricts header names to characters that round-trip as raw
+// manifest keys; the plain-text parser treats '#', '=', quotes, and brackets
+// specially, so anything outside this set could not be reloaded.
 func validHeaderName(name string) bool {
-	name = strings.TrimSpace(name)
 	if name == "" {
 		return false
 	}
 	for _, r := range name {
-		if r <= 32 || r >= 127 || r == ':' {
-			return false
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_' {
+			continue
 		}
+		return false
 	}
 	return true
 }

--- a/internal/registry/manifest_test.go
+++ b/internal/registry/manifest_test.go
@@ -136,6 +136,33 @@ func TestManifestValidateErrors(t *testing.T) {
 			expects: "invalid header name",
 		},
 		{
+			name: "remote rejects header name that cannot round-trip",
+			mutate: func(m *Manifest) {
+				*m = Manifest{
+					Name:      "cloud-sql",
+					Transport: TransportHTTP,
+					URL:       "https://sqladmin.googleapis.com/mcp",
+					Headers:   map[string]string{"X#Trace": "1"},
+					Enabled:   true,
+					Clients:   []string{"codex"},
+				}
+			},
+			expects: "invalid header name",
+		},
+		{
+			name: "remote rejects url with surrounding whitespace",
+			mutate: func(m *Manifest) {
+				*m = Manifest{
+					Name:      "cloud-sql",
+					Transport: TransportHTTP,
+					URL:       "https://sqladmin.googleapis.com/mcp ",
+					Enabled:   true,
+					Clients:   []string{"codex"},
+				}
+			},
+			expects: "url must not have leading or trailing whitespace",
+		},
+		{
 			name: "remote rejects negative timeout",
 			mutate: func(m *Manifest) {
 				*m = Manifest{

--- a/internal/registry/manifest_test.go
+++ b/internal/registry/manifest_test.go
@@ -55,6 +55,101 @@ func TestManifestValidateErrors(t *testing.T) {
 			expects: "command is required",
 		},
 		{
+			name: "invalid transport",
+			mutate: func(m *Manifest) {
+				m.Transport = "websocket"
+			},
+			expects: "transport must be one of",
+		},
+		{
+			name: "stdio rejects url",
+			mutate: func(m *Manifest) {
+				m.URL = "https://example.com/mcp"
+			},
+			expects: "url is only supported",
+		},
+		{
+			name: "remote missing url",
+			mutate: func(m *Manifest) {
+				*m = Manifest{
+					Name:      "cloud-sql",
+					Transport: TransportHTTP,
+					Enabled:   true,
+					Clients:   []string{"codex"},
+				}
+			},
+			expects: "url is required",
+		},
+		{
+			name: "remote rejects command",
+			mutate: func(m *Manifest) {
+				*m = Manifest{
+					Name:      "cloud-sql",
+					Transport: TransportHTTP,
+					URL:       "https://sqladmin.googleapis.com/mcp",
+					Command:   "mcp-server-cloud-sql",
+					Enabled:   true,
+					Clients:   []string{"codex"},
+				}
+			},
+			expects: "command is not supported",
+		},
+		{
+			name: "remote rejects args",
+			mutate: func(m *Manifest) {
+				*m = Manifest{
+					Name:      "cloud-sql",
+					Transport: TransportHTTP,
+					URL:       "https://sqladmin.googleapis.com/mcp",
+					Args:      []string{"--stdio"},
+					Enabled:   true,
+					Clients:   []string{"codex"},
+				}
+			},
+			expects: "args are not supported",
+		},
+		{
+			name: "remote requires http url",
+			mutate: func(m *Manifest) {
+				*m = Manifest{
+					Name:      "cloud-sql",
+					Transport: TransportHTTP,
+					URL:       "file:///tmp/mcp",
+					Enabled:   true,
+					Clients:   []string{"codex"},
+				}
+			},
+			expects: "url must use http or https",
+		},
+		{
+			name: "remote rejects invalid header name",
+			mutate: func(m *Manifest) {
+				*m = Manifest{
+					Name:      "cloud-sql",
+					Transport: TransportHTTP,
+					URL:       "https://sqladmin.googleapis.com/mcp",
+					Headers:   map[string]string{"Bad Header": "value"},
+					Enabled:   true,
+					Clients:   []string{"codex"},
+				}
+			},
+			expects: "invalid header name",
+		},
+		{
+			name: "remote rejects negative timeout",
+			mutate: func(m *Manifest) {
+				*m = Manifest{
+					Name:      "cloud-sql",
+					Transport: TransportHTTP,
+					URL:       "https://sqladmin.googleapis.com/mcp",
+					TimeoutMS: -1,
+					Enabled:   true,
+					Clients:   []string{"codex"},
+				}
+			},
+			expects: "timeout_ms must be positive",
+		},
+		{
 			name: "duplicate clients",
 			mutate: func(m *Manifest) {
 				m.Clients = []string{"claude-desktop", "claude-desktop"}
@@ -103,5 +198,24 @@ func TestManifestValidateErrors(t *testing.T) {
 				t.Fatalf("expected error containing %q, got: %v", tt.expects, err)
 			}
 		})
+	}
+}
+
+func TestManifestValidateRemoteOK(t *testing.T) {
+	m := Manifest{
+		Name:          "cloud-sql",
+		Transport:     TransportHTTP,
+		URL:           "https://sqladmin.googleapis.com/mcp",
+		OAuthResource: "https://sqladmin.googleapis.com/",
+		TimeoutMS:     30000,
+		Headers:       map[string]string{"x-goog-user-project": "project-id"},
+		Enabled:       true,
+		Clients:       []string{"codex"},
+	}
+	if err := m.Validate(); err != nil {
+		t.Fatalf("expected remote manifest to validate, got: %v", err)
+	}
+	if !m.IsRemote() {
+		t.Fatalf("expected remote manifest to report IsRemote")
 	}
 }

--- a/internal/registry/parser.go
+++ b/internal/registry/parser.go
@@ -11,6 +11,7 @@ import (
 const (
 	sectionTop         = ""
 	sectionEnv         = "env"
+	sectionHeaders     = "headers"
 	sectionRequiredEnv = "required_env"
 	sectionSecretEnv   = "secret_env"
 )
@@ -46,7 +47,7 @@ func ParseManifest(data []byte) (Manifest, error) {
 			}
 			name := strings.TrimSpace(line[1 : len(line)-1])
 			switch name {
-			case sectionEnv, sectionRequiredEnv, sectionSecretEnv:
+			case sectionEnv, sectionHeaders, sectionRequiredEnv, sectionSecretEnv:
 				section = name
 			default:
 				return Manifest{}, fmt.Errorf("line %d: unknown section %q", lineNo, name)
@@ -70,6 +71,15 @@ func ParseManifest(data []byte) (Manifest, error) {
 				return Manifest{}, fmt.Errorf("line %d: invalid env value for %q: %w", lineNo, key, err)
 			}
 			m.Env[key] = sv
+		case sectionHeaders:
+			sv, err := parseString(value)
+			if err != nil {
+				return Manifest{}, fmt.Errorf("line %d: invalid header value for %q: %w", lineNo, key, err)
+			}
+			if m.Headers == nil {
+				m.Headers = map[string]string{}
+			}
+			m.Headers[key] = sv
 		case sectionRequiredEnv:
 			if key != "keys" {
 				return Manifest{}, fmt.Errorf("line %d: unknown key %q in [required_env]", lineNo, key)
@@ -112,12 +122,35 @@ func MarshalManifest(m Manifest) ([]byte, error) {
 	var b strings.Builder
 
 	fmt.Fprintf(&b, "name = %s\n", strconv.Quote(m.Name))
-	fmt.Fprintf(&b, "command = %s\n", strconv.Quote(m.Command))
-	fmt.Fprintf(&b, "args = %s\n", formatStringArray(m.Args))
+	if m.TransportType() != TransportStdio {
+		fmt.Fprintf(&b, "transport = %s\n", strconv.Quote(m.TransportType()))
+		fmt.Fprintf(&b, "url = %s\n", strconv.Quote(m.URL))
+		if m.TimeoutMS > 0 {
+			fmt.Fprintf(&b, "timeout_ms = %d\n", m.TimeoutMS)
+		}
+		if strings.TrimSpace(m.OAuthResource) != "" {
+			fmt.Fprintf(&b, "oauth_resource = %s\n", strconv.Quote(m.OAuthResource))
+		}
+	} else {
+		fmt.Fprintf(&b, "command = %s\n", strconv.Quote(m.Command))
+		fmt.Fprintf(&b, "args = %s\n", formatStringArray(m.Args))
+	}
 	fmt.Fprintf(&b, "enabled = %t\n", m.Enabled)
 	fmt.Fprintf(&b, "clients = %s\n", formatStringArray(m.Clients))
 	if strings.TrimSpace(m.Description) != "" {
 		fmt.Fprintf(&b, "description = %s\n", strconv.Quote(m.Description))
+	}
+
+	if len(m.Headers) > 0 {
+		keys := make([]string, 0, len(m.Headers))
+		for key := range m.Headers {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		b.WriteString("\n[headers]\n")
+		for _, key := range keys {
+			fmt.Fprintf(&b, "%s = %s\n", key, strconv.Quote(m.Headers[key]))
+		}
 	}
 
 	if len(m.Env) > 0 {
@@ -163,6 +196,30 @@ func parseTopLevel(m *Manifest, key, value string) error {
 			return fmt.Errorf("invalid command: %w", err)
 		}
 		m.Command = sv
+	case "transport":
+		sv, err := parseString(value)
+		if err != nil {
+			return fmt.Errorf("invalid transport: %w", err)
+		}
+		m.Transport = sv
+	case "url":
+		sv, err := parseString(value)
+		if err != nil {
+			return fmt.Errorf("invalid url: %w", err)
+		}
+		m.URL = sv
+	case "oauth_resource":
+		sv, err := parseString(value)
+		if err != nil {
+			return fmt.Errorf("invalid oauth_resource: %w", err)
+		}
+		m.OAuthResource = sv
+	case "timeout_ms":
+		iv, err := parseInt(value)
+		if err != nil {
+			return fmt.Errorf("invalid timeout_ms: %w", err)
+		}
+		m.TimeoutMS = iv
 	case "description":
 		sv, err := parseString(value)
 		if err != nil {
@@ -230,6 +287,15 @@ func parseBool(raw string) (bool, error) {
 	default:
 		return false, fmt.Errorf("expected true or false")
 	}
+}
+
+func parseInt(raw string) (int, error) {
+	value := strings.TrimSpace(raw)
+	iv, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, fmt.Errorf("expected integer")
+	}
+	return iv, nil
 }
 
 func parseStringArray(raw string) ([]string, error) {

--- a/internal/registry/parser_test.go
+++ b/internal/registry/parser_test.go
@@ -57,6 +57,59 @@ func TestParseAndMarshalManifestRoundTrip(t *testing.T) {
 	if out.Env["STEWREADS_CONFIG_PATH"] == "" {
 		t.Fatalf("expected env value to survive roundtrip")
 	}
+	if out.TransportType() != TransportStdio {
+		t.Fatalf("expected legacy manifest to default to stdio, got: %q", out.TransportType())
+	}
+	if strings.Contains(string(encoded), "transport") {
+		t.Fatalf("expected stdio manifest to omit default transport, got:\n%s", encoded)
+	}
+}
+
+func TestParseAndMarshalRemoteManifestRoundTrip(t *testing.T) {
+	in := Manifest{
+		Name:          "cloud-sql",
+		Transport:     TransportHTTP,
+		URL:           "https://sqladmin.googleapis.com/mcp",
+		TimeoutMS:     30000,
+		OAuthResource: "https://sqladmin.googleapis.com/",
+		Enabled:       true,
+		Clients:       []string{"codex"},
+		Description:   "Cloud SQL remote MCP",
+		Headers: map[string]string{
+			"x-goog-user-project": "example-project",
+		},
+	}
+
+	encoded, err := MarshalManifest(in)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	for _, want := range []string{
+		`transport = "http"`,
+		`url = "https://sqladmin.googleapis.com/mcp"`,
+		`timeout_ms = 30000`,
+		`oauth_resource = "https://sqladmin.googleapis.com/"`,
+		"[headers]",
+		`x-goog-user-project = "example-project"`,
+	} {
+		if !strings.Contains(string(encoded), want) {
+			t.Fatalf("expected encoded manifest to contain %q, got:\n%s", want, encoded)
+		}
+	}
+	if strings.Contains(string(encoded), "command") {
+		t.Fatalf("expected remote manifest to omit command, got:\n%s", encoded)
+	}
+
+	out, err := ParseManifest(encoded)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if out.TransportType() != TransportHTTP || out.URL != in.URL || out.OAuthResource != in.OAuthResource {
+		t.Fatalf("remote roundtrip mismatch: got %#v", out)
+	}
+	if out.Headers["x-goog-user-project"] != "example-project" {
+		t.Fatalf("expected headers to survive roundtrip, got: %#v", out.Headers)
+	}
 }
 
 func TestParseManifestRejectsUnknownSection(t *testing.T) {
@@ -122,11 +175,11 @@ unexpected = ["MISSING_KEY"]
 
 func TestParseManifestSecretEnvRoundTrip(t *testing.T) {
 	in := Manifest{
-		Name:        "stewreads",
-		Command:     "stewreads-mcp",
-		Args:        []string{},
-		Enabled:     true,
-		Clients:     []string{"claude-desktop"},
+		Name:    "stewreads",
+		Command: "stewreads-mcp",
+		Args:    []string{},
+		Enabled: true,
+		Clients: []string{"claude-desktop"},
 		Env: map[string]string{
 			"STEWREADS_API_KEY": "shhh",
 		},
@@ -170,6 +223,27 @@ unexpected = ["STEWREADS_API_KEY"]
 		t.Fatalf("expected parse error for unknown secret_env key")
 	}
 	if !strings.Contains(err.Error(), "unknown key") || !strings.Contains(err.Error(), "[secret_env]") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestParseManifestRejectsUnknownHeadersValue(t *testing.T) {
+	manifest := `
+name = "cloud-sql"
+transport = "http"
+url = "https://sqladmin.googleapis.com/mcp"
+enabled = true
+clients = ["codex"]
+
+[headers]
+x-goog-user-project = 123
+`
+
+	_, err := ParseManifest([]byte(manifest))
+	if err == nil {
+		t.Fatalf("expected parse error for non-string header value")
+	}
+	if !strings.Contains(err.Error(), "invalid header value") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/registry/snapshot.go
+++ b/internal/registry/snapshot.go
@@ -399,6 +399,20 @@ func manifestsEqual(a, b Manifest) bool {
 		return false
 	}
 
+	if a.TransportType() != b.TransportType() || a.URL != b.URL ||
+		a.TimeoutMS != b.TimeoutMS || a.OAuthResource != b.OAuthResource {
+		return false
+	}
+
+	if len(a.Headers) != len(b.Headers) {
+		return false
+	}
+	for key, value := range a.Headers {
+		if b.Headers[key] != value {
+			return false
+		}
+	}
+
 	if !slices.Equal(a.Args, b.Args) {
 		return false
 	}

--- a/internal/registry/snapshot.go
+++ b/internal/registry/snapshot.go
@@ -16,7 +16,11 @@ const (
 	snapshotVersionV3 = 3
 	snapshotVersionV4 = 4
 	snapshotVersionV5 = 5
-	SnapshotVersion   = 6
+	snapshotVersionV6 = 6
+	// SnapshotVersion 7 adds remote transport fields on server manifests;
+	// pre-remote importers reject v7 snapshots cleanly by version instead of
+	// misreading a remote server as a stdio manifest without a command.
+	SnapshotVersion = 7
 )
 
 type Snapshot struct {
@@ -310,7 +314,7 @@ func ImportSnapshot(store *Store, snapshot Snapshot, apply bool) (ImportResult, 
 }
 
 func (s Snapshot) Validate() error {
-	if s.Version != snapshotVersionV1 && s.Version != snapshotVersionV2 && s.Version != snapshotVersionV3 && s.Version != snapshotVersionV4 && s.Version != snapshotVersionV5 && s.Version != SnapshotVersion {
+	if s.Version != snapshotVersionV1 && s.Version != snapshotVersionV2 && s.Version != snapshotVersionV3 && s.Version != snapshotVersionV4 && s.Version != snapshotVersionV5 && s.Version != snapshotVersionV6 && s.Version != SnapshotVersion {
 		return fmt.Errorf("unsupported snapshot version %d (supported: %d)", s.Version, SnapshotVersion)
 	}
 	if s.Version == snapshotVersionV1 && len(s.Rings) > 0 {
@@ -324,6 +328,9 @@ func (s Snapshot) Validate() error {
 	}
 	if s.Version < snapshotVersionV5 && snapshotHasRingContracts(s) {
 		return fmt.Errorf("snapshot version %d does not support ring contracts", s.Version)
+	}
+	if s.Version < SnapshotVersion && snapshotHasRemoteServers(s) {
+		return fmt.Errorf("snapshot version %d does not support remote transports", s.Version)
 	}
 
 	seen := map[string]struct{}{}
@@ -593,6 +600,15 @@ func normalizedRingSkills(r Ring) []string {
 func snapshotHasRingSkills(snapshot Snapshot) bool {
 	for _, ring := range snapshot.Rings {
 		if len(ring.Skills) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func snapshotHasRemoteServers(snapshot Snapshot) bool {
+	for _, server := range snapshot.Servers {
+		if server.IsRemote() {
 			return true
 		}
 	}

--- a/internal/registry/snapshot_test.go
+++ b/internal/registry/snapshot_test.go
@@ -281,6 +281,66 @@ func TestImportSnapshotDryRunAndApply(t *testing.T) {
 	}
 }
 
+func TestImportSnapshotDetectsRemoteFieldChanges(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "servers"))
+	if err := store.Save(Manifest{
+		Name:      "cloud-sql",
+		Transport: TransportHTTP,
+		URL:       "https://old.example.com/mcp",
+		Headers:   map[string]string{"x-goog-user-project": "old-project"},
+		Enabled:   true,
+		Clients:   []string{"codex"},
+	}); err != nil {
+		t.Fatalf("save initial manifest: %v", err)
+	}
+
+	snapshot := Snapshot{
+		Version: SnapshotVersion,
+		Servers: []Manifest{
+			{
+				Name:      "cloud-sql",
+				Transport: TransportHTTP,
+				URL:       "https://new.example.com/mcp",
+				Headers:   map[string]string{"x-goog-user-project": "old-project"},
+				Enabled:   true,
+				Clients:   []string{"codex"},
+			},
+		},
+	}
+
+	result, err := ImportSnapshot(store, snapshot, true)
+	if err != nil {
+		t.Fatalf("apply import failed: %v", err)
+	}
+	if len(result.Updated) != 1 || result.Updated[0] != "cloud-sql" {
+		t.Fatalf("expected url-only change to be detected as update, got: %+v", result)
+	}
+	after, err := store.Get("cloud-sql")
+	if err != nil {
+		t.Fatalf("load manifest after apply: %v", err)
+	}
+	if after.URL != "https://new.example.com/mcp" {
+		t.Fatalf("expected url to be updated, got: %q", after.URL)
+	}
+
+	snapshot.Servers[0].Headers = map[string]string{"x-goog-user-project": "new-project"}
+	result, err = ImportSnapshot(store, snapshot, true)
+	if err != nil {
+		t.Fatalf("apply header import failed: %v", err)
+	}
+	if len(result.Updated) != 1 || result.Updated[0] != "cloud-sql" {
+		t.Fatalf("expected header-only change to be detected as update, got: %+v", result)
+	}
+
+	result, err = ImportSnapshot(store, snapshot, true)
+	if err != nil {
+		t.Fatalf("no-op import failed: %v", err)
+	}
+	if len(result.Updated) != 0 || len(result.Unchanged) != 1 {
+		t.Fatalf("expected identical snapshot to be unchanged, got: %+v", result)
+	}
+}
+
 func TestImportSnapshotRingsDryRunAndApply(t *testing.T) {
 	store := NewStore(filepath.Join(t.TempDir(), "servers"))
 	for _, manifest := range []Manifest{

--- a/internal/registry/snapshot_test.go
+++ b/internal/registry/snapshot_test.go
@@ -207,6 +207,36 @@ func TestParseSnapshotV4RejectsRingContracts(t *testing.T) {
 	}
 }
 
+func TestParseSnapshotV6RejectsRemoteServers(t *testing.T) {
+	payload := []byte(`{"version":6,"servers":[{"name":"cloud-sql","transport":"http","url":"https://example.com/mcp","enabled":true,"clients":["codex"]}]}`)
+	_, err := ParseSnapshotJSON(payload)
+	if err == nil || !strings.Contains(err.Error(), "does not support remote transports") {
+		t.Fatalf("expected v6 remote-transport error, got: %v", err)
+	}
+}
+
+func TestParseSnapshotV7AcceptsRemoteServers(t *testing.T) {
+	payload := []byte(`{"version":7,"servers":[{"name":"cloud-sql","transport":"http","url":"https://example.com/mcp","enabled":true,"clients":["codex"]}]}`)
+	snapshot, err := ParseSnapshotJSON(payload)
+	if err != nil {
+		t.Fatalf("parse v7 snapshot with remote server: %v", err)
+	}
+	if len(snapshot.Servers) != 1 || !snapshot.Servers[0].IsRemote() {
+		t.Fatalf("expected remote server to parse, got: %#v", snapshot.Servers)
+	}
+}
+
+func TestParseSnapshotV6AcceptsStdioServers(t *testing.T) {
+	payload := []byte(`{"version":6,"servers":[{"name":"alpha","command":"/usr/bin/env","enabled":true,"clients":["claude-desktop"]}]}`)
+	snapshot, err := ParseSnapshotJSON(payload)
+	if err != nil {
+		t.Fatalf("parse v6 stdio snapshot: %v", err)
+	}
+	if snapshot.Version != snapshotVersionV6 {
+		t.Fatalf("expected v6 snapshot to keep version 6, got %d", snapshot.Version)
+	}
+}
+
 func TestImportSnapshotDryRunAndApply(t *testing.T) {
 	store := NewStore(filepath.Join(t.TempDir(), "servers"))
 	if err := store.Save(Manifest{


### PR DESCRIPTION
## Summary

First of three PRs adding remote MCP support. This one adds the registry model and CLI surface for `http`/`sse` transports, plus guards so no client adapter materializes remote entries until per-client support lands (codex next, then claude-code/gemini).

**Model** (`internal/registry`)
- New manifest fields: `transport` (empty = `stdio` for legacy manifests), `url`, `[headers]`, `timeout_ms`, `oauth_resource`
- Validation enforces transport/field pairing: remote requires `url` (http/https with host) and rejects `command`, `args`, `[env]`, `[required_env]`, `[secret_env]`; stdio rejects the remote fields
- Manifest marshaling stays byte-compatible for stdio manifests

**CLI** (`madari add`)
- `--transport`, `--url`, `--header KEY=VALUE` (repeatable), `--timeout-ms`, `--oauth-resource`
- `--command` required and path-resolved only for stdio

**Guards (the reason this PR is safe standalone)**
- Every sync adapter (claude-desktop, claude-code, codex, gemini, vibe) treats remote manifests as ineligible — no `command = ''` entries written, refcounted sources preserved
- `ring render` omits remote members with a warning, via a per-target `supportsRemote` capability flag (off for all targets here)
- `doctor` skips the executable-path check for remote manifests instead of misreporting them as errors; drift ignores remote until adapters materialize them

## Test plan

- New guard test in each of the five adapter packages: remote manifest → no adds, unmanaged entries preserved
- CLI tests: remote add round-trip, header/URL/transport validation errors, render omit warning
- Registry tests: transport validation matrix, marshal/parse round-trip with `[headers]`
- Manual sandbox: add http manifest → sync is a no-op, doctor reports `ready`, ring render warns and omits

## Follow-ups (deliberately out of scope)

- PR 2: codex remote materialization (`url` + `oauth_resource`), flip its `supportsRemote` flag, make doctor drift per-adapter, verify codex's header/timeout config surface
- PR 3: claude-code + gemini (JSON `type: "http"`); decide header secrecy policy (headers carry bearer tokens; needs the v0.1.5 placement treatment before any repo-scoped config can receive them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)