### PR TITLE
codex: materialize remote MCP manifests

### DIFF
--- a/cmd/madari/client_targets.go
+++ b/cmd/madari/client_targets.go
@@ -19,7 +19,6 @@ type clientTarget struct {
 	target             string
 	syncAdapter        clients.ClientAdapter
 	ringConfigRenderer func(io.Writer, map[string]renderedServer) error
-	ringRenderRemote   bool
 	userScope          bool
 	skillRoots         skillTargetRoots
 }
@@ -44,7 +43,6 @@ var clientTargets = []clientTarget{
 		target:             codex.Target,
 		syncAdapter:        codex.Adapter{},
 		ringConfigRenderer: renderCodexTOML,
-		ringRenderRemote:   true,
 		skillRoots: skillTargetRoots{
 			project: defaultProjectSkillRoot(".agents", "skills"),
 			user:    defaultHomeSkillRoot(".agents", "skills"),
@@ -98,9 +96,13 @@ func ringRenderTargetsFromClientTargets() map[string]ringRenderTarget {
 	targets := map[string]ringRenderTarget{}
 	for _, ct := range clientTargets {
 		if ct.ringConfigRenderer != nil {
+			supportsRemote := func(string) bool { return false }
+			if ct.syncAdapter != nil {
+				supportsRemote = ct.syncAdapter.SupportsRemote
+			}
 			targets[ct.target] = ringRenderTarget{
 				target:         ct.target,
-				supportsRemote: ct.ringRenderRemote,
+				supportsRemote: supportsRemote,
 				render:         ct.ringConfigRenderer,
 			}
 		}

--- a/cmd/madari/client_targets.go
+++ b/cmd/madari/client_targets.go
@@ -44,6 +44,7 @@ var clientTargets = []clientTarget{
 		target:             codex.Target,
 		syncAdapter:        codex.Adapter{},
 		ringConfigRenderer: renderCodexTOML,
+		ringRenderRemote:   true,
 		skillRoots: skillTargetRoots{
 			project: defaultProjectSkillRoot(".agents", "skills"),
 			user:    defaultHomeSkillRoot(".agents", "skills"),

--- a/cmd/madari/render_targets.go
+++ b/cmd/madari/render_targets.go
@@ -21,8 +21,10 @@ type renderedServer struct {
 }
 
 type ringRenderTarget struct {
-	target         string
-	supportsRemote bool
+	target string
+	// supportsRemote mirrors the sync adapter's per-transport remote
+	// capability so render and sync never disagree about materialization.
+	supportsRemote func(transport string) bool
 	render         func(io.Writer, map[string]renderedServer) error
 }
 
@@ -53,6 +55,13 @@ func renderCodexTOML(out io.Writer, servers map[string]renderedServer) error {
 			fmt.Fprintf(out, "url = %s\n", tomlString(entry.URL))
 			if entry.OAuthResource != "" {
 				fmt.Fprintf(out, "oauth_resource = %s\n", tomlString(entry.OAuthResource))
+			}
+			if len(entry.Headers) > 0 {
+				fmt.Fprintln(out)
+				fmt.Fprintf(out, "[mcp_servers.%s.http_headers]\n", tomlKey(name))
+				for _, key := range sortedMapKeys(entry.Headers) {
+					fmt.Fprintf(out, "%s = %s\n", tomlKey(key), tomlString(entry.Headers[key]))
+				}
 			}
 		} else {
 			fmt.Fprintf(out, "command = %s\n", tomlString(entry.Command))

--- a/cmd/madari/render_targets.go
+++ b/cmd/madari/render_targets.go
@@ -49,18 +49,25 @@ func renderCodexTOML(out io.Writer, servers map[string]renderedServer) error {
 		}
 		entry := servers[name]
 		fmt.Fprintf(out, "[mcp_servers.%s]\n", tomlKey(name))
-		fmt.Fprintf(out, "command = %s\n", tomlString(entry.Command))
-		if len(entry.Args) > 0 {
-			fmt.Fprintf(out, "args = %s\n", tomlStringArray(entry.Args))
-		}
-		if len(entry.RuntimeEnvKeys) > 0 {
-			fmt.Fprintf(out, "env_vars = %s\n", tomlStringArray(entry.RuntimeEnvKeys))
-		}
-		if len(entry.Env) > 0 {
-			fmt.Fprintln(out)
-			fmt.Fprintf(out, "[mcp_servers.%s.env]\n", tomlKey(name))
-			for _, key := range sortedMapKeys(entry.Env) {
-				fmt.Fprintf(out, "%s = %s\n", tomlKey(key), tomlString(entry.Env[key]))
+		if entry.URL != "" {
+			fmt.Fprintf(out, "url = %s\n", tomlString(entry.URL))
+			if entry.OAuthResource != "" {
+				fmt.Fprintf(out, "oauth_resource = %s\n", tomlString(entry.OAuthResource))
+			}
+		} else {
+			fmt.Fprintf(out, "command = %s\n", tomlString(entry.Command))
+			if len(entry.Args) > 0 {
+				fmt.Fprintf(out, "args = %s\n", tomlStringArray(entry.Args))
+			}
+			if len(entry.RuntimeEnvKeys) > 0 {
+				fmt.Fprintf(out, "env_vars = %s\n", tomlStringArray(entry.RuntimeEnvKeys))
+			}
+			if len(entry.Env) > 0 {
+				fmt.Fprintln(out)
+				fmt.Fprintf(out, "[mcp_servers.%s.env]\n", tomlKey(name))
+				for _, key := range sortedMapKeys(entry.Env) {
+					fmt.Fprintf(out, "%s = %s\n", tomlKey(key), tomlString(entry.Env[key]))
+				}
 			}
 		}
 	}

--- a/cmd/madari/ring.go
+++ b/cmd/madari/ring.go
@@ -411,12 +411,9 @@ func (a cliApp) cmdRingRender(args []string) error {
 			continue
 		}
 		if manifest.IsRemote() {
-			if !renderTarget.supportsRemote {
+			if !renderTarget.supportsRemote(manifest.TransportType()) {
 				fmt.Fprintf(a.stderr, "warning: ring member %s uses %s transport, which %s render does not support yet; omitted\n", member, manifest.TransportType(), target)
 				continue
-			}
-			if len(manifest.Headers) > 0 {
-				fmt.Fprintf(a.stderr, "warning: ring member %s: headers are not emitted for %s render\n", member, target)
 			}
 			if manifest.TimeoutMS > 0 {
 				fmt.Fprintf(a.stderr, "warning: ring member %s: timeout_ms is not emitted for %s render\n", member, target)

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -1392,10 +1392,31 @@ func manifestEndpoint(manifest registry.Manifest) string {
 func doctorEndpointDetail(server doctor.ServerReport) string {
 	switch server.Transport {
 	case registry.TransportHTTP, registry.TransportSSE:
-		return fmt.Sprintf("url=%s sync=pending", server.URL)
+		pending := remotePendingTargets(server.Clients)
+		if len(pending) == 0 {
+			return fmt.Sprintf("url=%s", server.URL)
+		}
+		return fmt.Sprintf("url=%s sync=pending(%s)", server.URL, strings.Join(pending, ","))
 	default:
 		return fmt.Sprintf("command=%s", server.Command)
 	}
+}
+
+// remotePendingTargets returns the manifest's sync targets whose adapters do
+// not materialize remote transports yet.
+func remotePendingTargets(targets []string) []string {
+	pending := []string{}
+	for _, target := range targets {
+		adapter, known := syncAdapters[target]
+		if !known {
+			continue
+		}
+		if !adapter.SupportsRemote() {
+			pending = append(pending, target)
+		}
+	}
+	sort.Strings(pending)
+	return pending
 }
 
 type unsupportedRemoteManifest struct {
@@ -1413,6 +1434,10 @@ func remoteSkipNames(skips []unsupportedRemoteManifest) []string {
 }
 
 func filterSyncableManifests(manifests []registry.Manifest, target string) ([]registry.Manifest, []string, []unsupportedRemoteManifest) {
+	remoteSupported := false
+	if adapter, known := syncAdapters[target]; known {
+		remoteSupported = adapter.SupportsRemote()
+	}
 	out := make([]registry.Manifest, 0, len(manifests))
 	var skipped []string
 	var unsupportedRemote []unsupportedRemoteManifest
@@ -1422,10 +1447,12 @@ func filterSyncableManifests(manifests []registry.Manifest, target string) ([]re
 			continue
 		}
 		if manifest.IsRemote() {
-			unsupportedRemote = append(unsupportedRemote, unsupportedRemoteManifest{
-				Name:      manifest.Name,
-				Transport: manifest.TransportType(),
-			})
+			if !remoteSupported {
+				unsupportedRemote = append(unsupportedRemote, unsupportedRemoteManifest{
+					Name:      manifest.Name,
+					Transport: manifest.TransportType(),
+				})
+			}
 			out = append(out, manifest)
 			continue
 		}

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -1392,7 +1392,7 @@ func manifestEndpoint(manifest registry.Manifest) string {
 func doctorEndpointDetail(server doctor.ServerReport) string {
 	switch server.Transport {
 	case registry.TransportHTTP, registry.TransportSSE:
-		pending := remotePendingTargets(server.Clients)
+		pending := remotePendingTargets(server.Clients, server.Transport)
 		if len(pending) == 0 {
 			return fmt.Sprintf("url=%s", server.URL)
 		}
@@ -1403,15 +1403,15 @@ func doctorEndpointDetail(server doctor.ServerReport) string {
 }
 
 // remotePendingTargets returns the manifest's sync targets whose adapters do
-// not materialize remote transports yet.
-func remotePendingTargets(targets []string) []string {
+// not materialize this remote transport yet.
+func remotePendingTargets(targets []string, transport string) []string {
 	pending := []string{}
 	for _, target := range targets {
 		adapter, known := syncAdapters[target]
 		if !known {
 			continue
 		}
-		if !adapter.SupportsRemote() {
+		if !adapter.SupportsRemote(transport) {
 			pending = append(pending, target)
 		}
 	}
@@ -1434,10 +1434,7 @@ func remoteSkipNames(skips []unsupportedRemoteManifest) []string {
 }
 
 func filterSyncableManifests(manifests []registry.Manifest, target string) ([]registry.Manifest, []string, []unsupportedRemoteManifest) {
-	remoteSupported := false
-	if adapter, known := syncAdapters[target]; known {
-		remoteSupported = adapter.SupportsRemote()
-	}
+	adapter, adapterKnown := syncAdapters[target]
 	out := make([]registry.Manifest, 0, len(manifests))
 	var skipped []string
 	var unsupportedRemote []unsupportedRemoteManifest
@@ -1447,7 +1444,7 @@ func filterSyncableManifests(manifests []registry.Manifest, target string) ([]re
 			continue
 		}
 		if manifest.IsRemote() {
-			if !remoteSupported {
+			if !adapterKnown || !adapter.SupportsRemote(manifest.TransportType()) {
 				unsupportedRemote = append(unsupportedRemote, unsupportedRemoteManifest{
 					Name:      manifest.Name,
 					Transport: manifest.TransportType(),
@@ -1630,7 +1627,7 @@ func printSyncSummary(stdout, stderr io.Writer, target, configPath string, dryRu
 	if len(unsupportedRemote) > 0 {
 		fmt.Fprintf(stdout, "unsupported remote: %s\n", formatNameList(remoteSkipNames(unsupportedRemote)))
 		for _, remote := range unsupportedRemote {
-			fmt.Fprintf(stderr, "warning: remote %s uses %s transport; stored in registry, but %s sync does not materialize remote transports yet\n", remote.Name, remote.Transport, target)
+			fmt.Fprintf(stderr, "warning: remote %s uses %s transport; stored in registry, but %s sync does not materialize %s transports yet\n", remote.Name, remote.Transport, target, remote.Transport)
 		}
 	}
 	if len(refused) > 0 {

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -2697,12 +2697,12 @@ func TestRunWithStoreSyncReportsUnsupportedRemote(t *testing.T) {
 	if result := runCmd(store, "add", "cloud-sql",
 		"--transport", "http",
 		"--url", "https://sqladmin.googleapis.com/mcp",
-		"--client", "codex"); result.code != 0 {
+		"--client", "vibe"); result.code != 0 {
 		t.Fatalf("setup add failed: %s", result.stderr)
 	}
 
 	configPath := filepath.Join(t.TempDir(), "config.toml")
-	result := runCmd(store, "sync", "codex", "--dry-run", "--config-path", configPath)
+	result := runCmd(store, "sync", "vibe", "--dry-run", "--config-path", configPath)
 	if result.code != 0 {
 		t.Fatalf("sync dry-run failed: stdout=%s stderr=%s", result.stdout, result.stderr)
 	}
@@ -2711,18 +2711,18 @@ func TestRunWithStoreSyncReportsUnsupportedRemote(t *testing.T) {
 	}
 	if !strings.Contains(result.stderr, "cloud-sql uses http transport") ||
 		!strings.Contains(result.stderr, "stored in registry") ||
-		!strings.Contains(result.stderr, "codex sync does not materialize remote transports yet") {
+		!strings.Contains(result.stderr, "vibe sync does not materialize remote transports yet") {
 		t.Fatalf("expected unsupported remote warning, got: %s", result.stderr)
 	}
 
-	result = runCmd(store, "sync", "codex", "--dry-run", "--json", "--config-path", configPath)
+	result = runCmd(store, "sync", "vibe", "--dry-run", "--json", "--config-path", configPath)
 	if result.code != 0 {
 		t.Fatalf("sync dry-run --json failed: stdout=%s stderr=%s", result.stdout, result.stderr)
 	}
 	expected := fmt.Sprintf(`{
   "schema_version": 1,
   "command": "sync",
-  "target": "codex",
+  "target": "vibe",
   "config_path": %q,
   "dry_run": true,
   "added": [],
@@ -2742,6 +2742,62 @@ func TestRunWithStoreSyncReportsUnsupportedRemote(t *testing.T) {
 `, configPath)
 	if result.stdout != expected {
 		t.Fatalf("sync --json unsupported remote schema drift:\nwant:\n%s\ngot:\n%s", expected, result.stdout)
+	}
+}
+
+func TestRunWithStoreSyncCodexMaterializesRemote(t *testing.T) {
+	store := newTestStore(t)
+
+	if result := runCmd(store, "add", "cloud-sql",
+		"--transport", "http",
+		"--url", "https://sqladmin.googleapis.com/mcp",
+		"--client", "codex",
+		"--oauth-resource", "https://sqladmin.googleapis.com/"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	result := runCmd(store, "sync", "codex", "--config-path", configPath)
+	if result.code != 0 {
+		t.Fatalf("sync failed: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	if !strings.Contains(result.stdout, "added: cloud-sql") {
+		t.Fatalf("expected remote entry added, got: %s", result.stdout)
+	}
+	if strings.Contains(result.stdout, "unsupported remote") {
+		t.Fatalf("expected no unsupported remote line for codex, got: %s", result.stdout)
+	}
+	if strings.TrimSpace(result.stderr) != "" {
+		t.Fatalf("expected no warnings for codex remote sync, got: %s", result.stderr)
+	}
+
+	payload, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read codex config: %v", err)
+	}
+	for _, want := range []string{
+		"url = 'https://sqladmin.googleapis.com/mcp'",
+		"oauth_resource = 'https://sqladmin.googleapis.com/'",
+	} {
+		if !strings.Contains(string(payload), want) {
+			t.Fatalf("expected %q in codex config, got:\n%s", want, payload)
+		}
+	}
+	if strings.Contains(string(payload), "command") {
+		t.Fatalf("expected no command key for remote entry, got:\n%s", payload)
+	}
+
+	result = runCmd(store, "sync", "codex", "--dry-run", "--json", "--config-path", configPath)
+	if result.code != 0 {
+		t.Fatalf("sync dry-run --json failed: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	if !strings.Contains(result.stdout, `"unsupported_remote": []`) {
+		t.Fatalf("expected empty unsupported_remote for codex, got: %s", result.stdout)
+	}
+	if !strings.Contains(result.stdout, `"unchanged": [
+    "cloud-sql"
+  ]`) {
+		t.Fatalf("expected cloud-sql unchanged on re-sync, got: %s", result.stdout)
 	}
 }
 
@@ -3552,7 +3608,7 @@ func TestRunWithStoreRingAttachReportsUnsupportedRemote(t *testing.T) {
 	if result := runCmd(store, "add", "cloud-sql",
 		"--transport", "http",
 		"--url", "https://sqladmin.googleapis.com/mcp",
-		"--client", "codex"); result.code != 0 {
+		"--client", "vibe"); result.code != 0 {
 		t.Fatalf("setup add failed: %s", result.stderr)
 	}
 	if result := runCmd(store, "ring", "create", "cloudsql-readonly", "--member", "cloud-sql"); result.code != 0 {
@@ -3560,7 +3616,7 @@ func TestRunWithStoreRingAttachReportsUnsupportedRemote(t *testing.T) {
 	}
 
 	configPath := filepath.Join(t.TempDir(), "config.toml")
-	result := runCmd(store, "ring", "attach", "cloudsql-readonly", "codex", "--dry-run", "--config-path", configPath)
+	result := runCmd(store, "ring", "attach", "cloudsql-readonly", "vibe", "--dry-run", "--config-path", configPath)
 	if result.code != 0 {
 		t.Fatalf("ring attach dry-run failed: stdout=%s stderr=%s", result.stdout, result.stderr)
 	}
@@ -3574,8 +3630,34 @@ func TestRunWithStoreRingAttachReportsUnsupportedRemote(t *testing.T) {
 	}
 	if !strings.Contains(result.stderr, "cloud-sql uses http transport") ||
 		!strings.Contains(result.stderr, "stored in registry") ||
-		!strings.Contains(result.stderr, "codex sync does not materialize remote transports yet") {
+		!strings.Contains(result.stderr, "vibe sync does not materialize remote transports yet") {
 		t.Fatalf("expected unsupported remote warning, got: %s", result.stderr)
+	}
+}
+
+func TestRunWithStoreRingAttachCodexRemote(t *testing.T) {
+	store := newTestStore(t)
+
+	if result := runCmd(store, "add", "cloud-sql",
+		"--transport", "http",
+		"--url", "https://sqladmin.googleapis.com/mcp",
+		"--client", "codex"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "ring", "create", "cloudsql-readonly", "--member", "cloud-sql"); result.code != 0 {
+		t.Fatalf("ring create failed: %s", result.stderr)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	result := runCmd(store, "ring", "attach", "cloudsql-readonly", "codex", "--dry-run", "--config-path", configPath)
+	if result.code != 0 {
+		t.Fatalf("ring attach dry-run failed: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	if !strings.Contains(result.stdout, "added: cloud-sql") {
+		t.Fatalf("expected remote member added, got: %s", result.stdout)
+	}
+	if strings.Contains(result.stdout, "unsupported remote") {
+		t.Fatalf("expected no unsupported remote line for codex attach, got: %s", result.stdout)
 	}
 }
 
@@ -4373,6 +4455,36 @@ env_vars = ["VAULT_ACCOUNT", "VAULT_TOKEN"]
 	}
 	if !strings.Contains(result.stderr, "secret env values omitted (VAULT_TOKEN)") {
 		t.Fatalf("expected secret omission warning, got: %s", result.stderr)
+	}
+}
+
+func TestRunWithStoreRingRenderCodexRemoteHTTP(t *testing.T) {
+	store := newTestStore(t)
+
+	if result := runCmd(store, "add", "cloud-sql",
+		"--transport", "http",
+		"--url", "https://sqladmin.googleapis.com/mcp",
+		"--client", "codex",
+		"--oauth-resource", "https://sqladmin.googleapis.com/"); result.code != 0 {
+		t.Fatalf("setup add cloud-sql failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "ring", "create", "cloudsql-readonly", "--member", "cloud-sql"); result.code != 0 {
+		t.Fatalf("ring create failed: %s", result.stderr)
+	}
+
+	result := runCmd(store, "ring", "render", "cloudsql-readonly", "--client", "codex")
+	if result.code != 0 {
+		t.Fatalf("ring render codex failed: %s", result.stderr)
+	}
+	want := `[mcp_servers.cloud-sql]
+url = "https://sqladmin.googleapis.com/mcp"
+oauth_resource = "https://sqladmin.googleapis.com/"
+`
+	if result.stdout != want {
+		t.Fatalf("render output for codex remote drift:\nwant:\n%s\ngot:\n%s", want, result.stdout)
+	}
+	if result.stderr != "" {
+		t.Fatalf("expected no remote render warnings, got: %s", result.stderr)
 	}
 }
 

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -2711,7 +2711,7 @@ func TestRunWithStoreSyncReportsUnsupportedRemote(t *testing.T) {
 	}
 	if !strings.Contains(result.stderr, "cloud-sql uses http transport") ||
 		!strings.Contains(result.stderr, "stored in registry") ||
-		!strings.Contains(result.stderr, "vibe sync does not materialize remote transports yet") {
+		!strings.Contains(result.stderr, "vibe sync does not materialize http transports yet") {
 		t.Fatalf("expected unsupported remote warning, got: %s", result.stderr)
 	}
 
@@ -3630,7 +3630,7 @@ func TestRunWithStoreRingAttachReportsUnsupportedRemote(t *testing.T) {
 	}
 	if !strings.Contains(result.stderr, "cloud-sql uses http transport") ||
 		!strings.Contains(result.stderr, "stored in registry") ||
-		!strings.Contains(result.stderr, "vibe sync does not materialize remote transports yet") {
+		!strings.Contains(result.stderr, "vibe sync does not materialize http transports yet") {
 		t.Fatalf("expected unsupported remote warning, got: %s", result.stderr)
 	}
 }
@@ -4465,7 +4465,8 @@ func TestRunWithStoreRingRenderCodexRemoteHTTP(t *testing.T) {
 		"--transport", "http",
 		"--url", "https://sqladmin.googleapis.com/mcp",
 		"--client", "codex",
-		"--oauth-resource", "https://sqladmin.googleapis.com/"); result.code != 0 {
+		"--oauth-resource", "https://sqladmin.googleapis.com/",
+		"--header", "x-goog-user-project=example-project"); result.code != 0 {
 		t.Fatalf("setup add cloud-sql failed: %s", result.stderr)
 	}
 	if result := runCmd(store, "ring", "create", "cloudsql-readonly", "--member", "cloud-sql"); result.code != 0 {
@@ -4479,12 +4480,38 @@ func TestRunWithStoreRingRenderCodexRemoteHTTP(t *testing.T) {
 	want := `[mcp_servers.cloud-sql]
 url = "https://sqladmin.googleapis.com/mcp"
 oauth_resource = "https://sqladmin.googleapis.com/"
+
+[mcp_servers.cloud-sql.http_headers]
+x-goog-user-project = "example-project"
 `
 	if result.stdout != want {
 		t.Fatalf("render output for codex remote drift:\nwant:\n%s\ngot:\n%s", want, result.stdout)
 	}
 	if result.stderr != "" {
 		t.Fatalf("expected no remote render warnings, got: %s", result.stderr)
+	}
+}
+
+func TestRunWithStoreSyncCodexKeepsSSEPending(t *testing.T) {
+	store := newTestStore(t)
+
+	if result := runCmd(store, "add", "events",
+		"--transport", "sse",
+		"--url", "https://example.com/sse",
+		"--client", "codex"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	result := runCmd(store, "sync", "codex", "--dry-run", "--config-path", configPath)
+	if result.code != 0 {
+		t.Fatalf("sync dry-run failed: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	if !strings.Contains(result.stdout, "unsupported remote: events") {
+		t.Fatalf("expected sse manifest reported as unsupported, got: %s", result.stdout)
+	}
+	if !strings.Contains(result.stderr, "codex sync does not materialize sse transports yet") {
+		t.Fatalf("expected sse-specific warning, got: %s", result.stderr)
 	}
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -143,9 +143,11 @@ Skills are not run inputs yet.
 - Entries Madari does not manage keep their JSON value, including fields and
   server shapes Madari does not model (e.g. `type`/`url` remote entries);
   only managed or newly added entries are serialized from manifests. Managed
-  remote `http`/`sse` manifests are modeled in the registry but kept
-  ineligible by every sync adapter until per-client remote materialization
-  lands. The enclosing document is reformatted on write. For adapters with raw-match
+  stdio entries are serialized from command manifests; managed Codex remote
+  entries are serialized from `url` manifests. Adapters whose
+  `SupportsRemote()` is false keep remote manifests ineligible until their
+  per-client remote materialization lands. The enclosing document is
+  reformatted on write. For adapters with raw-match
   validation (currently Claude Code and Claude Desktop), if an unmanaged entry
   has the same name as a desired manifest, Madari only treats it as an exact
   match when its canonical raw JSON, after normalizing empty modeled optional

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -16,10 +16,10 @@ madari remove <name>
 `madari add` defaults to `stdio`, where `--command` is required and is resolved
 to an absolute executable path. Remote manifests use `--transport http` or
 `--transport sse` with `--url`; optional remote metadata includes `--header`,
-`--timeout-ms`, and `--oauth-resource`. Remote manifests are stored and
-validated, but sync and render targets skip them until per-client support
+`--timeout-ms`, and `--oauth-resource`. Remote manifests materialize for
+`codex`; the other sync and render targets skip them until per-client support
 lands. `madari list` and `madari doctor` show each server's transport and
-endpoint so remote entries are visible while materialization is pending.
+endpoint so remote entries are visible where materialization is pending.
 
 ## Install Workflow
 
@@ -58,7 +58,10 @@ sync with `--scope user`.
 `~/.codex/config.toml` when `CODEX_HOME` is unset). Static non-secret `[env]`
 values are written under `[mcp_servers.<name>.env]`; `[required_env]` and
 `[secret_env]` keys are forwarded through `env_vars`, and static secret
-values are not written into Codex config.
+values are not written into Codex config. Codex also materializes managed
+remote HTTP/SSE entries as native `url` entries with optional
+`oauth_resource`; manifest `[headers]` and `timeout_ms` are not part of
+Codex's config surface and are not emitted.
 
 `vibe` sync targets Vibe's user config (`$VIBE_HOME/config.toml`, or
 `~/.vibe/config.toml` when `VIBE_HOME` is unset). Static `[env]` values are
@@ -141,8 +144,9 @@ Render targets are independent from sync adapters. `claude-code`,
 `[[mcp_servers]]` entries with `transport = "stdio"`.
 Codex render output also emits `env_vars = [...]` for `[required_env]` and
 `[secret_env]` keys so runtime-provided environment values can be forwarded.
-Remote `http`/`sse` ring members are omitted with warnings; no render target
-materializes remote transports yet.
+Codex render also emits remote HTTP/SSE members as `url` entries with optional
+`oauth_resource`. For the other render targets, remote `http`/`sse` ring
+members are omitted with warnings until per-client support lands.
 Ring skill members are not embedded in MCP render output; use `ring attach`
 for native skill materialization.
 Ephemeral-session recipe:

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -16,10 +16,11 @@ madari remove <name>
 `madari add` defaults to `stdio`, where `--command` is required and is resolved
 to an absolute executable path. Remote manifests use `--transport http` or
 `--transport sse` with `--url`; optional remote metadata includes `--header`,
-`--timeout-ms`, and `--oauth-resource`. Remote manifests materialize for
-`codex`; the other sync and render targets skip them until per-client support
-lands. `madari list` and `madari doctor` show each server's transport and
-endpoint so remote entries are visible where materialization is pending.
+`--timeout-ms`, and `--oauth-resource`. Remote `http` manifests materialize
+for `codex`; `sse` manifests and the other sync and render targets skip them
+until per-client support lands. `madari list` and `madari doctor` show each
+server's transport and endpoint so remote entries are visible where
+materialization is pending.
 
 ## Install Workflow
 
@@ -59,9 +60,10 @@ sync with `--scope user`.
 values are written under `[mcp_servers.<name>.env]`; `[required_env]` and
 `[secret_env]` keys are forwarded through `env_vars`, and static secret
 values are not written into Codex config. Codex also materializes managed
-remote HTTP/SSE entries as native `url` entries with optional
-`oauth_resource`; manifest `[headers]` and `timeout_ms` are not part of
-Codex's config surface and are not emitted.
+remote Streamable HTTP entries as native `url` entries with optional
+`oauth_resource`, and manifest `[headers]` as Codex `http_headers`. `sse`
+manifests stay pending (Codex's documented remote support is Streamable
+HTTP), and `timeout_ms` has no Codex equivalent and is not emitted.
 
 `vibe` sync targets Vibe's user config (`$VIBE_HOME/config.toml`, or
 `~/.vibe/config.toml` when `VIBE_HOME` is unset). Static `[env]` values are
@@ -144,9 +146,10 @@ Render targets are independent from sync adapters. `claude-code`,
 `[[mcp_servers]]` entries with `transport = "stdio"`.
 Codex render output also emits `env_vars = [...]` for `[required_env]` and
 `[secret_env]` keys so runtime-provided environment values can be forwarded.
-Codex render also emits remote HTTP/SSE members as `url` entries with optional
-`oauth_resource`. For the other render targets, remote `http`/`sse` ring
-members are omitted with warnings until per-client support lands.
+Codex render also emits remote Streamable HTTP members as `url` entries with
+optional `oauth_resource` and `[headers]` as `http_headers`. SSE members and
+the other render targets omit remote ring members with warnings until
+per-client support lands.
 Ring skill members are not embedded in MCP render output; use `ring attach`
 for native skill materialization.
 Ephemeral-session recipe:

--- a/docs/manifest-spec.md
+++ b/docs/manifest-spec.md
@@ -33,16 +33,18 @@ Known client IDs:
 
 `claude-desktop`, `claude-code`, `gemini`, `codex`, and `vibe` are
 sync-capable today. All are also render targets for `madari ring render`.
-Remote `http`/`sse` manifests are materialized for `codex` (native `url`
-entries plus optional OAuth metadata); the other targets keep remote entries
-ineligible until their auth and config behavior is validated per client.
+Remote `http` manifests are materialized for `codex` (native `url` entries
+plus optional OAuth metadata and `[headers]` as `http_headers`). `sse`
+manifests and the other targets keep remote entries ineligible until their
+auth and config behavior is validated per client.
 
 ### `[headers]`
 
 Key/value static HTTP headers for remote transports. Header names are limited
 to letters, digits, `-`, and `_` so they round-trip through the manifest
-format. Headers are stored in the manifest but emitted only for clients that
-support header configuration.
+format. Headers are emitted only for clients that support header
+configuration (Codex writes them as `http_headers`); other targets store
+them without emitting.
 
 ### `[env]`
 

--- a/docs/manifest-spec.md
+++ b/docs/manifest-spec.md
@@ -33,9 +33,9 @@ Known client IDs:
 
 `claude-desktop`, `claude-code`, `gemini`, `codex`, and `vibe` are
 sync-capable today. All are also render targets for `madari ring render`.
-Remote `http`/`sse` manifests are stored and validated, but no sync or render
-target materializes them yet; adapters keep remote entries ineligible until
-their auth and config behavior is validated per client.
+Remote `http`/`sse` manifests are materialized for `codex` (native `url`
+entries plus optional OAuth metadata); the other targets keep remote entries
+ineligible until their auth and config behavior is validated per client.
 
 ### `[headers]`
 

--- a/internal/clients/adapter.go
+++ b/internal/clients/adapter.go
@@ -43,6 +43,11 @@ type ClientAdapter interface {
 	Target() string
 	// DefaultConfigPath resolves the adapter's default config path.
 	DefaultConfigPath() (string, error)
+	// SupportsRemote reports whether this adapter materializes remote
+	// (http/sse) manifests into the client config. Adapters that return
+	// false keep remote manifests ineligible: stored in the registry,
+	// surfaced as pending, never written to the client.
+	SupportsRemote() bool
 	// Sync computes/applies config changes for the target client.
 	//
 	// On dry-run, return the plan only. On apply, persist config and managed

--- a/internal/clients/adapter.go
+++ b/internal/clients/adapter.go
@@ -44,10 +44,11 @@ type ClientAdapter interface {
 	// DefaultConfigPath resolves the adapter's default config path.
 	DefaultConfigPath() (string, error)
 	// SupportsRemote reports whether this adapter materializes remote
-	// (http/sse) manifests into the client config. Adapters that return
-	// false keep remote manifests ineligible: stored in the registry,
-	// surfaced as pending, never written to the client.
-	SupportsRemote() bool
+	// manifests of the given transport (registry.TransportHTTP or
+	// registry.TransportSSE) into the client config. Unsupported transports
+	// keep the manifest ineligible: stored in the registry, surfaced as
+	// pending, never written to the client.
+	SupportsRemote(transport string) bool
 	// Sync computes/applies config changes for the target client.
 	//
 	// On dry-run, return the plan only. On apply, persist config and managed

--- a/internal/clients/claude-desktop/adapter.go
+++ b/internal/clients/claude-desktop/adapter.go
@@ -18,6 +18,12 @@ func (Adapter) DefaultConfigPath() (string, error) {
 	return DefaultDesktopConfigPath()
 }
 
+// SupportsRemote is false: remote manifests stay ineligible until this
+// adapter materializes remote transports.
+func (Adapter) SupportsRemote() bool {
+	return false
+}
+
 func (Adapter) Sync(manifests []registry.Manifest, opts clients.SyncOptions) (clients.SyncResult, error) {
 	return Sync(manifests, opts)
 }

--- a/internal/clients/claude-desktop/adapter.go
+++ b/internal/clients/claude-desktop/adapter.go
@@ -20,7 +20,7 @@ func (Adapter) DefaultConfigPath() (string, error) {
 
 // SupportsRemote is false: remote manifests stay ineligible until this
 // adapter materializes remote transports.
-func (Adapter) SupportsRemote() bool {
+func (Adapter) SupportsRemote(string) bool {
 	return false
 }
 

--- a/internal/clients/claudecode/adapter.go
+++ b/internal/clients/claudecode/adapter.go
@@ -18,6 +18,12 @@ func (Adapter) DefaultConfigPath() (string, error) {
 	return DefaultProjectConfigPath()
 }
 
+// SupportsRemote is false: remote manifests stay ineligible until this
+// adapter materializes remote transports.
+func (Adapter) SupportsRemote() bool {
+	return false
+}
+
 func (Adapter) Sync(manifests []registry.Manifest, opts clients.SyncOptions) (clients.SyncResult, error) {
 	return Sync(manifests, opts)
 }

--- a/internal/clients/claudecode/adapter.go
+++ b/internal/clients/claudecode/adapter.go
@@ -20,7 +20,7 @@ func (Adapter) DefaultConfigPath() (string, error) {
 
 // SupportsRemote is false: remote manifests stay ineligible until this
 // adapter materializes remote transports.
-func (Adapter) SupportsRemote() bool {
+func (Adapter) SupportsRemote(string) bool {
 	return false
 }
 

--- a/internal/clients/codex/adapter.go
+++ b/internal/clients/codex/adapter.go
@@ -18,6 +18,12 @@ func (Adapter) DefaultConfigPath() (string, error) {
 	return DefaultConfigPath()
 }
 
+// SupportsRemote is true: Codex materializes remote manifests as native
+// url entries in config.toml.
+func (Adapter) SupportsRemote() bool {
+	return true
+}
+
 func (Adapter) Sync(manifests []registry.Manifest, opts clients.SyncOptions) (clients.SyncResult, error) {
 	return Sync(manifests, opts)
 }

--- a/internal/clients/codex/adapter.go
+++ b/internal/clients/codex/adapter.go
@@ -18,10 +18,11 @@ func (Adapter) DefaultConfigPath() (string, error) {
 	return DefaultConfigPath()
 }
 
-// SupportsRemote is true: Codex materializes remote manifests as native
-// url entries in config.toml.
-func (Adapter) SupportsRemote() bool {
-	return true
+// SupportsRemote is true for Streamable HTTP only: Codex materializes http
+// manifests as native url entries in config.toml. SSE endpoints are not part
+// of Codex's documented remote support and stay pending.
+func (Adapter) SupportsRemote(transport string) bool {
+	return supportsRemoteTransport(transport)
 }
 
 func (Adapter) Sync(manifests []registry.Manifest, opts clients.SyncOptions) (clients.SyncResult, error) {

--- a/internal/clients/codex/sync.go
+++ b/internal/clients/codex/sync.go
@@ -241,7 +241,7 @@ func entriesForTarget(manifests []registry.Manifest) map[string]syncshared.Entry
 			continue
 		}
 		entry := syncshared.Entry[serverConfig]{}
-		if manifest.Enabled && !manifest.IsRemote() {
+		if manifest.Enabled {
 			entry.Eligible = true
 			entry.Value = materializeServer(manifest)
 		}
@@ -251,6 +251,16 @@ func entriesForTarget(manifests []registry.Manifest) map[string]syncshared.Entry
 }
 
 func materializeServer(manifest registry.Manifest) serverConfig {
+	if manifest.IsRemote() {
+		// Codex remote entries carry url plus optional OAuth metadata.
+		// headers and timeout_ms are not part of Codex's config surface and
+		// are deliberately not emitted (documented in the manifest spec).
+		return serverConfig{
+			URL:           manifest.URL,
+			OAuthResource: manifest.OAuthResource,
+		}
+	}
+
 	entry := serverConfig{
 		Command: manifest.Command,
 		EnvVars: runtimeEnvKeys(
@@ -299,6 +309,12 @@ func runtimeEnvKeys(keyGroups ...[]string) []string {
 
 func equalServer(a, b serverConfig) bool {
 	if a.Command != b.Command {
+		return false
+	}
+	if a.URL != b.URL {
+		return false
+	}
+	if a.OAuthResource != b.OAuthResource {
 		return false
 	}
 	if effectiveEnabled(a) != effectiveEnabled(b) {
@@ -397,6 +413,20 @@ func parseServer(name string, raw any) (serverConfig, error) {
 		}
 		entry.Command = command
 	}
+	if rawURL, exists := table["url"]; exists {
+		url, ok := rawURL.(string)
+		if !ok {
+			return serverConfig{}, fmt.Errorf("parse mcp_servers.%s.url: expected string", name)
+		}
+		entry.URL = url
+	}
+	if rawOAuthResource, exists := table["oauth_resource"]; exists {
+		oauthResource, ok := rawOAuthResource.(string)
+		if !ok {
+			return serverConfig{}, fmt.Errorf("parse mcp_servers.%s.oauth_resource: expected string", name)
+		}
+		entry.OAuthResource = oauthResource
+	}
 	if enabled, ok, err := optionalBool(table, "enabled"); err != nil {
 		return serverConfig{}, fmt.Errorf("parse mcp_servers.%s.enabled: %w", name, err)
 	} else if ok {
@@ -483,9 +513,11 @@ func optionalStringMap(table map[string]any, key string) (map[string]string, boo
 }
 
 type serverConfig struct {
-	Command string            `toml:"command"`
-	Enabled *bool             `toml:"enabled,omitempty"`
-	Args    []string          `toml:"args,omitempty"`
-	EnvVars []string          `toml:"env_vars,omitempty"`
-	Env     map[string]string `toml:"env,omitempty"`
+	Command       string            `toml:"command,omitempty"`
+	URL           string            `toml:"url,omitempty"`
+	OAuthResource string            `toml:"oauth_resource,omitempty"`
+	Enabled       *bool             `toml:"enabled,omitempty"`
+	Args          []string          `toml:"args,omitempty"`
+	EnvVars       []string          `toml:"env_vars,omitempty"`
+	Env           map[string]string `toml:"env,omitempty"`
 }

--- a/internal/clients/codex/sync.go
+++ b/internal/clients/codex/sync.go
@@ -241,7 +241,7 @@ func entriesForTarget(manifests []registry.Manifest) map[string]syncshared.Entry
 			continue
 		}
 		entry := syncshared.Entry[serverConfig]{}
-		if manifest.Enabled {
+		if manifest.Enabled && (!manifest.IsRemote() || supportsRemoteTransport(manifest.TransportType())) {
 			entry.Eligible = true
 			entry.Value = materializeServer(manifest)
 		}
@@ -250,15 +250,30 @@ func entriesForTarget(manifests []registry.Manifest) map[string]syncshared.Entry
 	return entries
 }
 
+// supportsRemoteTransport gates which remote transports Codex materializes:
+// Streamable HTTP is Codex's documented remote config support; SSE stays
+// pending.
+func supportsRemoteTransport(transport string) bool {
+	return transport == registry.TransportHTTP
+}
+
 func materializeServer(manifest registry.Manifest) serverConfig {
 	if manifest.IsRemote() {
-		// Codex remote entries carry url plus optional OAuth metadata.
-		// headers and timeout_ms are not part of Codex's config surface and
-		// are deliberately not emitted (documented in the manifest spec).
-		return serverConfig{
+		// Codex remote entries carry url, optional OAuth metadata, and
+		// static headers as http_headers. timeout_ms has no Codex
+		// equivalent and is deliberately not emitted (documented in the
+		// manifest spec).
+		entry := serverConfig{
 			URL:           manifest.URL,
 			OAuthResource: manifest.OAuthResource,
 		}
+		if len(manifest.Headers) > 0 {
+			entry.HTTPHeaders = make(map[string]string, len(manifest.Headers))
+			for key, value := range manifest.Headers {
+				entry.HTTPHeaders[key] = value
+			}
+		}
+		return entry
 	}
 
 	entry := serverConfig{
@@ -316,6 +331,14 @@ func equalServer(a, b serverConfig) bool {
 	}
 	if a.OAuthResource != b.OAuthResource {
 		return false
+	}
+	if len(a.HTTPHeaders) != len(b.HTTPHeaders) {
+		return false
+	}
+	for key, value := range a.HTTPHeaders {
+		if b.HTTPHeaders[key] != value {
+			return false
+		}
 	}
 	if effectiveEnabled(a) != effectiveEnabled(b) {
 		return false
@@ -427,6 +450,11 @@ func parseServer(name string, raw any) (serverConfig, error) {
 		}
 		entry.OAuthResource = oauthResource
 	}
+	if headers, ok, err := optionalStringMap(table, "http_headers"); err != nil {
+		return serverConfig{}, fmt.Errorf("parse mcp_servers.%s.http_headers: %w", name, err)
+	} else if ok {
+		entry.HTTPHeaders = headers
+	}
 	if enabled, ok, err := optionalBool(table, "enabled"); err != nil {
 		return serverConfig{}, fmt.Errorf("parse mcp_servers.%s.enabled: %w", name, err)
 	} else if ok {
@@ -520,4 +548,5 @@ type serverConfig struct {
 	Args          []string          `toml:"args,omitempty"`
 	EnvVars       []string          `toml:"env_vars,omitempty"`
 	Env           map[string]string `toml:"env,omitempty"`
+	HTTPHeaders   map[string]string `toml:"http_headers,omitempty"`
 }

--- a/internal/clients/codex/sync_test.go
+++ b/internal/clients/codex/sync_test.go
@@ -580,7 +580,7 @@ STEWREADS_CONFIG_PATH = "~/.config/stewreads/config.toml"
 	}
 }
 
-func TestSyncSkipsManagedRemoteManifest(t *testing.T) {
+func TestSyncApplyRemoteHTTP(t *testing.T) {
 	tmp := t.TempDir()
 	configPath := filepath.Join(tmp, "config.toml")
 	statePath := filepath.Join(tmp, "state", "codex-managed.json")
@@ -594,60 +594,89 @@ args = ["run", "weather.py"]
 		t.Fatalf("write config fixture: %v", err)
 	}
 
-	remote := registry.Manifest{
-		Name:      "cloud-sql",
-		Transport: registry.TransportHTTP,
-		URL:       "https://example.com/mcp",
-		Enabled:   true,
-		Clients:   []string{Target},
-	}
-	result, err := Sync([]registry.Manifest{remote}, SyncOptions{
+	manifest := newCloudSQLManifest()
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{
 		ConfigPath: configPath,
 		StatePath:  statePath,
 	})
 	if err != nil {
-		t.Fatalf("sync failed: %v", err)
+		t.Fatalf("sync remote failed: %v", err)
 	}
-	if len(result.Added) != 0 || len(result.Updated) != 0 || len(result.Removed) != 0 {
-		t.Fatalf("expected remote manifest to be ineligible until the adapter supports it, got: %+v", result)
+	if !reflect.DeepEqual(result.Added, []string{"cloud-sql"}) {
+		t.Fatalf("expected remote add result, got: %+v", result)
 	}
 
 	servers := readServers(t, configPath)
-	if _, exists := servers["cloud-sql"]; exists {
-		t.Fatalf("expected remote manifest not to be materialized, got: %#v", servers)
+	got := servers["cloud-sql"]
+	if got.Command != "" {
+		t.Fatalf("expected remote Codex entry to omit command, got: %q", got.Command)
+	}
+	if got.URL != "https://sqladmin.googleapis.com/mcp" {
+		t.Fatalf("expected remote URL, got: %q", got.URL)
+	}
+	if got.OAuthResource != "https://sqladmin.googleapis.com/" {
+		t.Fatalf("expected OAuth resource, got: %q", got.OAuthResource)
 	}
 	if _, ok := servers["weather"]; !ok {
 		t.Fatalf("expected unmanaged weather entry to be preserved")
 	}
-}
 
-func TestSyncRemoteOnlyDoesNotCreateFiles(t *testing.T) {
-	tmp := t.TempDir()
-	configPath := filepath.Join(tmp, "config.toml")
-	statePath := filepath.Join(tmp, "state", "codex-managed.json")
-
-	remote := registry.Manifest{
-		Name:      "cloud-sql",
-		Transport: registry.TransportHTTP,
-		URL:       "https://example.com/mcp",
-		Enabled:   true,
-		Clients:   []string{Target},
-	}
-	result, err := Sync([]registry.Manifest{remote}, SyncOptions{
+	manifest.URL = "https://sqladmin.googleapis.com/mcp/v2"
+	result, err = Sync([]registry.Manifest{manifest}, SyncOptions{
 		ConfigPath: configPath,
 		StatePath:  statePath,
 	})
 	if err != nil {
-		t.Fatalf("sync failed: %v", err)
+		t.Fatalf("sync remote url change failed: %v", err)
 	}
-	if len(result.Added)+len(result.Updated)+len(result.Removed) != 0 {
-		t.Fatalf("expected no-op sync result, got: %+v", result)
+	if !reflect.DeepEqual(result.Updated, []string{"cloud-sql"}) {
+		t.Fatalf("expected url change to be an update, got: %+v", result)
 	}
-	if _, err := os.Stat(configPath); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("expected no config file for remote-only no-op sync, got err=%v", err)
+	if readServers(t, configPath)["cloud-sql"].URL != manifest.URL {
+		t.Fatalf("expected updated url to be written")
 	}
-	if _, err := os.Stat(statePath); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("expected no state file for remote-only no-op sync, got err=%v", err)
+}
+
+func TestAttachRingRemoteHTTPLifecycle(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "codex-managed.json")
+	manifest := newCloudSQLManifest()
+	opts := SyncOptions{ConfigPath: configPath, StatePath: statePath}
+
+	result, err := AttachRing(registry.Ring{Name: "cloudsql-readonly", Members: []string{"cloud-sql"}}, []registry.Manifest{manifest}, opts)
+	if err != nil {
+		t.Fatalf("attach remote ring: %v", err)
+	}
+	if !reflect.DeepEqual(result.Added, []string{"cloud-sql"}) {
+		t.Fatalf("expected remote ring add, got: %+v", result)
+	}
+	servers := readServers(t, configPath)
+	if servers["cloud-sql"].URL != manifest.URL {
+		t.Fatalf("expected remote entry to be materialized, got: %#v", servers["cloud-sql"])
+	}
+
+	result, err = DetachRing("cloudsql-readonly", opts)
+	if err != nil {
+		t.Fatalf("detach remote ring: %v", err)
+	}
+	if !reflect.DeepEqual(result.Removed, []string{"cloud-sql"}) {
+		t.Fatalf("expected remote ring removal, got: %+v", result)
+	}
+	servers = readServers(t, configPath)
+	if _, exists := servers["cloud-sql"]; exists {
+		t.Fatalf("expected remote entry to be removed after detach, got: %#v", servers)
+	}
+}
+
+func newCloudSQLManifest() registry.Manifest {
+	return registry.Manifest{
+		Name:          "cloud-sql",
+		Transport:     registry.TransportHTTP,
+		URL:           "https://sqladmin.googleapis.com/mcp",
+		OAuthResource: "https://sqladmin.googleapis.com/",
+		Enabled:       true,
+		Clients:       []string{Target},
 	}
 }
 

--- a/internal/clients/codex/sync_test.go
+++ b/internal/clients/codex/sync_test.go
@@ -595,6 +595,7 @@ args = ["run", "weather.py"]
 	}
 
 	manifest := newCloudSQLManifest()
+	manifest.Headers = map[string]string{"x-goog-user-project": "example-project"}
 	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{
 		ConfigPath: configPath,
 		StatePath:  statePath,
@@ -617,8 +618,23 @@ args = ["run", "weather.py"]
 	if got.OAuthResource != "https://sqladmin.googleapis.com/" {
 		t.Fatalf("expected OAuth resource, got: %q", got.OAuthResource)
 	}
+	if got.HTTPHeaders["x-goog-user-project"] != "example-project" {
+		t.Fatalf("expected manifest headers as http_headers, got: %#v", got.HTTPHeaders)
+	}
 	if _, ok := servers["weather"]; !ok {
 		t.Fatalf("expected unmanaged weather entry to be preserved")
+	}
+
+	manifest.Headers["x-goog-user-project"] = "other-project"
+	result, err = Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync header change failed: %v", err)
+	}
+	if !reflect.DeepEqual(result.Updated, []string{"cloud-sql"}) {
+		t.Fatalf("expected header change to be an update, got: %+v", result)
 	}
 
 	manifest.URL = "https://sqladmin.googleapis.com/mcp/v2"
@@ -666,6 +682,28 @@ func TestAttachRingRemoteHTTPLifecycle(t *testing.T) {
 	servers = readServers(t, configPath)
 	if _, exists := servers["cloud-sql"]; exists {
 		t.Fatalf("expected remote entry to be removed after detach, got: %#v", servers)
+	}
+}
+
+func TestSyncKeepsSSEPending(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "codex-managed.json")
+
+	manifest := newCloudSQLManifest()
+	manifest.Transport = registry.TransportSSE
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	if len(result.Added)+len(result.Updated)+len(result.Removed) != 0 {
+		t.Fatalf("expected sse manifest to stay ineligible, got: %+v", result)
+	}
+	if _, err := os.Stat(configPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected no config file for sse-only sync, got err=%v", err)
 	}
 }
 

--- a/internal/clients/gemini/adapter.go
+++ b/internal/clients/gemini/adapter.go
@@ -18,6 +18,12 @@ func (Adapter) DefaultConfigPath() (string, error) {
 	return DefaultProjectConfigPath()
 }
 
+// SupportsRemote is false: remote manifests stay ineligible until this
+// adapter materializes remote transports.
+func (Adapter) SupportsRemote() bool {
+	return false
+}
+
 func (Adapter) Sync(manifests []registry.Manifest, opts clients.SyncOptions) (clients.SyncResult, error) {
 	return Sync(manifests, opts)
 }

--- a/internal/clients/gemini/adapter.go
+++ b/internal/clients/gemini/adapter.go
@@ -20,7 +20,7 @@ func (Adapter) DefaultConfigPath() (string, error) {
 
 // SupportsRemote is false: remote manifests stay ineligible until this
 // adapter materializes remote transports.
-func (Adapter) SupportsRemote() bool {
+func (Adapter) SupportsRemote(string) bool {
 	return false
 }
 

--- a/internal/clients/vibe/adapter.go
+++ b/internal/clients/vibe/adapter.go
@@ -18,6 +18,12 @@ func (Adapter) DefaultConfigPath() (string, error) {
 	return DefaultConfigPath()
 }
 
+// SupportsRemote is false: remote manifests stay ineligible until this
+// adapter materializes remote transports.
+func (Adapter) SupportsRemote() bool {
+	return false
+}
+
 func (Adapter) Sync(manifests []registry.Manifest, opts clients.SyncOptions) (clients.SyncResult, error) {
 	return Sync(manifests, opts)
 }

--- a/internal/clients/vibe/adapter.go
+++ b/internal/clients/vibe/adapter.go
@@ -20,7 +20,7 @@ func (Adapter) DefaultConfigPath() (string, error) {
 
 // SupportsRemote is false: remote manifests stay ineligible until this
 // adapter materializes remote transports.
-func (Adapter) SupportsRemote() bool {
+func (Adapter) SupportsRemote(string) bool {
 	return false
 }
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -170,7 +170,7 @@ func Run(store *registry.Store, opts Options) (Report, error) {
 
 	report.ClientConfigs = make([]ClientConfigReport, 0, len(opts.Adapters))
 	for _, adapter := range opts.Adapters {
-		if !hasTargetInManifests(manifests, adapter.Target()) {
+		if !hasTargetInManifests(manifests, adapter.Target(), adapter.SupportsRemote()) {
 			report.ClientConfigs = append(report.ClientConfigs, ClientConfigReport{
 				Target: adapter.Target(),
 				Status: StatusSkipped,
@@ -650,11 +650,11 @@ func hasTarget(manifest registry.Manifest, targets []string) bool {
 	return false
 }
 
-func hasTargetInManifests(manifests []registry.Manifest, target string) bool {
+func hasTargetInManifests(manifests []registry.Manifest, target string, remoteSupported bool) bool {
 	for _, manifest := range manifests {
-		// No adapter materializes remote transports yet, so remote manifests
-		// alone don't warrant a client config on disk.
-		if manifest.IsRemote() {
+		// Remote manifests only warrant a client config on disk when the
+		// target's adapter materializes remote transports.
+		if manifest.IsRemote() && !remoteSupported {
 			continue
 		}
 		if manifest.HasClient(target) {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -170,7 +170,7 @@ func Run(store *registry.Store, opts Options) (Report, error) {
 
 	report.ClientConfigs = make([]ClientConfigReport, 0, len(opts.Adapters))
 	for _, adapter := range opts.Adapters {
-		if !hasTargetInManifests(manifests, adapter.Target(), adapter.SupportsRemote()) {
+		if !hasTargetInManifests(manifests, adapter.Target(), adapter.SupportsRemote) {
 			report.ClientConfigs = append(report.ClientConfigs, ClientConfigReport{
 				Target: adapter.Target(),
 				Status: StatusSkipped,
@@ -650,11 +650,11 @@ func hasTarget(manifest registry.Manifest, targets []string) bool {
 	return false
 }
 
-func hasTargetInManifests(manifests []registry.Manifest, target string, remoteSupported bool) bool {
+func hasTargetInManifests(manifests []registry.Manifest, target string, supportsRemote func(transport string) bool) bool {
 	for _, manifest := range manifests {
 		// Remote manifests only warrant a client config on disk when the
-		// target's adapter materializes remote transports.
-		if manifest.IsRemote() && !remoteSupported {
+		// target's adapter materializes their transport.
+		if manifest.IsRemote() && !supportsRemote(manifest.TransportType()) {
 			continue
 		}
 		if manifest.HasClient(target) {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -21,7 +21,7 @@ type testAdapter struct {
 
 func (a testAdapter) Target() string                     { return a.target }
 func (a testAdapter) DefaultConfigPath() (string, error) { return a.configPath, nil }
-func (a testAdapter) SupportsRemote() bool               { return a.supportsRemote }
+func (a testAdapter) SupportsRemote(string) bool         { return a.supportsRemote }
 func (a testAdapter) Sync(_ []registry.Manifest, _ clients.SyncOptions) (clients.SyncResult, error) {
 	return clients.SyncResult{}, nil
 }

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -14,12 +14,14 @@ import (
 
 // testAdapter is a minimal ClientAdapter for use in doctor tests.
 type testAdapter struct {
-	target     string
-	configPath string
+	target         string
+	configPath     string
+	supportsRemote bool
 }
 
 func (a testAdapter) Target() string                     { return a.target }
 func (a testAdapter) DefaultConfigPath() (string, error) { return a.configPath, nil }
+func (a testAdapter) SupportsRemote() bool               { return a.supportsRemote }
 func (a testAdapter) Sync(_ []registry.Manifest, _ clients.SyncOptions) (clients.SyncResult, error) {
 	return clients.SyncResult{}, nil
 }
@@ -279,6 +281,39 @@ func TestRunSkipsClientConfigForRemoteOnlyTarget(t *testing.T) {
 	}
 	if report.Servers[0].Transport != registry.TransportHTTP || report.Servers[0].URL != "https://example.com/mcp" {
 		t.Fatalf("expected remote transport details in report, got: %+v", report.Servers[0])
+	}
+}
+
+func TestRunChecksClientConfigForRemoteCapableTarget(t *testing.T) {
+	tmp := t.TempDir()
+	store := registry.NewStore(filepath.Join(tmp, "servers"))
+
+	if err := store.Save(registry.Manifest{
+		Name:      "cloud-sql",
+		Transport: registry.TransportHTTP,
+		URL:       "https://example.com/mcp",
+		Enabled:   true,
+		Clients:   []string{"codex"},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+
+	adapter := testAdapter{
+		target:         "codex",
+		configPath:     filepath.Join(tmp, "config.toml"),
+		supportsRemote: true,
+	}
+	report, err := Run(store, Options{Adapters: []clients.ClientAdapter{adapter}})
+	if err != nil {
+		t.Fatalf("doctor run failed: %v", err)
+	}
+
+	cc, ok := findClientConfig(report, "codex")
+	if !ok {
+		t.Fatalf("expected codex client config report, got: %+v", report.ClientConfigs)
+	}
+	if cc.Status == StatusSkipped {
+		t.Fatalf("expected remote-capable target to run the config check, got: %+v", cc)
 	}
 }
 


### PR DESCRIPTION
## Summary

Second PR of the remote MCP sequence (follows #63). Codex becomes the first adapter to materialize `http`/`sse` manifests; every "remote is unsupported" assumption from #63 becomes per-adapter.

**Adapter capability**
- `SupportsRemote()` added to the `ClientAdapter` interface (ADR-001 extension model); codex returns true, the other four adapters keep remote manifests ineligible

**Codex materialization**
- sync / ring attach / ring render emit remote manifests as native `url` entries with optional `oauth_resource` — the exact shape from the tested Cloud SQL setup (`docs/cloudsql-readonly.md` on the example branch)
- `[headers]` and `timeout_ms` are not part of Codex's config surface and are deliberately not emitted (documented in cli-reference and the manifest spec)
- codex config parsing models `url`/`oauth_resource`, so url changes surface as updates and unmanaged remote collisions compare correctly

**Per-adapter reporting (was blanket in #63)**
- sync/attach `unsupported remote` summary + warning no longer fire for codex; still fire for the other targets
- doctor's missing-config gate counts remote manifests for remote-capable targets
- doctor server detail lists pending targets by name: a manifest targeting codex+gemini shows `url=… sync=pending(gemini)`; codex-only remote manifests show no pending suffix

**Drift needs no special casing**: doctor drift plans run through `adapter.Sync(DryRun)`, so codex remote entries drift-check exactly as sync writes them (`codex drift: [ready] in sync` immediately after a remote sync).

## Test plan

- codex adapter: remote add + url-change update lifecycle, ring attach/detach lifecycle, remote entries omit `command`
- cmd: codex remote sync materializes (text + JSON, `unsupported_remote` empty), codex ring attach adds remote member, codex ring render emits `url`/`oauth_resource` with no warnings
- unsupported targets keep #63 behavior (tests moved to `vibe` as the representative)
- doctor: remote-capable mock adapter runs the config check; remote-only unsupported target still skips it
- manual sandbox: mixed codex+gemini remote manifest → codex config written with url entry, doctor ready with `sync=pending(gemini)`, gemini render warns and omits

## Follow-ups (out of scope)

- PR 3: claude-code + gemini remote materialization (JSON `type: "http"`); requires the header-secrecy placement decision first (headers carry bearer tokens; claude-code writes repo-scoped configs)
- cloudsql-readonly example ring + skill package from the original branch, once export/import work starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)