### PR TITLE
claude-code, gemini: materialize remote MCP manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ madari sync codex --dry-run
 madari sync codex
 ```
 
+Remote MCP servers are added with a transport and URL instead of a command.
+Credential headers (like `Authorization`) and names marked `--secret-header`
+never land in repo-scoped configs — they refuse at project scope and sync
+with `--scope user`:
+
+```bash
+madari add linear \
+  --transport http \
+  --url https://mcp.linear.app/mcp \
+  --header "Authorization=Bearer $LINEAR_TOKEN" \
+  --client claude-code
+
+madari sync claude-code --scope user
+```
+
 Create a ring when a few capabilities belong together:
 
 ```bash
@@ -103,7 +118,10 @@ is useful for temporary sessions and experiments.
 - Backup plus atomic write on sync
 - Explicit ownership of every managed entry
 - No hidden mutation of unmanaged client config
-- Secret env keys are not written into repo-scoped configs
+- Secret env values are not written into repo-scoped configs
+- Remote header values for credential headers (`Authorization`, api-key and
+  token variants) and `--secret-header` names follow the same policy, and
+  `ring render` never emits them
 - Diagnostics through `madari doctor`, `madari status`, and `madari ring status`
 
 ## Supported Clients
@@ -115,6 +133,10 @@ Madari can sync MCP servers for:
 - `gemini`
 - `codex`
 - `vibe`
+
+Remote (`http`/`sse`) servers currently materialize for `claude-code` and
+`gemini` (both transports) and `codex` (`http` only); other targets store
+remote manifests and report them as pending.
 
 Madari can materialize skills for:
 

--- a/cmd/madari/client_targets.go
+++ b/cmd/madari/client_targets.go
@@ -51,7 +51,7 @@ var clientTargets = []clientTarget{
 	{
 		target:             gemini.Target,
 		syncAdapter:        gemini.Adapter{},
-		ringConfigRenderer: renderMCPServersJSON,
+		ringConfigRenderer: renderGeminiJSON,
 		userScope:          true,
 		skillRoots: skillTargetRoots{
 			project: defaultProjectSkillRoot(".gemini", "skills"),

--- a/cmd/madari/client_targets.go
+++ b/cmd/madari/client_targets.go
@@ -19,8 +19,11 @@ type clientTarget struct {
 	target             string
 	syncAdapter        clients.ClientAdapter
 	ringConfigRenderer func(io.Writer, map[string]renderedServer) error
-	userScope          bool
-	skillRoots         skillTargetRoots
+	// ringRenderTimeout marks renderers that emit timeout_ms as the
+	// client's per-server timeout field for remote entries.
+	ringRenderTimeout bool
+	userScope         bool
+	skillRoots        skillTargetRoots
 }
 
 var clientTargets = []clientTarget{
@@ -33,6 +36,7 @@ var clientTargets = []clientTarget{
 		target:             claudecode.Target,
 		syncAdapter:        claudecode.Adapter{},
 		ringConfigRenderer: renderMCPServersJSON,
+		ringRenderTimeout:  true,
 		userScope:          true,
 		skillRoots: skillTargetRoots{
 			project: defaultProjectSkillRoot(".claude", "skills"),
@@ -52,6 +56,7 @@ var clientTargets = []clientTarget{
 		target:             gemini.Target,
 		syncAdapter:        gemini.Adapter{},
 		ringConfigRenderer: renderGeminiJSON,
+		ringRenderTimeout:  true,
 		userScope:          true,
 		skillRoots: skillTargetRoots{
 			project: defaultProjectSkillRoot(".gemini", "skills"),
@@ -101,9 +106,10 @@ func ringRenderTargetsFromClientTargets() map[string]ringRenderTarget {
 				supportsRemote = ct.syncAdapter.SupportsRemote
 			}
 			targets[ct.target] = ringRenderTarget{
-				target:         ct.target,
-				supportsRemote: supportsRemote,
-				render:         ct.ringConfigRenderer,
+				target:             ct.target,
+				supportsRemote:     supportsRemote,
+				emitsRemoteTimeout: ct.ringRenderTimeout,
+				render:             ct.ringConfigRenderer,
 			}
 		}
 	}

--- a/cmd/madari/render_targets.go
+++ b/cmd/madari/render_targets.go
@@ -16,6 +16,7 @@ type renderedServer struct {
 	Args           []string          `json:"args,omitempty"`
 	URL            string            `json:"url,omitempty"`
 	Headers        map[string]string `json:"headers,omitempty"`
+	TimeoutMS      int               `json:"timeout,omitempty"`
 	OAuthResource  string            `json:"-"`
 	Env            map[string]string `json:"env,omitempty"`
 	RuntimeEnvKeys []string          `json:"-"`
@@ -26,7 +27,11 @@ type ringRenderTarget struct {
 	// supportsRemote mirrors the sync adapter's per-transport remote
 	// capability so render and sync never disagree about materialization.
 	supportsRemote func(transport string) bool
-	render         func(io.Writer, map[string]renderedServer) error
+	// emitsRemoteTimeout is true when the renderer carries timeout_ms into
+	// the client's per-server timeout field; targets without an equivalent
+	// (codex) warn instead.
+	emitsRemoteTimeout bool
+	render             func(io.Writer, map[string]renderedServer) error
 }
 
 var ringRenderTargets = ringRenderTargetsFromClientTargets()
@@ -53,6 +58,7 @@ type geminiRenderedServer struct {
 	HTTPURL string            `json:"httpUrl,omitempty"`
 	URL     string            `json:"url,omitempty"`
 	Headers map[string]string `json:"headers,omitempty"`
+	Timeout int               `json:"timeout,omitempty"`
 	Env     map[string]string `json:"env,omitempty"`
 }
 
@@ -63,6 +69,7 @@ func renderGeminiJSON(out io.Writer, servers map[string]renderedServer) error {
 			Command: entry.Command,
 			Args:    entry.Args,
 			Headers: entry.Headers,
+			Timeout: entry.TimeoutMS,
 			Env:     entry.Env,
 		}
 		switch entry.Transport {

--- a/cmd/madari/render_targets.go
+++ b/cmd/madari/render_targets.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"sort"
 	"strings"
+
+	"github.com/ankitvg/madari/internal/registry"
 )
 
 // renderedServer is the self-contained client config entry ring render emits.
@@ -14,7 +16,6 @@ type renderedServer struct {
 	Args           []string          `json:"args,omitempty"`
 	URL            string            `json:"url,omitempty"`
 	Headers        map[string]string `json:"headers,omitempty"`
-	TimeoutMS      int               `json:"timeout,omitempty"`
 	OAuthResource  string            `json:"-"`
 	Env            map[string]string `json:"env,omitempty"`
 	RuntimeEnvKeys []string          `json:"-"`
@@ -41,6 +42,38 @@ func supportedRingRenderTargets() []string {
 
 func renderMCPServersJSON(out io.Writer, servers map[string]renderedServer) error {
 	return writeJSON(out, map[string]map[string]renderedServer{"mcpServers": servers})
+}
+
+// geminiRenderedServer mirrors gemini-cli's settings.json server shape:
+// remote transports are distinguished by field (httpUrl = Streamable HTTP,
+// url = SSE) rather than a type key.
+type geminiRenderedServer struct {
+	Command string            `json:"command,omitempty"`
+	Args    []string          `json:"args,omitempty"`
+	HTTPURL string            `json:"httpUrl,omitempty"`
+	URL     string            `json:"url,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
+	Env     map[string]string `json:"env,omitempty"`
+}
+
+func renderGeminiJSON(out io.Writer, servers map[string]renderedServer) error {
+	shaped := make(map[string]geminiRenderedServer, len(servers))
+	for name, entry := range servers {
+		server := geminiRenderedServer{
+			Command: entry.Command,
+			Args:    entry.Args,
+			Headers: entry.Headers,
+			Env:     entry.Env,
+		}
+		switch entry.Transport {
+		case registry.TransportHTTP:
+			server.HTTPURL = entry.URL
+		case registry.TransportSSE:
+			server.URL = entry.URL
+		}
+		shaped[name] = server
+	}
+	return writeJSON(out, map[string]map[string]geminiRenderedServer{"mcpServers": shaped})
 }
 
 func renderCodexTOML(out io.Writer, servers map[string]renderedServer) error {

--- a/cmd/madari/ring.go
+++ b/cmd/madari/ring.go
@@ -415,8 +415,10 @@ func (a cliApp) cmdRingRender(args []string) error {
 				fmt.Fprintf(a.stderr, "warning: ring member %s uses %s transport, which %s render does not support yet; omitted\n", member, manifest.TransportType(), target)
 				continue
 			}
-			if manifest.TimeoutMS > 0 {
+			timeoutMS := manifest.TimeoutMS
+			if timeoutMS > 0 && !renderTarget.emitsRemoteTimeout {
 				fmt.Fprintf(a.stderr, "warning: ring member %s: timeout_ms is not emitted for %s render\n", member, target)
+				timeoutMS = 0
 			}
 			headers := copyStringMap(manifest.Headers)
 			if secretNames := manifest.SecretHeaderNames(); len(secretNames) > 0 {
@@ -432,6 +434,7 @@ func (a cliApp) cmdRingRender(args []string) error {
 				Transport:     manifest.TransportType(),
 				URL:           manifest.URL,
 				Headers:       headers,
+				TimeoutMS:     timeoutMS,
 				OAuthResource: manifest.OAuthResource,
 			}
 			continue

--- a/cmd/madari/ring.go
+++ b/cmd/madari/ring.go
@@ -418,11 +418,20 @@ func (a cliApp) cmdRingRender(args []string) error {
 			if manifest.TimeoutMS > 0 {
 				fmt.Fprintf(a.stderr, "warning: ring member %s: timeout_ms is not emitted for %s render\n", member, target)
 			}
+			headers := copyStringMap(manifest.Headers)
+			if secretNames := manifest.SecretHeaderNames(); len(secretNames) > 0 {
+				// Render output is for sharing/ephemeral use: secret header
+				// values are never emitted, mirroring secret_env render
+				// policy. The warning names the headers to provide manually.
+				for _, name := range secretNames {
+					delete(headers, name)
+				}
+				fmt.Fprintf(a.stderr, "warning: ring member %s: secret header values omitted from render: %s\n", member, strings.Join(secretNames, ", "))
+			}
 			servers[member] = renderedServer{
 				Transport:     manifest.TransportType(),
 				URL:           manifest.URL,
-				Headers:       copyStringMap(manifest.Headers),
-				TimeoutMS:     manifest.TimeoutMS,
+				Headers:       headers,
 				OAuthResource: manifest.OAuthResource,
 			}
 			continue

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -332,6 +332,7 @@ func (a cliApp) cmdAdd(args []string) error {
 	var headerPairs stringList
 	var requiredEnv stringList
 	var secretEnv stringList
+	var secretHeaders stringList
 
 	fs.StringVar(&command, "command", "", "Server command")
 	fs.StringVar(&transport, "transport", "", "Server transport (stdio, http, or sse; default: stdio)")
@@ -346,6 +347,7 @@ func (a cliApp) cmdAdd(args []string) error {
 	fs.Var(&headerPairs, "header", "HTTP header KEY=VALUE for remote transports (repeatable)")
 	fs.Var(&requiredEnv, "required-env", "Required environment key (repeatable)")
 	fs.Var(&secretEnv, "secret-env", "Secret env key barred from repo-scoped configs (repeatable)")
+	fs.Var(&secretHeaders, "secret-header", "Secret header name barred from repo-scoped configs (repeatable)")
 
 	if err := fs.Parse(args[1:]); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -401,6 +403,7 @@ func (a cliApp) cmdAdd(args []string) error {
 		Env:           env,
 		RequiredEnv:   registry.RequiredEnv{Keys: append([]string(nil), requiredEnv...)},
 		SecretEnv:     registry.SecretEnv{Keys: append([]string(nil), secretEnv...)},
+		SecretHeaders: registry.SecretHeaders{Keys: append([]string(nil), secretHeaders...)},
 	}
 
 	if err := a.store.Add(manifest); err != nil {
@@ -1633,7 +1636,7 @@ func printSyncSummary(stdout, stderr io.Writer, target, configPath string, dryRu
 	if len(refused) > 0 {
 		fmt.Fprintf(stdout, "refused: %s\n", formatNameList(refused))
 		for _, name := range refused {
-			fmt.Fprintf(stderr, "warning: refused %s: secret env values cannot be written to the repo-scoped config; run `madari sync %s --scope user` or remove the static [env] value for keys marked in [secret_env]\n", name, target)
+			fmt.Fprintf(stderr, "warning: refused %s: secret values cannot be written to the repo-scoped config; run `madari sync %s --scope user` or remove the static secret values (env values for [secret_env] keys, header values for credential or [secret_headers] names)\n", name, target)
 		}
 	}
 	if len(unchanged) > 0 {
@@ -1735,6 +1738,8 @@ func printAddHelp(out io.Writer) {
 	fmt.Fprintln(out, "  --transport <transport>    Server transport: stdio, http, or sse (default: stdio)")
 	fmt.Fprintln(out, "  --url <url>                Remote MCP server URL for http/sse transports")
 	fmt.Fprintln(out, "  --header KEY=VALUE         HTTP header for remote transports (repeatable)")
+	fmt.Fprintln(out, "  --secret-header <NAME>     Secret header name barred from repo-scoped configs (repeatable);")
+	fmt.Fprintln(out, "                             well-known credential headers are always treated as secret")
 	fmt.Fprintln(out, "  --timeout-ms <ms>          Remote MCP timeout in milliseconds")
 	fmt.Fprintln(out, "  --oauth-resource <url>     OAuth resource for remote clients that support it")
 	fmt.Fprintln(out, "  --client <client>          Target client id (required, repeatable)")

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -4521,7 +4521,34 @@ func TestRunWithStoreRingRenderRemoteUnsupportedTarget(t *testing.T) {
 	if result := runCmd(store, "add", "cloud-sql",
 		"--transport", "http",
 		"--url", "https://sqladmin.googleapis.com/mcp",
-		"--client", "claude-code"); result.code != 0 {
+		"--client", "claude-desktop"); result.code != 0 {
+		t.Fatalf("setup add cloud-sql failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "ring", "create", "cloudsql-readonly", "--member", "cloud-sql"); result.code != 0 {
+		t.Fatalf("ring create failed: %s", result.stderr)
+	}
+
+	result := runCmd(store, "ring", "render", "cloudsql-readonly", "--client", "claude-desktop")
+	if result.code != 0 {
+		t.Fatalf("ring render claude-desktop failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, `"mcpServers": {}`) {
+		t.Fatalf("expected empty MCP config for unsupported remote target, got:\n%s", result.stdout)
+	}
+	if !strings.Contains(result.stderr, "uses http transport") || !strings.Contains(result.stderr, "does not support yet") {
+		t.Fatalf("expected unsupported remote warning, got: %s", result.stderr)
+	}
+}
+
+func TestRunWithStoreRingRenderClaudeCodeRemote(t *testing.T) {
+	store := newTestStore(t)
+
+	if result := runCmd(store, "add", "cloud-sql",
+		"--transport", "http",
+		"--url", "https://example.com/mcp",
+		"--client", "claude-code",
+		"--header", "x-goog-user-project=example-project",
+		"--header", "Authorization=Bearer sekrit"); result.code != 0 {
 		t.Fatalf("setup add cloud-sql failed: %s", result.stderr)
 	}
 	if result := runCmd(store, "ring", "create", "cloudsql-readonly", "--member", "cloud-sql"); result.code != 0 {
@@ -4532,11 +4559,72 @@ func TestRunWithStoreRingRenderRemoteUnsupportedTarget(t *testing.T) {
 	if result.code != 0 {
 		t.Fatalf("ring render claude-code failed: %s", result.stderr)
 	}
-	if !strings.Contains(result.stdout, `"mcpServers": {}`) {
-		t.Fatalf("expected empty MCP config for unsupported remote target, got:\n%s", result.stdout)
+	want := `{
+  "mcpServers": {
+    "cloud-sql": {
+      "type": "http",
+      "url": "https://example.com/mcp",
+      "headers": {
+        "x-goog-user-project": "example-project"
+      }
+    }
+  }
+}
+`
+	if result.stdout != want {
+		t.Fatalf("render output for claude-code remote drift:\nwant:\n%s\ngot:\n%s", want, result.stdout)
 	}
-	if !strings.Contains(result.stderr, "uses http transport") || !strings.Contains(result.stderr, "does not support yet") {
-		t.Fatalf("expected unsupported remote warning, got: %s", result.stderr)
+	if !strings.Contains(result.stderr, "secret header values omitted from render: Authorization") {
+		t.Fatalf("expected secret header omission warning, got: %s", result.stderr)
+	}
+	if strings.Contains(result.stdout, "sekrit") {
+		t.Fatalf("expected secret header value to stay out of render output, got: %s", result.stdout)
+	}
+}
+
+func TestRunWithStoreRingRenderGeminiRemote(t *testing.T) {
+	store := newTestStore(t)
+
+	if result := runCmd(store, "add", "cloud-sql",
+		"--transport", "http",
+		"--url", "https://example.com/mcp",
+		"--client", "gemini",
+		"--header", "x-goog-user-project=example-project"); result.code != 0 {
+		t.Fatalf("setup add cloud-sql failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "add", "events",
+		"--transport", "sse",
+		"--url", "https://example.com/sse",
+		"--client", "gemini"); result.code != 0 {
+		t.Fatalf("setup add events failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "ring", "create", "remote-mix", "--member", "cloud-sql", "--member", "events"); result.code != 0 {
+		t.Fatalf("ring create failed: %s", result.stderr)
+	}
+
+	result := runCmd(store, "ring", "render", "remote-mix", "--client", "gemini")
+	if result.code != 0 {
+		t.Fatalf("ring render gemini failed: %s", result.stderr)
+	}
+	want := `{
+  "mcpServers": {
+    "cloud-sql": {
+      "httpUrl": "https://example.com/mcp",
+      "headers": {
+        "x-goog-user-project": "example-project"
+      }
+    },
+    "events": {
+      "url": "https://example.com/sse"
+    }
+  }
+}
+`
+	if result.stdout != want {
+		t.Fatalf("render output for gemini remote drift:\nwant:\n%s\ngot:\n%s", want, result.stdout)
+	}
+	if result.stderr != "" {
+		t.Fatalf("expected no render warnings, got: %s", result.stderr)
 	}
 }
 

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -4547,6 +4547,7 @@ func TestRunWithStoreRingRenderClaudeCodeRemote(t *testing.T) {
 		"--transport", "http",
 		"--url", "https://example.com/mcp",
 		"--client", "claude-code",
+		"--timeout-ms", "30000",
 		"--header", "x-goog-user-project=example-project",
 		"--header", "Authorization=Bearer sekrit"); result.code != 0 {
 		t.Fatalf("setup add cloud-sql failed: %s", result.stderr)
@@ -4566,7 +4567,8 @@ func TestRunWithStoreRingRenderClaudeCodeRemote(t *testing.T) {
       "url": "https://example.com/mcp",
       "headers": {
         "x-goog-user-project": "example-project"
-      }
+      },
+      "timeout": 30000
     }
   }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -143,11 +143,14 @@ Skills are not run inputs yet.
 - Entries Madari does not manage keep their JSON value, including fields and
   server shapes Madari does not model (e.g. `type`/`url` remote entries);
   only managed or newly added entries are serialized from manifests. Managed
-  stdio entries are serialized from command manifests; managed Codex remote
-  entries are serialized from `url` manifests. Adapters whose
-  `SupportsRemote()` is false keep remote manifests ineligible until their
-  per-client remote materialization lands. The enclosing document is
-  reformatted on write. For adapters with raw-match
+  stdio entries are serialized from command manifests; managed remote entries
+  are serialized client-natively (Codex `url`/`http_headers`, Claude Code
+  `type`/`url`/`headers`, Gemini `httpUrl` or `url` plus `headers`). Adapters
+  report remote support per transport via `SupportsRemote(transport)`;
+  unsupported combinations keep remote manifests ineligible. Remote header
+  values for credential headers (built-in list plus `[secret_headers]`)
+  follow the secret placement policy: refused and scrubbed at repo scope,
+  user scope only. The enclosing document is reformatted on write. For adapters with raw-match
   validation (currently Claude Code and Claude Desktop), if an unmanaged entry
   has the same name as a desired manifest, Madari only treats it as an exact
   match when its canonical raw JSON, after normalizing empty modeled optional

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -16,11 +16,13 @@ madari remove <name>
 `madari add` defaults to `stdio`, where `--command` is required and is resolved
 to an absolute executable path. Remote manifests use `--transport http` or
 `--transport sse` with `--url`; optional remote metadata includes `--header`,
-`--timeout-ms`, and `--oauth-resource`. Remote `http` manifests materialize
-for `codex`; `sse` manifests and the other sync and render targets skip them
-until per-client support lands. `madari list` and `madari doctor` show each
-server's transport and endpoint so remote entries are visible where
-materialization is pending.
+`--secret-header`, `--timeout-ms`, and `--oauth-resource`. Remote manifests
+materialize for `codex` (`http` only), `claude-code`, and `gemini` (`http`
+and `sse`); the remaining targets and transports skip them until per-client
+support lands. Well-known credential headers, and names marked with
+`--secret-header`, are refused in repo-scoped configs. `madari list` and
+`madari doctor` show each server's transport and endpoint so remote entries
+are visible where materialization is pending.
 
 ## Install Workflow
 
@@ -51,9 +53,16 @@ madari sync vibe
 (`.mcp.json` or `~/.claude.json`) and `gemini` (`.gemini/settings.json` or
 `~/.gemini/settings.json`). `project` is the default. Each scope tracks its
 managed entries independently. Servers carrying static values for
-`[secret_env]` keys are refused per entry at project scope (other servers
-keep syncing; a previously materialized secret entry is scrubbed) and must
-sync with `--scope user`.
+`[secret_env]` keys — or remote header values for credential headers and
+`[secret_headers]` names — are refused per entry at project scope (other
+servers keep syncing; a previously materialized secret entry is scrubbed)
+and must sync with `--scope user`.
+
+`claude-code` and `gemini` also materialize managed remote entries.
+Claude Code writes `type`/`url` entries with `headers` into its config;
+Gemini writes `httpUrl` (Streamable HTTP) or `url` (SSE) entries with
+`headers`. `oauth_resource` and `timeout_ms` have no equivalent in either
+client and are not emitted.
 
 `codex` sync targets Codex's user config (`$CODEX_HOME/config.toml`, or
 `~/.codex/config.toml` when `CODEX_HOME` is unset). Static non-secret `[env]`
@@ -147,9 +156,12 @@ Render targets are independent from sync adapters. `claude-code`,
 Codex render output also emits `env_vars = [...]` for `[required_env]` and
 `[secret_env]` keys so runtime-provided environment values can be forwarded.
 Codex render also emits remote Streamable HTTP members as `url` entries with
-optional `oauth_resource` and `[headers]` as `http_headers`. SSE members and
-the other render targets omit remote ring members with warnings until
-per-client support lands.
+optional `oauth_resource` and `[headers]` as `http_headers`. Claude Code
+render emits remote members as `type`/`url`/`headers`; Gemini render emits
+`httpUrl` (Streamable HTTP) or `url` (SSE) with `headers`. Secret header
+values are never emitted by render — the warning names the headers to
+provide manually. Remote members are omitted with warnings for targets or
+transports without support (codex SSE, claude-desktop, vibe).
 Ring skill members are not embedded in MCP render output; use `ring attach`
 for native skill materialization.
 Ephemeral-session recipe:

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -59,10 +59,12 @@ servers keep syncing; a previously materialized secret entry is scrubbed)
 and must sync with `--scope user`.
 
 `claude-code` and `gemini` also materialize managed remote entries.
-Claude Code writes `type`/`url` entries with `headers` into its config;
+Claude Code writes `type`/`url` entries with `headers` into its config
+(accepting existing unmanaged `streamable-http` entries as equal to `http`);
 Gemini writes `httpUrl` (Streamable HTTP) or `url` (SSE) entries with
-`headers`. `oauth_resource` and `timeout_ms` have no equivalent in either
-client and are not emitted.
+`headers`. `timeout_ms` is carried through as each client's per-server
+`timeout` field (milliseconds). `oauth_resource` has no equivalent in either
+client and is not emitted.
 
 `codex` sync targets Codex's user config (`$CODEX_HOME/config.toml`, or
 `~/.codex/config.toml` when `CODEX_HOME` is unset). Static non-secret `[env]`

--- a/docs/manifest-spec.md
+++ b/docs/manifest-spec.md
@@ -33,18 +33,23 @@ Known client IDs:
 
 `claude-desktop`, `claude-code`, `gemini`, `codex`, and `vibe` are
 sync-capable today. All are also render targets for `madari ring render`.
-Remote `http` manifests are materialized for `codex` (native `url` entries
-plus optional OAuth metadata and `[headers]` as `http_headers`). `sse`
-manifests and the other targets keep remote entries ineligible until their
-auth and config behavior is validated per client.
+Remote materialization is per client and per transport:
+
+- `codex`: `http` only, as native `url` entries plus optional OAuth metadata
+  and `[headers]` as `http_headers`.
+- `claude-code`: `http` and `sse`, as `type`/`url` entries with `headers`.
+- `gemini`: `http` (as `httpUrl`) and `sse` (as `url`), with `headers`.
+- `claude-desktop` and `vibe`: remote entries stay ineligible until their
+  auth and config behavior is validated per client.
 
 ### `[headers]`
 
 Key/value static HTTP headers for remote transports. Header names are limited
 to letters, digits, `-`, and `_` so they round-trip through the manifest
 format. Headers are emitted only for clients that support header
-configuration (Codex writes them as `http_headers`); other targets store
-them without emitting.
+configuration (Codex writes them as `http_headers`; Claude Code and Gemini
+as `headers`); other targets store them without emitting. Header values for
+credential headers follow the `[secret_headers]` placement policy below.
 
 ### `[env]`
 
@@ -64,6 +69,20 @@ Key/value static environment variables for stdio transports.
   write static secret values into Codex config. Vibe sync targets the user
   config, so static secret values are allowed there like other user-scoped
   configs.
+
+### `[secret_headers]`
+
+- `keys` (array of strings): header names whose values are secrets, following
+  the same placement policy as `[secret_env]`: entries carrying a secret
+  header value are refused at repo scope (and scrubbed if previously
+  materialized there) and materialize only into user-scoped configs.
+
+Well-known credential headers are always treated as secret, with or without a
+`[secret_headers]` entry: `Authorization`, `Proxy-Authorization`, `Cookie`,
+api-key variants, and names containing `token` or `secret` (all
+case-insensitive). Use `[secret_headers]` to mark additional headers whose
+values must stay out of committed configs. `ring render` never emits secret
+header values; the warning names the headers to provide manually.
 
 ## Example
 
@@ -105,6 +124,8 @@ description = "Official Cloud SQL remote MCP server"
 - `url` is required for `http` and `sse`.
 - Remote transports reject `command`, `args`, `[env]`, `[required_env]`, and
   `[secret_env]` because they are local process settings.
+- `[secret_headers]` is remote-only; names must be valid header names and
+  unique (case-insensitive).
 
 ## Ring Files
 

--- a/internal/clients/claudecode/adapter.go
+++ b/internal/clients/claudecode/adapter.go
@@ -18,10 +18,10 @@ func (Adapter) DefaultConfigPath() (string, error) {
 	return DefaultProjectConfigPath()
 }
 
-// SupportsRemote is false: remote manifests stay ineligible until this
-// adapter materializes remote transports.
-func (Adapter) SupportsRemote(string) bool {
-	return false
+// SupportsRemote reports which remote transports this adapter
+// materializes as native config entries.
+func (Adapter) SupportsRemote(transport string) bool {
+	return supportsRemoteTransport(transport)
 }
 
 func (Adapter) Sync(manifests []registry.Manifest, opts clients.SyncOptions) (clients.SyncResult, error) {

--- a/internal/clients/claudecode/sync.go
+++ b/internal/clients/claudecode/sync.go
@@ -336,11 +336,13 @@ func supportsRemoteTransport(transport string) bool {
 
 func materializeServer(manifest registry.Manifest) serverConfig {
 	if manifest.IsRemote() {
-		// Remote entries carry type/url/headers. oauth_resource and
-		// timeout_ms have no .mcp.json equivalent and are not emitted.
+		// Remote entries carry type/url/headers plus the per-server tool
+		// timeout in milliseconds. oauth_resource has no .mcp.json
+		// equivalent and is not emitted.
 		entry := serverConfig{
-			Type: manifest.TransportType(),
-			URL:  manifest.URL,
+			Type:    manifest.TransportType(),
+			URL:     manifest.URL,
+			Timeout: manifest.TimeoutMS,
 		}
 		if len(manifest.Headers) > 0 {
 			entry.Headers = make(map[string]string, len(manifest.Headers))
@@ -364,11 +366,24 @@ func materializeServer(manifest registry.Manifest) serverConfig {
 	return entry
 }
 
+// normalizeType folds Claude Code's documented streamable-http alias into
+// http so hand-written entries copied from server docs compare as equal to
+// madari's materialization instead of raising unmanaged conflicts.
+func normalizeType(transport string) string {
+	if transport == "streamable-http" {
+		return "http"
+	}
+	return transport
+}
+
 func equalServer(a, b serverConfig) bool {
 	if a.Command != b.Command {
 		return false
 	}
-	if a.Type != b.Type || a.URL != b.URL {
+	if normalizeType(a.Type) != normalizeType(b.Type) || a.URL != b.URL {
+		return false
+	}
+	if a.Timeout != b.Timeout {
 		return false
 	}
 	if len(a.Headers) != len(b.Headers) {
@@ -488,6 +503,13 @@ func stripEmptyModeledServerFields(object map[string]any) bool {
 			delete(object, "headers")
 		}
 	}
+	if value, exists := object["type"]; exists {
+		transport, ok := value.(string)
+		if !ok {
+			return false
+		}
+		object["type"] = normalizeType(transport)
+	}
 	return true
 }
 
@@ -537,4 +559,5 @@ type serverConfig struct {
 	Env     map[string]string `json:"env,omitempty"`
 	URL     string            `json:"url,omitempty"`
 	Headers map[string]string `json:"headers,omitempty"`
+	Timeout int               `json:"timeout,omitempty"`
 }

--- a/internal/clients/claudecode/sync.go
+++ b/internal/clients/claudecode/sync.go
@@ -307,9 +307,11 @@ func entriesForTarget(manifests []registry.Manifest, userScope bool) map[string]
 		switch {
 		case !manifest.Enabled:
 			// ineligible
-		case manifest.IsRemote():
-			// Remote transports are not materialized by this adapter yet.
+		case manifest.IsRemote() && !supportsRemoteTransport(manifest.TransportType()):
+			// unsupported remote transports stay pending
 		case !userScope && manifest.HasSecretValue():
+			// covers static secret env values and secret header values;
+			// refusal at project scope keeps credentials out of .mcp.json
 			entry.Refused = true
 		default:
 			entry.Eligible = true
@@ -320,7 +322,35 @@ func entriesForTarget(manifests []registry.Manifest, userScope bool) map[string]
 	return entries
 }
 
+// supportsRemoteTransport gates which remote transports Claude Code
+// materializes: both Streamable HTTP and SSE are documented .mcp.json
+// server types (SSE is deprecated upstream but still supported).
+func supportsRemoteTransport(transport string) bool {
+	switch transport {
+	case registry.TransportHTTP, registry.TransportSSE:
+		return true
+	default:
+		return false
+	}
+}
+
 func materializeServer(manifest registry.Manifest) serverConfig {
+	if manifest.IsRemote() {
+		// Remote entries carry type/url/headers. oauth_resource and
+		// timeout_ms have no .mcp.json equivalent and are not emitted.
+		entry := serverConfig{
+			Type: manifest.TransportType(),
+			URL:  manifest.URL,
+		}
+		if len(manifest.Headers) > 0 {
+			entry.Headers = make(map[string]string, len(manifest.Headers))
+			for key, value := range manifest.Headers {
+				entry.Headers[key] = value
+			}
+		}
+		return entry
+	}
+
 	entry := serverConfig{Command: manifest.Command}
 	if len(manifest.Args) > 0 {
 		entry.Args = append([]string(nil), manifest.Args...)
@@ -337,6 +367,17 @@ func materializeServer(manifest registry.Manifest) serverConfig {
 func equalServer(a, b serverConfig) bool {
 	if a.Command != b.Command {
 		return false
+	}
+	if a.Type != b.Type || a.URL != b.URL {
+		return false
+	}
+	if len(a.Headers) != len(b.Headers) {
+		return false
+	}
+	for key, value := range a.Headers {
+		if b.Headers[key] != value {
+			return false
+		}
 	}
 	if len(a.Args) != len(b.Args) {
 		return false
@@ -438,6 +479,15 @@ func stripEmptyModeledServerFields(object map[string]any) bool {
 			delete(object, "env")
 		}
 	}
+	if value, exists := object["headers"]; exists {
+		headers, ok := value.(map[string]any)
+		if !ok {
+			return false
+		}
+		if len(headers) == 0 {
+			delete(object, "headers")
+		}
+	}
 	return true
 }
 
@@ -481,7 +531,10 @@ func loadClaudeCodeConfig(path string) (map[string]json.RawMessage, map[string]j
 }
 
 type serverConfig struct {
-	Command string            `json:"command"`
+	Type    string            `json:"type,omitempty"`
+	Command string            `json:"command,omitempty"`
 	Args    []string          `json:"args,omitempty"`
 	Env     map[string]string `json:"env,omitempty"`
+	URL     string            `json:"url,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
 }

--- a/internal/clients/claudecode/sync_test.go
+++ b/internal/clients/claudecode/sync_test.go
@@ -1211,6 +1211,7 @@ func TestSyncApplyRemoteHTTP(t *testing.T) {
 		Transport: registry.TransportHTTP,
 		URL:       "https://example.com/mcp",
 		Headers:   map[string]string{"x-goog-user-project": "example-project"},
+		TimeoutMS: 30000,
 		Enabled:   true,
 		Clients:   []string{Target},
 	}
@@ -1232,6 +1233,9 @@ func TestSyncApplyRemoteHTTP(t *testing.T) {
 	}
 	if got.Headers["x-goog-user-project"] != "example-project" {
 		t.Fatalf("expected non-secret headers to materialize, got: %#v", got.Headers)
+	}
+	if got.Timeout != 30000 {
+		t.Fatalf("expected timeout_ms carried through as timeout, got: %#v", got)
 	}
 	if _, ok := servers["weather"]; !ok {
 		t.Fatalf("expected unmanaged weather entry to be preserved")
@@ -1275,6 +1279,47 @@ func TestSyncApplyRemoteSSE(t *testing.T) {
 	got := readServers(t, configPath)["events"]
 	if got.Type != "sse" || got.URL != "https://example.com/sse" {
 		t.Fatalf("expected sse type/url entry, got: %#v", got)
+	}
+}
+
+func TestSyncTreatsStreamableHTTPAliasAsEqual(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".mcp.json")
+	statePath := filepath.Join(tmp, "state", "claude-code-managed.json")
+	original := []byte(`{
+  "mcpServers": {
+    "cloud-sql": {
+      "type": "streamable-http",
+      "url": "https://example.com/mcp"
+    }
+  }
+}
+`)
+	if err := os.WriteFile(configPath, original, 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	remote := registry.Manifest{
+		Name:      "cloud-sql",
+		Transport: registry.TransportHTTP,
+		URL:       "https://example.com/mcp",
+		Enabled:   true,
+		Clients:   []string{Target},
+	}
+	result, err := Sync([]registry.Manifest{remote}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("expected streamable-http alias to compare equal, got: %v", err)
+	}
+	if len(result.Unchanged) != 1 || result.Unchanged[0] != "cloud-sql" {
+		t.Fatalf("expected alias entry reported unchanged, got: %+v", result)
+	}
+	// The unmanaged entry keeps its raw value: no adoption, no rewrite.
+	got := readServers(t, configPath)["cloud-sql"]
+	if got.Type != "streamable-http" {
+		t.Fatalf("expected unmanaged alias entry preserved verbatim, got: %#v", got)
 	}
 }
 

--- a/internal/clients/claudecode/sync_test.go
+++ b/internal/clients/claudecode/sync_test.go
@@ -1189,7 +1189,7 @@ func assertJSONEqual(t *testing.T, want, got []byte) {
 	}
 }
 
-func TestSyncSkipsManagedRemoteManifest(t *testing.T) {
+func TestSyncApplyRemoteHTTP(t *testing.T) {
 	tmp := t.TempDir()
 	configPath := filepath.Join(tmp, ".mcp.json")
 	statePath := filepath.Join(tmp, "state", "claude-code-managed.json")
@@ -1210,6 +1210,7 @@ func TestSyncSkipsManagedRemoteManifest(t *testing.T) {
 		Name:      "cloud-sql",
 		Transport: registry.TransportHTTP,
 		URL:       "https://example.com/mcp",
+		Headers:   map[string]string{"x-goog-user-project": "example-project"},
 		Enabled:   true,
 		Clients:   []string{Target},
 	}
@@ -1220,20 +1221,64 @@ func TestSyncSkipsManagedRemoteManifest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sync failed: %v", err)
 	}
-	if len(result.Added) != 0 || len(result.Updated) != 0 || len(result.Removed) != 0 {
-		t.Fatalf("expected remote manifest to be ineligible until the adapter supports it, got: %+v", result)
+	if len(result.Added) != 1 || result.Added[0] != "cloud-sql" {
+		t.Fatalf("expected remote add result, got: %+v", result)
 	}
 
 	servers := readServers(t, configPath)
-	if _, exists := servers["cloud-sql"]; exists {
-		t.Fatalf("expected remote manifest not to be materialized, got: %#v", servers)
+	got := servers["cloud-sql"]
+	if got.Type != "http" || got.URL != "https://example.com/mcp" || got.Command != "" {
+		t.Fatalf("expected type/url remote entry without command, got: %#v", got)
+	}
+	if got.Headers["x-goog-user-project"] != "example-project" {
+		t.Fatalf("expected non-secret headers to materialize, got: %#v", got.Headers)
 	}
 	if _, ok := servers["weather"]; !ok {
 		t.Fatalf("expected unmanaged weather entry to be preserved")
 	}
+
+	remote.URL = "https://example.com/mcp/v2"
+	result, err = Sync([]registry.Manifest{remote}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync url change failed: %v", err)
+	}
+	if len(result.Updated) != 1 || result.Updated[0] != "cloud-sql" {
+		t.Fatalf("expected url change to be an update, got: %+v", result)
+	}
 }
 
-func TestSyncRemoteOnlyDoesNotCreateFiles(t *testing.T) {
+func TestSyncApplyRemoteSSE(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".mcp.json")
+	statePath := filepath.Join(tmp, "state", "claude-code-managed.json")
+
+	remote := registry.Manifest{
+		Name:      "events",
+		Transport: registry.TransportSSE,
+		URL:       "https://example.com/sse",
+		Enabled:   true,
+		Clients:   []string{Target},
+	}
+	result, err := Sync([]registry.Manifest{remote}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	if len(result.Added) != 1 || result.Added[0] != "events" {
+		t.Fatalf("expected sse add result, got: %+v", result)
+	}
+	got := readServers(t, configPath)["events"]
+	if got.Type != "sse" || got.URL != "https://example.com/sse" {
+		t.Fatalf("expected sse type/url entry, got: %#v", got)
+	}
+}
+
+func TestSyncRefusesSecretHeaderAtProjectScope(t *testing.T) {
 	tmp := t.TempDir()
 	configPath := filepath.Join(tmp, ".mcp.json")
 	statePath := filepath.Join(tmp, "state", "claude-code-managed.json")
@@ -1242,6 +1287,7 @@ func TestSyncRemoteOnlyDoesNotCreateFiles(t *testing.T) {
 		Name:      "cloud-sql",
 		Transport: registry.TransportHTTP,
 		URL:       "https://example.com/mcp",
+		Headers:   map[string]string{"Authorization": "Bearer sekrit"},
 		Enabled:   true,
 		Clients:   []string{Target},
 	}
@@ -1250,16 +1296,70 @@ func TestSyncRemoteOnlyDoesNotCreateFiles(t *testing.T) {
 		StatePath:  statePath,
 	})
 	if err != nil {
-		t.Fatalf("sync failed: %v", err)
+		t.Fatalf("project-scope sync failed: %v", err)
 	}
-	if len(result.Added)+len(result.Updated)+len(result.Removed) != 0 {
-		t.Fatalf("expected no-op sync result, got: %+v", result)
+	if len(result.Refused) != 1 || result.Refused[0] != "cloud-sql" {
+		t.Fatalf("expected credential header to refuse at project scope, got: %+v", result)
 	}
 	if _, err := os.Stat(configPath); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("expected no config file for remote-only no-op sync, got err=%v", err)
+		t.Fatalf("expected no project config for refused-only sync, got err=%v", err)
 	}
-	if _, err := os.Stat(statePath); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("expected no state file for remote-only no-op sync, got err=%v", err)
+
+	userConfigPath := filepath.Join(tmp, "claude.json")
+	userStatePath := filepath.Join(tmp, "state", "claude-code-user-managed.json")
+	result, err = Sync([]registry.Manifest{remote}, SyncOptions{
+		ConfigPath: userConfigPath,
+		StatePath:  userStatePath,
+		Scope:      clients.ScopeUser,
+	})
+	if err != nil {
+		t.Fatalf("user-scope sync failed: %v", err)
+	}
+	if len(result.Added) != 1 || len(result.Refused) != 0 {
+		t.Fatalf("expected user scope to materialize secret headers, got: %+v", result)
+	}
+	got := readServers(t, userConfigPath)["cloud-sql"]
+	if got.Headers["Authorization"] != "Bearer sekrit" {
+		t.Fatalf("expected secret header in user-scoped config, got: %#v", got.Headers)
+	}
+}
+
+func TestSyncScrubsSecretHeaderFromProjectConfig(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".mcp.json")
+	statePath := filepath.Join(tmp, "state", "claude-code-managed.json")
+
+	remote := registry.Manifest{
+		Name:      "cloud-sql",
+		Transport: registry.TransportHTTP,
+		URL:       "https://example.com/mcp",
+		Headers:   map[string]string{"x-goog-user-project": "example-project"},
+		Enabled:   true,
+		Clients:   []string{Target},
+	}
+	if _, err := Sync([]registry.Manifest{remote}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	}); err != nil {
+		t.Fatalf("setup sync failed: %v", err)
+	}
+
+	// The header set later gains a credential: the managed entry must be
+	// removed from the repo config on the next sync, scrubbing the value.
+	remote.Headers["Authorization"] = "Bearer sekrit"
+	result, err := Sync([]registry.Manifest{remote}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("scrub sync failed: %v", err)
+	}
+	if len(result.Refused) != 1 || len(result.Removed) != 1 {
+		t.Fatalf("expected refusal plus removal to scrub, got: %+v", result)
+	}
+	servers := readServers(t, configPath)
+	if _, exists := servers["cloud-sql"]; exists {
+		t.Fatalf("expected secret-header entry scrubbed from project config, got: %#v", servers)
 	}
 }
 

--- a/internal/clients/gemini/adapter.go
+++ b/internal/clients/gemini/adapter.go
@@ -18,10 +18,10 @@ func (Adapter) DefaultConfigPath() (string, error) {
 	return DefaultProjectConfigPath()
 }
 
-// SupportsRemote is false: remote manifests stay ineligible until this
-// adapter materializes remote transports.
-func (Adapter) SupportsRemote(string) bool {
-	return false
+// SupportsRemote reports which remote transports this adapter
+// materializes as native config entries.
+func (Adapter) SupportsRemote(transport string) bool {
+	return supportsRemoteTransport(transport)
 }
 
 func (Adapter) Sync(manifests []registry.Manifest, opts clients.SyncOptions) (clients.SyncResult, error) {

--- a/internal/clients/gemini/sync.go
+++ b/internal/clients/gemini/sync.go
@@ -280,9 +280,12 @@ func entriesForTarget(manifests []registry.Manifest, userScope bool) map[string]
 		switch {
 		case !manifest.Enabled:
 			// ineligible
-		case manifest.IsRemote():
-			// Remote transports are not materialized by this adapter yet.
+		case manifest.IsRemote() && !supportsRemoteTransport(manifest.TransportType()):
+			// unsupported remote transports stay pending
 		case !userScope && manifest.HasSecretValue():
+			// covers static secret env values and secret header values;
+			// refusal at project scope keeps credentials out of
+			// .gemini/settings.json
 			entry.Refused = true
 		default:
 			entry.Eligible = true
@@ -293,7 +296,38 @@ func entriesForTarget(manifests []registry.Manifest, userScope bool) map[string]
 	return entries
 }
 
+// supportsRemoteTransport gates which remote transports Gemini materializes:
+// Streamable HTTP uses the httpUrl field, SSE uses url, per gemini-cli's
+// settings.json schema.
+func supportsRemoteTransport(transport string) bool {
+	switch transport {
+	case registry.TransportHTTP, registry.TransportSSE:
+		return true
+	default:
+		return false
+	}
+}
+
 func materializeServer(manifest registry.Manifest) serverConfig {
+	if manifest.IsRemote() {
+		// Gemini distinguishes transports by field, not a type key:
+		// httpUrl = Streamable HTTP, url = SSE. oauth_resource and
+		// timeout_ms have no settings.json equivalent and are not emitted.
+		entry := serverConfig{}
+		if manifest.TransportType() == registry.TransportHTTP {
+			entry.HTTPURL = manifest.URL
+		} else {
+			entry.URL = manifest.URL
+		}
+		if len(manifest.Headers) > 0 {
+			entry.Headers = make(map[string]string, len(manifest.Headers))
+			for key, value := range manifest.Headers {
+				entry.Headers[key] = value
+			}
+		}
+		return entry
+	}
+
 	entry := serverConfig{Command: manifest.Command}
 	if len(manifest.Args) > 0 {
 		entry.Args = append([]string(nil), manifest.Args...)
@@ -310,6 +344,17 @@ func materializeServer(manifest registry.Manifest) serverConfig {
 func equalServer(a, b serverConfig) bool {
 	if a.Command != b.Command {
 		return false
+	}
+	if a.HTTPURL != b.HTTPURL || a.URL != b.URL {
+		return false
+	}
+	if len(a.Headers) != len(b.Headers) {
+		return false
+	}
+	for key, value := range a.Headers {
+		if b.Headers[key] != value {
+			return false
+		}
 	}
 	if len(a.Args) != len(b.Args) {
 		return false
@@ -370,7 +415,10 @@ func loadGeminiConfig(path string) (map[string]json.RawMessage, map[string]json.
 }
 
 type serverConfig struct {
-	Command string            `json:"command"`
+	Command string            `json:"command,omitempty"`
 	Args    []string          `json:"args,omitempty"`
 	Env     map[string]string `json:"env,omitempty"`
+	HTTPURL string            `json:"httpUrl,omitempty"`
+	URL     string            `json:"url,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
 }

--- a/internal/clients/gemini/sync.go
+++ b/internal/clients/gemini/sync.go
@@ -311,9 +311,10 @@ func supportsRemoteTransport(transport string) bool {
 func materializeServer(manifest registry.Manifest) serverConfig {
 	if manifest.IsRemote() {
 		// Gemini distinguishes transports by field, not a type key:
-		// httpUrl = Streamable HTTP, url = SSE. oauth_resource and
-		// timeout_ms have no settings.json equivalent and are not emitted.
-		entry := serverConfig{}
+		// httpUrl = Streamable HTTP, url = SSE. timeout is the per-server
+		// request timeout in milliseconds. oauth_resource has no
+		// settings.json equivalent and is not emitted.
+		entry := serverConfig{Timeout: manifest.TimeoutMS}
 		if manifest.TransportType() == registry.TransportHTTP {
 			entry.HTTPURL = manifest.URL
 		} else {
@@ -346,6 +347,9 @@ func equalServer(a, b serverConfig) bool {
 		return false
 	}
 	if a.HTTPURL != b.HTTPURL || a.URL != b.URL {
+		return false
+	}
+	if a.Timeout != b.Timeout {
 		return false
 	}
 	if len(a.Headers) != len(b.Headers) {
@@ -421,4 +425,5 @@ type serverConfig struct {
 	HTTPURL string            `json:"httpUrl,omitempty"`
 	URL     string            `json:"url,omitempty"`
 	Headers map[string]string `json:"headers,omitempty"`
+	Timeout int               `json:"timeout,omitempty"`
 }

--- a/internal/clients/gemini/sync_test.go
+++ b/internal/clients/gemini/sync_test.go
@@ -557,7 +557,7 @@ func TestAttachRingConflictsOnEqualUnmanagedEntry(t *testing.T) {
 	}
 }
 
-func TestSyncSkipsManagedRemoteManifest(t *testing.T) {
+func TestSyncApplyRemoteHTTP(t *testing.T) {
 	tmp := t.TempDir()
 	configPath := filepath.Join(tmp, ".gemini", "settings.json")
 	statePath := filepath.Join(tmp, "state", "gemini-managed.json")
@@ -581,6 +581,7 @@ func TestSyncSkipsManagedRemoteManifest(t *testing.T) {
 		Name:      "cloud-sql",
 		Transport: registry.TransportHTTP,
 		URL:       "https://example.com/mcp",
+		Headers:   map[string]string{"x-goog-user-project": "example-project"},
 		Enabled:   true,
 		Clients:   []string{Target},
 	}
@@ -591,20 +592,52 @@ func TestSyncSkipsManagedRemoteManifest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sync failed: %v", err)
 	}
-	if len(result.Added) != 0 || len(result.Updated) != 0 || len(result.Removed) != 0 {
-		t.Fatalf("expected remote manifest to be ineligible until the adapter supports it, got: %+v", result)
+	if len(result.Added) != 1 || result.Added[0] != "cloud-sql" {
+		t.Fatalf("expected remote add result, got: %+v", result)
 	}
 
 	servers := readServers(t, configPath)
-	if _, exists := servers["cloud-sql"]; exists {
-		t.Fatalf("expected remote manifest not to be materialized, got: %#v", servers)
+	got := servers["cloud-sql"]
+	if got.HTTPURL != "https://example.com/mcp" || got.URL != "" || got.Command != "" {
+		t.Fatalf("expected streamable http entry with httpUrl only, got: %#v", got)
+	}
+	if got.Headers["x-goog-user-project"] != "example-project" {
+		t.Fatalf("expected non-secret headers to materialize, got: %#v", got.Headers)
 	}
 	if _, ok := servers["weather"]; !ok {
 		t.Fatalf("expected unmanaged weather entry to be preserved")
 	}
 }
 
-func TestSyncRemoteOnlyDoesNotCreateFiles(t *testing.T) {
+func TestSyncApplyRemoteSSE(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".gemini", "settings.json")
+	statePath := filepath.Join(tmp, "state", "gemini-managed.json")
+
+	remote := registry.Manifest{
+		Name:      "events",
+		Transport: registry.TransportSSE,
+		URL:       "https://example.com/sse",
+		Enabled:   true,
+		Clients:   []string{Target},
+	}
+	result, err := Sync([]registry.Manifest{remote}, SyncOptions{
+		ConfigPath: configPath,
+		StatePath:  statePath,
+	})
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	if len(result.Added) != 1 || result.Added[0] != "events" {
+		t.Fatalf("expected sse add result, got: %+v", result)
+	}
+	got := readServers(t, configPath)["events"]
+	if got.URL != "https://example.com/sse" || got.HTTPURL != "" {
+		t.Fatalf("expected sse entry with url only, got: %#v", got)
+	}
+}
+
+func TestSyncRefusesSecretHeaderAtProjectScope(t *testing.T) {
 	tmp := t.TempDir()
 	configPath := filepath.Join(tmp, ".gemini", "settings.json")
 	statePath := filepath.Join(tmp, "state", "gemini-managed.json")
@@ -613,6 +646,7 @@ func TestSyncRemoteOnlyDoesNotCreateFiles(t *testing.T) {
 		Name:      "cloud-sql",
 		Transport: registry.TransportHTTP,
 		URL:       "https://example.com/mcp",
+		Headers:   map[string]string{"Authorization": "Bearer sekrit"},
 		Enabled:   true,
 		Clients:   []string{Target},
 	}
@@ -621,16 +655,31 @@ func TestSyncRemoteOnlyDoesNotCreateFiles(t *testing.T) {
 		StatePath:  statePath,
 	})
 	if err != nil {
-		t.Fatalf("sync failed: %v", err)
+		t.Fatalf("project-scope sync failed: %v", err)
 	}
-	if len(result.Added)+len(result.Updated)+len(result.Removed) != 0 {
-		t.Fatalf("expected no-op sync result, got: %+v", result)
+	if len(result.Refused) != 1 || result.Refused[0] != "cloud-sql" {
+		t.Fatalf("expected credential header to refuse at project scope, got: %+v", result)
 	}
 	if _, err := os.Stat(configPath); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("expected no config file for remote-only no-op sync, got err=%v", err)
+		t.Fatalf("expected no project config for refused-only sync, got err=%v", err)
 	}
-	if _, err := os.Stat(statePath); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("expected no state file for remote-only no-op sync, got err=%v", err)
+
+	userConfigPath := filepath.Join(tmp, "user-settings.json")
+	userStatePath := filepath.Join(tmp, "state", "gemini-user-managed.json")
+	result, err = Sync([]registry.Manifest{remote}, SyncOptions{
+		ConfigPath: userConfigPath,
+		StatePath:  userStatePath,
+		Scope:      clients.ScopeUser,
+	})
+	if err != nil {
+		t.Fatalf("user-scope sync failed: %v", err)
+	}
+	if len(result.Added) != 1 || len(result.Refused) != 0 {
+		t.Fatalf("expected user scope to materialize secret headers, got: %+v", result)
+	}
+	got := readServers(t, userConfigPath)["cloud-sql"]
+	if got.Headers["Authorization"] != "Bearer sekrit" {
+		t.Fatalf("expected secret header in user-scoped config, got: %#v", got.Headers)
 	}
 }
 

--- a/internal/clients/gemini/sync_test.go
+++ b/internal/clients/gemini/sync_test.go
@@ -582,6 +582,7 @@ func TestSyncApplyRemoteHTTP(t *testing.T) {
 		Transport: registry.TransportHTTP,
 		URL:       "https://example.com/mcp",
 		Headers:   map[string]string{"x-goog-user-project": "example-project"},
+		TimeoutMS: 30000,
 		Enabled:   true,
 		Clients:   []string{Target},
 	}
@@ -603,6 +604,9 @@ func TestSyncApplyRemoteHTTP(t *testing.T) {
 	}
 	if got.Headers["x-goog-user-project"] != "example-project" {
 		t.Fatalf("expected non-secret headers to materialize, got: %#v", got.Headers)
+	}
+	if got.Timeout != 30000 {
+		t.Fatalf("expected timeout_ms carried through as timeout, got: %#v", got)
 	}
 	if _, ok := servers["weather"]; !ok {
 		t.Fatalf("expected unmanaged weather entry to be preserved")

--- a/internal/registry/manifest.go
+++ b/internal/registry/manifest.go
@@ -75,9 +75,11 @@ var secretHeaderNameExact = map[string]bool{
 var secretHeaderNameSubstrings = []string{"token", "secret", "api-key", "apikey"}
 
 // IsSecretHeaderName reports whether a header name is treated as a
-// credential by default.
+// credential by default. Underscores are folded to hyphens before matching
+// so variants like X_API_KEY cannot slip past the detector.
 func IsSecretHeaderName(name string) bool {
 	name = strings.ToLower(strings.TrimSpace(name))
+	name = strings.ReplaceAll(name, "_", "-")
 	if secretHeaderNameExact[name] {
 		return true
 	}

--- a/internal/registry/manifest.go
+++ b/internal/registry/manifest.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -34,6 +35,7 @@ type Manifest struct {
 	Env           map[string]string `toml:"env,omitempty" json:"env,omitempty"`
 	RequiredEnv   RequiredEnv       `toml:"required_env,omitempty" json:"required_env,omitempty"`
 	SecretEnv     SecretEnv         `toml:"secret_env,omitempty" json:"secret_env,omitempty"`
+	SecretHeaders SecretHeaders     `toml:"secret_headers,omitempty" json:"secret_headers,omitempty"`
 }
 
 // RequiredEnv describes environment variables that must be present at runtime.
@@ -47,13 +49,85 @@ type SecretEnv struct {
 	Keys []string `toml:"keys,omitempty" json:"keys,omitempty"`
 }
 
-// HasSecretValue reports whether the manifest carries a static env value for
-// any key marked secret — the case placement policy must guard against.
-// Keys are trimmed to match Validate, which accepts padded secret_env
-// entries; an untrimmed lookup here would fail open and leak the value.
+// SecretHeaders marks remote header names whose values are secrets and must
+// never be materialized into repo-scoped client configs. Well-known
+// credential headers (see IsSecretHeaderName) are treated as secret even
+// when not listed here.
+type SecretHeaders struct {
+	Keys []string `toml:"keys,omitempty" json:"keys,omitempty"`
+}
+
+// secretHeaderNameExact lists headers that carry credentials by definition,
+// compared case-insensitively. Values for these names are refused in
+// repo-scoped configs even without a [secret_headers] entry, so a forgotten
+// annotation cannot commit a token.
+var secretHeaderNameExact = map[string]bool{
+	"authorization":       true,
+	"proxy-authorization": true,
+	"cookie":              true,
+	"api-key":             true,
+	"apikey":              true,
+	"x-api-key":           true,
+}
+
+// secretHeaderNameSubstrings extends the exact list to conventional
+// credential naming (x-auth-token, x-goog-api-key, session-secret, ...).
+var secretHeaderNameSubstrings = []string{"token", "secret", "api-key", "apikey"}
+
+// IsSecretHeaderName reports whether a header name is treated as a
+// credential by default.
+func IsSecretHeaderName(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if secretHeaderNameExact[name] {
+		return true
+	}
+	for _, fragment := range secretHeaderNameSubstrings {
+		if strings.Contains(name, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
+// HasSecretValue reports whether the manifest carries a static value the
+// placement policy must keep out of repo-scoped configs: an env value for a
+// key marked secret, or a remote header value whose name is marked secret or
+// is a well-known credential header. Keys are trimmed to match Validate,
+// which accepts padded entries; an untrimmed lookup here would fail open and
+// leak the value.
 func (m Manifest) HasSecretValue() bool {
 	for _, key := range m.SecretEnv.Keys {
 		if _, exists := m.Env[strings.TrimSpace(key)]; exists {
+			return true
+		}
+	}
+	for name := range m.Headers {
+		if m.isSecretHeader(name) {
+			return true
+		}
+	}
+	return false
+}
+
+// SecretHeaderNames returns the manifest's header names whose values must
+// not land in repo-scoped configs, sorted for stable output.
+func (m Manifest) SecretHeaderNames() []string {
+	var names []string
+	for name := range m.Headers {
+		if m.isSecretHeader(name) {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func (m Manifest) isSecretHeader(name string) bool {
+	if IsSecretHeaderName(name) {
+		return true
+	}
+	for _, key := range m.SecretHeaders.Keys {
+		if strings.EqualFold(strings.TrimSpace(key), strings.TrimSpace(name)) {
 			return true
 		}
 	}
@@ -117,6 +191,9 @@ func (m Manifest) Validate() error {
 		if strings.TrimSpace(m.OAuthResource) != "" {
 			errs = append(errs, "oauth_resource is only supported for remote transports")
 		}
+		if len(m.SecretHeaders.Keys) > 0 {
+			errs = append(errs, "secret_headers is only supported for remote transports")
+		}
 	case TransportHTTP, TransportSSE:
 		if strings.TrimSpace(m.URL) == "" {
 			errs = append(errs, "url is required for remote transports")
@@ -152,6 +229,20 @@ func (m Manifest) Validate() error {
 		if !validHeaderName(key) {
 			errs = append(errs, fmt.Sprintf("invalid header name %q (allowed: letters, digits, '-', '_')", key))
 		}
+	}
+
+	seenSecretHeaders := map[string]struct{}{}
+	for _, key := range m.SecretHeaders.Keys {
+		key = strings.ToLower(strings.TrimSpace(key))
+		if !validHeaderName(key) {
+			errs = append(errs, fmt.Sprintf("invalid secret_headers name %q (allowed: letters, digits, '-', '_')", key))
+			continue
+		}
+		if _, exists := seenSecretHeaders[key]; exists {
+			errs = append(errs, fmt.Sprintf("duplicate secret_headers name %q", key))
+			continue
+		}
+		seenSecretHeaders[key] = struct{}{}
 	}
 
 	if len(m.Clients) == 0 {

--- a/internal/registry/manifest_test.go
+++ b/internal/registry/manifest_test.go
@@ -163,6 +163,41 @@ func TestManifestValidateErrors(t *testing.T) {
 			expects: "url must not have leading or trailing whitespace",
 		},
 		{
+			name: "stdio rejects secret_headers",
+			mutate: func(m *Manifest) {
+				m.SecretHeaders.Keys = []string{"x-routing-key"}
+			},
+			expects: "secret_headers is only supported for remote transports",
+		},
+		{
+			name: "remote rejects invalid secret_headers name",
+			mutate: func(m *Manifest) {
+				*m = Manifest{
+					Name:          "cloud-sql",
+					Transport:     TransportHTTP,
+					URL:           "https://sqladmin.googleapis.com/mcp",
+					SecretHeaders: SecretHeaders{Keys: []string{"bad header"}},
+					Enabled:       true,
+					Clients:       []string{"codex"},
+				}
+			},
+			expects: "invalid secret_headers name",
+		},
+		{
+			name: "remote rejects duplicate secret_headers names",
+			mutate: func(m *Manifest) {
+				*m = Manifest{
+					Name:          "cloud-sql",
+					Transport:     TransportHTTP,
+					URL:           "https://sqladmin.googleapis.com/mcp",
+					SecretHeaders: SecretHeaders{Keys: []string{"x-routing-key", "X-Routing-Key"}},
+					Enabled:       true,
+					Clients:       []string{"codex"},
+				}
+			},
+			expects: "duplicate secret_headers name",
+		},
+		{
 			name: "remote rejects negative timeout",
 			mutate: func(m *Manifest) {
 				*m = Manifest{
@@ -244,5 +279,53 @@ func TestManifestValidateRemoteOK(t *testing.T) {
 	}
 	if !m.IsRemote() {
 		t.Fatalf("expected remote manifest to report IsRemote")
+	}
+}
+
+func TestIsSecretHeaderName(t *testing.T) {
+	secret := []string{
+		"Authorization", "authorization", "Proxy-Authorization", "Cookie",
+		"X-Api-Key", "api-key", "ApiKey", "X-Auth-Token", "X-Goog-Api-Key",
+		"Session-Secret", "X-Access-Token",
+	}
+	for _, name := range secret {
+		if !IsSecretHeaderName(name) {
+			t.Fatalf("expected %q to be a secret header name", name)
+		}
+	}
+	public := []string{"x-goog-user-project", "X-Figma-Region", "Accept", "Content-Type", "X-Request-Id"}
+	for _, name := range public {
+		if IsSecretHeaderName(name) {
+			t.Fatalf("expected %q to be a non-secret header name", name)
+		}
+	}
+}
+
+func TestManifestSecretHeaderDetection(t *testing.T) {
+	m := Manifest{
+		Name:      "cloud-sql",
+		Transport: TransportHTTP,
+		URL:       "https://example.com/mcp",
+		Headers:   map[string]string{"x-goog-user-project": "project-id"},
+		Enabled:   true,
+		Clients:   []string{"claude-code"},
+	}
+	if m.HasSecretValue() {
+		t.Fatalf("expected routing-only headers to be non-secret")
+	}
+
+	m.Headers["Authorization"] = "Bearer token"
+	if !m.HasSecretValue() {
+		t.Fatalf("expected built-in credential header to be secret without annotation")
+	}
+	if names := m.SecretHeaderNames(); len(names) != 1 || names[0] != "Authorization" {
+		t.Fatalf("expected Authorization as the secret header, got: %#v", names)
+	}
+
+	delete(m.Headers, "Authorization")
+	m.Headers["x-routing-key"] = "internal-value"
+	m.SecretHeaders.Keys = []string{"X-Routing-Key"}
+	if !m.HasSecretValue() {
+		t.Fatalf("expected explicitly marked header to be secret (case-insensitive)")
 	}
 }

--- a/internal/registry/manifest_test.go
+++ b/internal/registry/manifest_test.go
@@ -287,6 +287,7 @@ func TestIsSecretHeaderName(t *testing.T) {
 		"Authorization", "authorization", "Proxy-Authorization", "Cookie",
 		"X-Api-Key", "api-key", "ApiKey", "X-Auth-Token", "X-Goog-Api-Key",
 		"Session-Secret", "X-Access-Token",
+		"X_API_KEY", "X-API_KEY", "Api_Key", "ACCESS_TOKEN",
 	}
 	for _, name := range secret {
 		if !IsSecretHeaderName(name) {

--- a/internal/registry/parser.go
+++ b/internal/registry/parser.go
@@ -14,6 +14,7 @@ const (
 	sectionHeaders     = "headers"
 	sectionRequiredEnv = "required_env"
 	sectionSecretEnv   = "secret_env"
+	sectionSecretHdrs  = "secret_headers"
 )
 
 // ParseManifest parses a constrained TOML manifest format and rejects unknown fields.
@@ -47,7 +48,7 @@ func ParseManifest(data []byte) (Manifest, error) {
 			}
 			name := strings.TrimSpace(line[1 : len(line)-1])
 			switch name {
-			case sectionEnv, sectionHeaders, sectionRequiredEnv, sectionSecretEnv:
+			case sectionEnv, sectionHeaders, sectionRequiredEnv, sectionSecretEnv, sectionSecretHdrs:
 				section = name
 			default:
 				return Manifest{}, fmt.Errorf("line %d: unknown section %q", lineNo, name)
@@ -98,6 +99,15 @@ func ParseManifest(data []byte) (Manifest, error) {
 				return Manifest{}, fmt.Errorf("line %d: invalid secret_env keys: %w", lineNo, err)
 			}
 			m.SecretEnv.Keys = arr
+		case sectionSecretHdrs:
+			if key != "keys" {
+				return Manifest{}, fmt.Errorf("line %d: unknown key %q in [secret_headers]", lineNo, key)
+			}
+			arr, err := parseStringArray(value)
+			if err != nil {
+				return Manifest{}, fmt.Errorf("line %d: invalid secret_headers keys: %w", lineNo, err)
+			}
+			m.SecretHeaders.Keys = arr
 		default:
 			return Manifest{}, fmt.Errorf("line %d: unknown parse section", lineNo)
 		}
@@ -176,6 +186,13 @@ func MarshalManifest(m Manifest) ([]byte, error) {
 		keys := append([]string(nil), m.SecretEnv.Keys...)
 		sort.Strings(keys)
 		b.WriteString("\n[secret_env]\n")
+		fmt.Fprintf(&b, "keys = %s\n", formatStringArray(keys))
+	}
+
+	if len(m.SecretHeaders.Keys) > 0 {
+		keys := append([]string(nil), m.SecretHeaders.Keys...)
+		sort.Strings(keys)
+		b.WriteString("\n[secret_headers]\n")
 		fmt.Fprintf(&b, "keys = %s\n", formatStringArray(keys))
 	}
 

--- a/internal/registry/parser_test.go
+++ b/internal/registry/parser_test.go
@@ -77,7 +77,9 @@ func TestParseAndMarshalRemoteManifestRoundTrip(t *testing.T) {
 		Description:   "Cloud SQL remote MCP",
 		Headers: map[string]string{
 			"x-goog-user-project": "example-project",
+			"x-routing-key":       "internal-value",
 		},
+		SecretHeaders: SecretHeaders{Keys: []string{"x-routing-key"}},
 	}
 
 	encoded, err := MarshalManifest(in)
@@ -91,6 +93,8 @@ func TestParseAndMarshalRemoteManifestRoundTrip(t *testing.T) {
 		`oauth_resource = "https://sqladmin.googleapis.com/"`,
 		"[headers]",
 		`x-goog-user-project = "example-project"`,
+		"[secret_headers]",
+		`keys = ["x-routing-key"]`,
 	} {
 		if !strings.Contains(string(encoded), want) {
 			t.Fatalf("expected encoded manifest to contain %q, got:\n%s", want, encoded)
@@ -109,6 +113,9 @@ func TestParseAndMarshalRemoteManifestRoundTrip(t *testing.T) {
 	}
 	if out.Headers["x-goog-user-project"] != "example-project" {
 		t.Fatalf("expected headers to survive roundtrip, got: %#v", out.Headers)
+	}
+	if len(out.SecretHeaders.Keys) != 1 || out.SecretHeaders.Keys[0] != "x-routing-key" {
+		t.Fatalf("expected secret_headers to survive roundtrip, got: %#v", out.SecretHeaders)
 	}
 }
 

--- a/internal/registry/snapshot.go
+++ b/internal/registry/snapshot.go
@@ -17,10 +17,13 @@ const (
 	snapshotVersionV4 = 4
 	snapshotVersionV5 = 5
 	snapshotVersionV6 = 6
-	// SnapshotVersion 7 adds remote transport fields on server manifests;
+	// snapshotVersionV7 added remote transport fields on server manifests;
 	// pre-remote importers reject v7 snapshots cleanly by version instead of
 	// misreading a remote server as a stdio manifest without a command.
-	SnapshotVersion = 7
+	snapshotVersionV7 = 7
+	// SnapshotVersion 8 adds [secret_headers]; older importers reject by
+	// version instead of silently dropping the secrecy annotation.
+	SnapshotVersion = 8
 )
 
 type Snapshot struct {
@@ -314,7 +317,7 @@ func ImportSnapshot(store *Store, snapshot Snapshot, apply bool) (ImportResult, 
 }
 
 func (s Snapshot) Validate() error {
-	if s.Version != snapshotVersionV1 && s.Version != snapshotVersionV2 && s.Version != snapshotVersionV3 && s.Version != snapshotVersionV4 && s.Version != snapshotVersionV5 && s.Version != snapshotVersionV6 && s.Version != SnapshotVersion {
+	if s.Version != snapshotVersionV1 && s.Version != snapshotVersionV2 && s.Version != snapshotVersionV3 && s.Version != snapshotVersionV4 && s.Version != snapshotVersionV5 && s.Version != snapshotVersionV6 && s.Version != snapshotVersionV7 && s.Version != SnapshotVersion {
 		return fmt.Errorf("unsupported snapshot version %d (supported: %d)", s.Version, SnapshotVersion)
 	}
 	if s.Version == snapshotVersionV1 && len(s.Rings) > 0 {
@@ -329,8 +332,11 @@ func (s Snapshot) Validate() error {
 	if s.Version < snapshotVersionV5 && snapshotHasRingContracts(s) {
 		return fmt.Errorf("snapshot version %d does not support ring contracts", s.Version)
 	}
-	if s.Version < SnapshotVersion && snapshotHasRemoteServers(s) {
+	if s.Version < snapshotVersionV7 && snapshotHasRemoteServers(s) {
 		return fmt.Errorf("snapshot version %d does not support remote transports", s.Version)
+	}
+	if s.Version < SnapshotVersion && snapshotHasSecretHeaders(s) {
+		return fmt.Errorf("snapshot version %d does not support secret_headers", s.Version)
 	}
 
 	seen := map[string]struct{}{}
@@ -453,7 +459,15 @@ func manifestsEqual(a, b Manifest) bool {
 	bSecret := append([]string(nil), b.SecretEnv.Keys...)
 	sort.Strings(aSecret)
 	sort.Strings(bSecret)
-	return slices.Equal(aSecret, bSecret)
+	if !slices.Equal(aSecret, bSecret) {
+		return false
+	}
+
+	aSecretHeaders := append([]string(nil), a.SecretHeaders.Keys...)
+	bSecretHeaders := append([]string(nil), b.SecretHeaders.Keys...)
+	sort.Strings(aSecretHeaders)
+	sort.Strings(bSecretHeaders)
+	return slices.Equal(aSecretHeaders, bSecretHeaders)
 }
 
 func ringsEqual(a, b Ring) bool {
@@ -609,6 +623,15 @@ func snapshotHasRingSkills(snapshot Snapshot) bool {
 func snapshotHasRemoteServers(snapshot Snapshot) bool {
 	for _, server := range snapshot.Servers {
 		if server.IsRemote() {
+			return true
+		}
+	}
+	return false
+}
+
+func snapshotHasSecretHeaders(snapshot Snapshot) bool {
+	for _, server := range snapshot.Servers {
+		if len(server.SecretHeaders.Keys) > 0 {
 			return true
 		}
 	}

--- a/internal/registry/snapshot_test.go
+++ b/internal/registry/snapshot_test.go
@@ -215,6 +215,25 @@ func TestParseSnapshotV6RejectsRemoteServers(t *testing.T) {
 	}
 }
 
+func TestParseSnapshotV7RejectsSecretHeaders(t *testing.T) {
+	payload := []byte(`{"version":7,"servers":[{"name":"cloud-sql","transport":"http","url":"https://example.com/mcp","secret_headers":{"keys":["x-routing-key"]},"enabled":true,"clients":["claude-code"]}]}`)
+	_, err := ParseSnapshotJSON(payload)
+	if err == nil || !strings.Contains(err.Error(), "does not support secret_headers") {
+		t.Fatalf("expected v7 secret-headers error, got: %v", err)
+	}
+}
+
+func TestParseSnapshotV8AcceptsSecretHeaders(t *testing.T) {
+	payload := []byte(`{"version":8,"servers":[{"name":"cloud-sql","transport":"http","url":"https://example.com/mcp","secret_headers":{"keys":["x-routing-key"]},"enabled":true,"clients":["claude-code"]}]}`)
+	snapshot, err := ParseSnapshotJSON(payload)
+	if err != nil {
+		t.Fatalf("parse v8 snapshot with secret_headers: %v", err)
+	}
+	if len(snapshot.Servers) != 1 || len(snapshot.Servers[0].SecretHeaders.Keys) != 1 {
+		t.Fatalf("expected secret_headers to parse, got: %#v", snapshot.Servers)
+	}
+}
+
 func TestParseSnapshotV7AcceptsRemoteServers(t *testing.T) {
 	payload := []byte(`{"version":7,"servers":[{"name":"cloud-sql","transport":"http","url":"https://example.com/mcp","enabled":true,"clients":["codex"]}]}`)
 	snapshot, err := ParseSnapshotJSON(payload)


### PR DESCRIPTION
## Summary

Third and final PR of the remote MCP sequence (follows #63, #64). Claude Code and Gemini materialize remote manifests as client-native entries, guarded by a header secrecy policy for repo-scoped configs.

**Materialization** (shapes verified against each client's docs)
- `claude-code`: `{"type": "http"|"sse", "url", "headers"}` in `.mcp.json` / `~/.claude.json`; raw-match validation (from #60) models the new fields, and canonicalization strips empty `headers` like `args`/`env`
- `gemini`: `httpUrl` (Streamable HTTP) or `url` (SSE) plus `headers` in `settings.json`, matching gemini-cli's field-per-transport schema
- `oauth_resource` and `timeout_ms` have no equivalent in either client and are not emitted; ring render also stops emitting the unvalidated `timeout` JSON field

**Header secrecy policy (hybrid, as decided)**
- new `[secret_headers]` manifest section (+ `madari add --secret-header`) mirrors `[secret_env]`
- **well-known credential headers are always secret** — `Authorization`, `Proxy-Authorization`, `Cookie`, api-key variants, and names containing `token`/`secret` (case-insensitive) — so a forgotten annotation cannot commit a bearer token
- entries with secret header values are refused per entry at project scope and scrubbed if previously materialized (same v0.1.5 machinery as secret env); `--scope user` materializes them normally
- `ring render` never emits secret header values; the warning names the omitted headers
- snapshot version bumps to 8 with a validation gate, so pre-`secret_headers` importers reject by version instead of silently dropping the annotation (also pinned the v7 remote gate that would have drifted with the bump)

**Status after this PR**: remote support is codex (`http`), claude-code (`http`+`sse`), gemini (`http`+`sse`). Claude-desktop (connectors UI, not config-file based) and vibe stay pending with the usual `unsupported remote` reporting.

## Test plan

- registry: `IsSecretHeaderName` matrix, secret-header detection (built-in + explicit + case-insensitive), `[secret_headers]` validation (remote-only, dupes, charset) and round-trip, snapshot v7-rejects/v8-accepts
- claude-code adapter: http lifecycle (add/update, non-secret headers materialize), sse entries, project-scope refusal + no file creation, user-scope materialization, credential-header scrub from project config
- gemini adapter: httpUrl vs url shape per transport, headers, refusal/user-scope pair
- cmd: render tests for both clients (exact output, secret header omitted with warning), unsupported-target render moved to claude-desktop
- manual sandbox: mixed secret/non-secret header manifest across both clients — project refuse, user-scope materialize, renders omit `Authorization`, doctor clean with no pending suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)