### PR TITLE
[codex] Add bearer token env remote auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ madari add linear \
 madari sync claude-code --scope user
 ```
 
+Remote servers that expect a bearer token from the runtime environment can
+store only the env var name. Codex materializes this as
+`bearer_token_env_var`, keeping the token value out of Madari and repo files:
+
+```bash
+madari add cloud-sql \
+  --transport http \
+  --url https://sqladmin.googleapis.com/mcp \
+  --bearer-token-env-var CLOUDSQL_MCP_TOKEN \
+  --client codex
+
+madari sync codex
+```
+
 Create a ring when a few capabilities belong together:
 
 ```bash
@@ -122,6 +136,8 @@ is useful for temporary sessions and experiments.
 - Remote header values for credential headers (`Authorization`, api-key and
   token variants) and `--secret-header` names follow the same policy, and
   `ring render` never emits them
+- Bearer token env references store only the env var name; the token value
+  stays in the runtime environment
 - Diagnostics through `madari doctor`, `madari status`, and `madari ring status`
 
 ## Supported Clients
@@ -136,7 +152,8 @@ Madari can sync MCP servers for:
 
 Remote (`http`/`sse`) servers currently materialize for `claude-code` and
 `gemini` (both transports) and `codex` (`http` only); other targets store
-remote manifests and report them as pending.
+remote manifests and report them as pending. Remote entries that require
+`bearer_token_env_var` currently materialize only for `codex`.
 
 Madari can materialize skills for:
 

--- a/cmd/madari/client_targets.go
+++ b/cmd/madari/client_targets.go
@@ -22,8 +22,11 @@ type clientTarget struct {
 	// ringRenderTimeout marks renderers that emit timeout_ms as the
 	// client's per-server timeout field for remote entries.
 	ringRenderTimeout bool
-	userScope         bool
-	skillRoots        skillTargetRoots
+	// remoteBearerTokenEnv marks clients that can read remote bearer tokens
+	// from an env var reference without Madari storing the token value.
+	remoteBearerTokenEnv bool
+	userScope            bool
+	skillRoots           skillTargetRoots
 }
 
 var clientTargets = []clientTarget{
@@ -44,9 +47,10 @@ var clientTargets = []clientTarget{
 		},
 	},
 	{
-		target:             codex.Target,
-		syncAdapter:        codex.Adapter{},
-		ringConfigRenderer: renderCodexTOML,
+		target:               codex.Target,
+		syncAdapter:          codex.Adapter{},
+		ringConfigRenderer:   renderCodexTOML,
+		remoteBearerTokenEnv: true,
 		skillRoots: skillTargetRoots{
 			project: defaultProjectSkillRoot(".agents", "skills"),
 			user:    defaultHomeSkillRoot(".agents", "skills"),
@@ -101,13 +105,8 @@ func ringRenderTargetsFromClientTargets() map[string]ringRenderTarget {
 	targets := map[string]ringRenderTarget{}
 	for _, ct := range clientTargets {
 		if ct.ringConfigRenderer != nil {
-			supportsRemote := func(string) bool { return false }
-			if ct.syncAdapter != nil {
-				supportsRemote = ct.syncAdapter.SupportsRemote
-			}
 			targets[ct.target] = ringRenderTarget{
 				target:             ct.target,
-				supportsRemote:     supportsRemote,
 				emitsRemoteTimeout: ct.ringRenderTimeout,
 				render:             ct.ringConfigRenderer,
 			}
@@ -139,4 +138,9 @@ func supportedSkillTargets() []string {
 func supportsSkillMaterialization(target string) bool {
 	ct, ok := clientTargetByName(target)
 	return ok && ct.skillRoots.supported()
+}
+
+func supportsRemoteBearerTokenEnv(target string) bool {
+	ct, ok := clientTargetByName(target)
+	return ok && ct.remoteBearerTokenEnv
 }

--- a/cmd/madari/json_output.go
+++ b/cmd/madari/json_output.go
@@ -22,13 +22,14 @@ type listJSON struct {
 }
 
 type serverJSON struct {
-	Name      string   `json:"name"`
-	Enabled   bool     `json:"enabled"`
-	Transport string   `json:"transport"`
-	Command   string   `json:"command"`
-	URL       string   `json:"url,omitempty"`
-	Clients   []string `json:"clients"`
-	Sources   []string `json:"sources"`
+	Name              string   `json:"name"`
+	Enabled           bool     `json:"enabled"`
+	Transport         string   `json:"transport"`
+	Command           string   `json:"command"`
+	URL               string   `json:"url,omitempty"`
+	BearerTokenEnvVar string   `json:"bearer_token_env_var,omitempty"`
+	Clients           []string `json:"clients"`
+	Sources           []string `json:"sources"`
 }
 
 type statusJSON struct {
@@ -111,14 +112,15 @@ type driftJSON struct {
 }
 
 type doctorServerJSON struct {
-	Name      string      `json:"name"`
-	Enabled   bool        `json:"enabled"`
-	Transport string      `json:"transport"`
-	Clients   []string    `json:"clients"`
-	Command   string      `json:"command"`
-	URL       string      `json:"url,omitempty"`
-	Status    string      `json:"status"`
-	Issues    []issueJSON `json:"issues"`
+	Name              string      `json:"name"`
+	Enabled           bool        `json:"enabled"`
+	Transport         string      `json:"transport"`
+	Clients           []string    `json:"clients"`
+	Command           string      `json:"command"`
+	URL               string      `json:"url,omitempty"`
+	BearerTokenEnvVar string      `json:"bearer_token_env_var,omitempty"`
+	Status            string      `json:"status"`
+	Issues            []issueJSON `json:"issues"`
 }
 
 type issueJSON struct {

--- a/cmd/madari/render_targets.go
+++ b/cmd/madari/render_targets.go
@@ -11,22 +11,20 @@ import (
 
 // renderedServer is the self-contained client config entry ring render emits.
 type renderedServer struct {
-	Transport      string            `json:"type,omitempty"`
-	Command        string            `json:"command,omitempty"`
-	Args           []string          `json:"args,omitempty"`
-	URL            string            `json:"url,omitempty"`
-	Headers        map[string]string `json:"headers,omitempty"`
-	TimeoutMS      int               `json:"timeout,omitempty"`
-	OAuthResource  string            `json:"-"`
-	Env            map[string]string `json:"env,omitempty"`
-	RuntimeEnvKeys []string          `json:"-"`
+	Transport         string            `json:"type,omitempty"`
+	Command           string            `json:"command,omitempty"`
+	Args              []string          `json:"args,omitempty"`
+	URL               string            `json:"url,omitempty"`
+	Headers           map[string]string `json:"headers,omitempty"`
+	TimeoutMS         int               `json:"timeout,omitempty"`
+	OAuthResource     string            `json:"-"`
+	BearerTokenEnvVar string            `json:"-"`
+	Env               map[string]string `json:"env,omitempty"`
+	RuntimeEnvKeys    []string          `json:"-"`
 }
 
 type ringRenderTarget struct {
 	target string
-	// supportsRemote mirrors the sync adapter's per-transport remote
-	// capability so render and sync never disagree about materialization.
-	supportsRemote func(transport string) bool
 	// emitsRemoteTimeout is true when the renderer carries timeout_ms into
 	// the client's per-server timeout field; targets without an equivalent
 	// (codex) warn instead.
@@ -95,6 +93,9 @@ func renderCodexTOML(out io.Writer, servers map[string]renderedServer) error {
 			fmt.Fprintf(out, "url = %s\n", tomlString(entry.URL))
 			if entry.OAuthResource != "" {
 				fmt.Fprintf(out, "oauth_resource = %s\n", tomlString(entry.OAuthResource))
+			}
+			if entry.BearerTokenEnvVar != "" {
+				fmt.Fprintf(out, "bearer_token_env_var = %s\n", tomlString(entry.BearerTokenEnvVar))
 			}
 			if len(entry.Headers) > 0 {
 				fmt.Fprintln(out)

--- a/cmd/madari/ring.go
+++ b/cmd/madari/ring.go
@@ -411,8 +411,12 @@ func (a cliApp) cmdRingRender(args []string) error {
 			continue
 		}
 		if manifest.IsRemote() {
-			if !renderTarget.supportsRemote(manifest.TransportType()) {
-				fmt.Fprintf(a.stderr, "warning: ring member %s uses %s transport, which %s render does not support yet; omitted\n", member, manifest.TransportType(), target)
+			if detail, unsupported := unsupportedRemoteForTarget(manifest, target); unsupported {
+				if detail.Auth != "" {
+					fmt.Fprintf(a.stderr, "warning: ring member %s requires %s, which %s render does not support yet; omitted\n", member, detail.Auth, target)
+				} else {
+					fmt.Fprintf(a.stderr, "warning: ring member %s uses %s transport, which %s render does not support yet; omitted\n", member, detail.Transport, target)
+				}
 				continue
 			}
 			timeoutMS := manifest.TimeoutMS
@@ -431,11 +435,12 @@ func (a cliApp) cmdRingRender(args []string) error {
 				fmt.Fprintf(a.stderr, "warning: ring member %s: secret header values omitted from render: %s\n", member, strings.Join(secretNames, ", "))
 			}
 			servers[member] = renderedServer{
-				Transport:     manifest.TransportType(),
-				URL:           manifest.URL,
-				Headers:       headers,
-				TimeoutMS:     timeoutMS,
-				OAuthResource: manifest.OAuthResource,
+				Transport:         manifest.TransportType(),
+				URL:               manifest.URL,
+				Headers:           headers,
+				TimeoutMS:         timeoutMS,
+				OAuthResource:     manifest.OAuthResource,
+				BearerTokenEnvVar: manifest.BearerTokenEnvVar,
 			}
 			continue
 		}

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -323,6 +323,7 @@ func (a cliApp) cmdAdd(args []string) error {
 	var transport string
 	var url string
 	var oauthResource string
+	var bearerTokenEnvVar string
 	var description string
 	var disabled bool
 	var timeoutMS int
@@ -338,6 +339,7 @@ func (a cliApp) cmdAdd(args []string) error {
 	fs.StringVar(&transport, "transport", "", "Server transport (stdio, http, or sse; default: stdio)")
 	fs.StringVar(&url, "url", "", "Remote MCP server URL for http/sse transports")
 	fs.StringVar(&oauthResource, "oauth-resource", "", "OAuth resource for remote MCP clients that support it")
+	fs.StringVar(&bearerTokenEnvVar, "bearer-token-env-var", "", "Runtime env key containing a bearer token for remote MCP clients that support it")
 	fs.StringVar(&description, "description", "", "Server description")
 	fs.IntVar(&timeoutMS, "timeout-ms", 0, "Remote MCP timeout in milliseconds")
 	fs.BoolVar(&disabled, "disabled", false, "Create server in disabled state")
@@ -389,21 +391,22 @@ func (a cliApp) cmdAdd(args []string) error {
 	}
 
 	manifest := registry.Manifest{
-		Name:          name,
-		Transport:     transport,
-		Command:       resolvedCommand,
-		Args:          append([]string(nil), cmdArgs...),
-		URL:           strings.TrimSpace(url),
-		Headers:       headers,
-		TimeoutMS:     timeoutMS,
-		OAuthResource: strings.TrimSpace(oauthResource),
-		Enabled:       !disabled,
-		Clients:       append([]string(nil), clients...),
-		Description:   description,
-		Env:           env,
-		RequiredEnv:   registry.RequiredEnv{Keys: append([]string(nil), requiredEnv...)},
-		SecretEnv:     registry.SecretEnv{Keys: append([]string(nil), secretEnv...)},
-		SecretHeaders: registry.SecretHeaders{Keys: append([]string(nil), secretHeaders...)},
+		Name:              name,
+		Transport:         transport,
+		Command:           resolvedCommand,
+		Args:              append([]string(nil), cmdArgs...),
+		URL:               strings.TrimSpace(url),
+		Headers:           headers,
+		TimeoutMS:         timeoutMS,
+		OAuthResource:     strings.TrimSpace(oauthResource),
+		BearerTokenEnvVar: strings.TrimSpace(bearerTokenEnvVar),
+		Enabled:           !disabled,
+		Clients:           append([]string(nil), clients...),
+		Description:       description,
+		Env:               env,
+		RequiredEnv:       registry.RequiredEnv{Keys: append([]string(nil), requiredEnv...)},
+		SecretEnv:         registry.SecretEnv{Keys: append([]string(nil), secretEnv...)},
+		SecretHeaders:     registry.SecretHeaders{Keys: append([]string(nil), secretHeaders...)},
 	}
 
 	if err := a.store.Add(manifest); err != nil {
@@ -457,13 +460,14 @@ func (a cliApp) cmdList(args []string) error {
 			clients := append([]string(nil), manifest.Clients...)
 			sort.Strings(clients)
 			payload.Servers = append(payload.Servers, serverJSON{
-				Name:      manifest.Name,
-				Enabled:   manifest.Enabled,
-				Transport: manifest.TransportType(),
-				Command:   manifest.Command,
-				URL:       manifest.URL,
-				Clients:   nonNilStrings(clients),
-				Sources:   nonNilStrings(managedSources[manifest.Name]),
+				Name:              manifest.Name,
+				Enabled:           manifest.Enabled,
+				Transport:         manifest.TransportType(),
+				Command:           manifest.Command,
+				URL:               manifest.URL,
+				BearerTokenEnvVar: manifest.BearerTokenEnvVar,
+				Clients:           nonNilStrings(clients),
+				Sources:           nonNilStrings(managedSources[manifest.Name]),
 			})
 		}
 		return writeJSON(a.stdout, payload)
@@ -892,14 +896,15 @@ func (a cliApp) cmdDoctor(args []string) error {
 				})
 			}
 			payload.Servers = append(payload.Servers, doctorServerJSON{
-				Name:      server.Name,
-				Enabled:   server.Enabled,
-				Transport: server.Transport,
-				Clients:   nonNilStrings(server.Clients),
-				Command:   server.Command,
-				URL:       server.URL,
-				Status:    string(server.Status),
-				Issues:    issues,
+				Name:              server.Name,
+				Enabled:           server.Enabled,
+				Transport:         server.Transport,
+				Clients:           nonNilStrings(server.Clients),
+				Command:           server.Command,
+				URL:               server.URL,
+				BearerTokenEnvVar: server.BearerTokenEnvVar,
+				Status:            string(server.Status),
+				Issues:            issues,
 			})
 		}
 		for _, manifestError := range report.ManifestErrors {
@@ -1395,7 +1400,7 @@ func manifestEndpoint(manifest registry.Manifest) string {
 func doctorEndpointDetail(server doctor.ServerReport) string {
 	switch server.Transport {
 	case registry.TransportHTTP, registry.TransportSSE:
-		pending := remotePendingTargets(server.Clients, server.Transport)
+		pending := remotePendingTargets(server.Clients, server.Transport, server.BearerTokenEnvVar)
 		if len(pending) == 0 {
 			return fmt.Sprintf("url=%s", server.URL)
 		}
@@ -1406,15 +1411,14 @@ func doctorEndpointDetail(server doctor.ServerReport) string {
 }
 
 // remotePendingTargets returns the manifest's sync targets whose adapters do
-// not materialize this remote transport yet.
-func remotePendingTargets(targets []string, transport string) []string {
+// not materialize this remote transport/auth combination yet.
+func remotePendingTargets(targets []string, transport, bearerTokenEnvVar string) []string {
 	pending := []string{}
 	for _, target := range targets {
-		adapter, known := syncAdapters[target]
-		if !known {
+		if _, known := syncAdapters[target]; !known {
 			continue
 		}
-		if !adapter.SupportsRemote(transport) {
+		if !targetSupportsRemoteManifest(target, transport, bearerTokenEnvVar) {
 			pending = append(pending, target)
 		}
 	}
@@ -1423,8 +1427,45 @@ func remotePendingTargets(targets []string, transport string) []string {
 }
 
 type unsupportedRemoteManifest struct {
-	Name      string
+	Name   string
+	Detail remoteUnsupportedDetail
+}
+
+type remoteUnsupportedDetail struct {
 	Transport string
+	Auth      string
+}
+
+func targetSupportsRemoteManifest(target, transport, bearerTokenEnvVar string) bool {
+	adapter, known := syncAdapters[target]
+	if !known || !adapter.SupportsRemote(transport) {
+		return false
+	}
+	if strings.TrimSpace(bearerTokenEnvVar) != "" && !supportsRemoteBearerTokenEnv(target) {
+		return false
+	}
+	return true
+}
+
+func unsupportedRemoteForTarget(manifest registry.Manifest, target string) (remoteUnsupportedDetail, bool) {
+	adapter, known := syncAdapters[target]
+	if !known || !adapter.SupportsRemote(manifest.TransportType()) {
+		return remoteUnsupportedDetail{Transport: manifest.TransportType()}, true
+	}
+	if manifest.RequiresBearerTokenEnv() && !supportsRemoteBearerTokenEnv(target) {
+		return remoteUnsupportedDetail{
+			Transport: manifest.TransportType(),
+			Auth:      "bearer_token_env_var auth",
+		}, true
+	}
+	return remoteUnsupportedDetail{}, false
+}
+
+func remoteUnsupportedWarning(name, target, action string, detail remoteUnsupportedDetail) string {
+	if detail.Auth != "" {
+		return fmt.Sprintf("remote %s requires %s; stored in registry, but %s %s does not materialize %s yet", name, detail.Auth, target, action, detail.Auth)
+	}
+	return fmt.Sprintf("remote %s uses %s transport; stored in registry, but %s %s does not materialize %s transports yet", name, detail.Transport, target, action, detail.Transport)
 }
 
 func remoteSkipNames(skips []unsupportedRemoteManifest) []string {
@@ -1437,7 +1478,6 @@ func remoteSkipNames(skips []unsupportedRemoteManifest) []string {
 }
 
 func filterSyncableManifests(manifests []registry.Manifest, target string) ([]registry.Manifest, []string, []unsupportedRemoteManifest) {
-	adapter, adapterKnown := syncAdapters[target]
 	out := make([]registry.Manifest, 0, len(manifests))
 	var skipped []string
 	var unsupportedRemote []unsupportedRemoteManifest
@@ -1447,11 +1487,14 @@ func filterSyncableManifests(manifests []registry.Manifest, target string) ([]re
 			continue
 		}
 		if manifest.IsRemote() {
-			if !adapterKnown || !adapter.SupportsRemote(manifest.TransportType()) {
+			if detail, unsupported := unsupportedRemoteForTarget(manifest, target); unsupported {
 				unsupportedRemote = append(unsupportedRemote, unsupportedRemoteManifest{
-					Name:      manifest.Name,
-					Transport: manifest.TransportType(),
+					Name:   manifest.Name,
+					Detail: detail,
 				})
+				if detail.Auth != "" {
+					manifest.Enabled = false
+				}
 			}
 			out = append(out, manifest)
 			continue
@@ -1630,7 +1673,7 @@ func printSyncSummary(stdout, stderr io.Writer, target, configPath string, dryRu
 	if len(unsupportedRemote) > 0 {
 		fmt.Fprintf(stdout, "unsupported remote: %s\n", formatNameList(remoteSkipNames(unsupportedRemote)))
 		for _, remote := range unsupportedRemote {
-			fmt.Fprintf(stderr, "warning: remote %s uses %s transport; stored in registry, but %s sync does not materialize %s transports yet\n", remote.Name, remote.Transport, target, remote.Transport)
+			fmt.Fprintf(stderr, "warning: %s\n", remoteUnsupportedWarning(remote.Name, target, "sync", remote.Detail))
 		}
 	}
 	if len(refused) > 0 {
@@ -1742,6 +1785,8 @@ func printAddHelp(out io.Writer) {
 	fmt.Fprintln(out, "                             well-known credential headers are always treated as secret")
 	fmt.Fprintln(out, "  --timeout-ms <ms>          Remote MCP timeout in milliseconds")
 	fmt.Fprintln(out, "  --oauth-resource <url>     OAuth resource for remote clients that support it")
+	fmt.Fprintln(out, "  --bearer-token-env-var <KEY>")
+	fmt.Fprintln(out, "                             Runtime env key containing a bearer token for remote clients that support it")
 	fmt.Fprintln(out, "  --client <client>          Target client id (required, repeatable)")
 	fmt.Fprintln(out, "  --arg <value>              Command argument (repeatable)")
 	fmt.Fprintln(out, "  --env KEY=VALUE            Environment variable (repeatable)")
@@ -1753,7 +1798,7 @@ func printAddHelp(out io.Writer) {
 	fmt.Fprintln(out, "Examples:")
 	fmt.Fprintln(out, "  madari add stewreads --command stewreads-mcp --client claude-desktop")
 	fmt.Fprintln(out, "  madari add mailer --command ./bin/mailer --client claude-desktop --required-env SMTP_PASSWORD")
-	fmt.Fprintln(out, "  madari add cloud-sql --transport http --url https://sqladmin.googleapis.com/mcp --client codex --oauth-resource https://sqladmin.googleapis.com/")
+	fmt.Fprintln(out, "  madari add cloud-sql --transport http --url https://sqladmin.googleapis.com/mcp --client codex --bearer-token-env-var CLOUDSQL_MCP_TOKEN")
 }
 
 func printInstallHelp(out io.Writer) {

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -194,6 +194,7 @@ func TestRunWithStoreAddRemoteHTTP(t *testing.T) {
 		"--url", "https://sqladmin.googleapis.com/mcp",
 		"--client", "codex",
 		"--oauth-resource", "https://sqladmin.googleapis.com/",
+		"--bearer-token-env-var", "CLOUDSQL_MCP_TOKEN",
 		"--timeout-ms", "30000",
 		"--header", "x-goog-user-project=example-project",
 	)
@@ -216,6 +217,9 @@ func TestRunWithStoreAddRemoteHTTP(t *testing.T) {
 	}
 	if manifest.OAuthResource != "https://sqladmin.googleapis.com/" {
 		t.Fatalf("unexpected oauth resource: %q", manifest.OAuthResource)
+	}
+	if manifest.BearerTokenEnvVar != "CLOUDSQL_MCP_TOKEN" {
+		t.Fatalf("unexpected bearer token env var: %q", manifest.BearerTokenEnvVar)
 	}
 	if manifest.TimeoutMS != 30000 {
 		t.Fatalf("unexpected timeout: %d", manifest.TimeoutMS)
@@ -2745,6 +2749,64 @@ func TestRunWithStoreSyncReportsUnsupportedRemote(t *testing.T) {
 	}
 }
 
+func TestRunWithStoreSyncReportsUnsupportedRemoteAuth(t *testing.T) {
+	store := newTestStore(t)
+
+	if result := runCmd(store, "add", "cloud-sql",
+		"--transport", "http",
+		"--url", "https://sqladmin.googleapis.com/mcp",
+		"--client", "claude-code",
+		"--bearer-token-env-var", "CLOUDSQL_MCP_TOKEN"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+
+	configPath := filepath.Join(t.TempDir(), ".mcp.json")
+	result := runCmd(store, "sync", "claude-code", "--dry-run", "--config-path", configPath)
+	if result.code != 0 {
+		t.Fatalf("sync dry-run failed: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	if !strings.Contains(result.stdout, "unsupported remote: cloud-sql") {
+		t.Fatalf("expected unsupported remote summary, got: %s", result.stdout)
+	}
+	if strings.Contains(result.stdout, "added: cloud-sql") {
+		t.Fatalf("expected auth-unsupported remote not to be added, got: %s", result.stdout)
+	}
+	if !strings.Contains(result.stderr, "cloud-sql requires bearer_token_env_var auth") ||
+		!strings.Contains(result.stderr, "stored in registry") ||
+		!strings.Contains(result.stderr, "claude-code sync does not materialize bearer_token_env_var auth yet") {
+		t.Fatalf("expected unsupported remote auth warning, got: %s", result.stderr)
+	}
+
+	result = runCmd(store, "sync", "claude-code", "--dry-run", "--json", "--config-path", configPath)
+	if result.code != 0 {
+		t.Fatalf("sync dry-run --json failed: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	expected := fmt.Sprintf(`{
+  "schema_version": 1,
+  "command": "sync",
+  "target": "claude-code",
+  "config_path": %q,
+  "dry_run": true,
+  "added": [],
+  "updated": [],
+  "removed": [],
+  "unchanged": [],
+  "skipped": [],
+  "unsupported_remote": [
+    "cloud-sql"
+  ],
+  "refused": [],
+  "skills_added": [],
+  "skills_updated": [],
+  "skills_removed": [],
+  "skills_unchanged": []
+}
+`, configPath)
+	if result.stdout != expected {
+		t.Fatalf("sync --json unsupported remote auth schema drift:\nwant:\n%s\ngot:\n%s", expected, result.stdout)
+	}
+}
+
 func TestRunWithStoreSyncCodexMaterializesRemote(t *testing.T) {
 	store := newTestStore(t)
 
@@ -2752,7 +2814,8 @@ func TestRunWithStoreSyncCodexMaterializesRemote(t *testing.T) {
 		"--transport", "http",
 		"--url", "https://sqladmin.googleapis.com/mcp",
 		"--client", "codex",
-		"--oauth-resource", "https://sqladmin.googleapis.com/"); result.code != 0 {
+		"--oauth-resource", "https://sqladmin.googleapis.com/",
+		"--bearer-token-env-var", "CLOUDSQL_MCP_TOKEN"); result.code != 0 {
 		t.Fatalf("setup add failed: %s", result.stderr)
 	}
 
@@ -2778,6 +2841,7 @@ func TestRunWithStoreSyncCodexMaterializesRemote(t *testing.T) {
 	for _, want := range []string{
 		"url = 'https://sqladmin.googleapis.com/mcp'",
 		"oauth_resource = 'https://sqladmin.googleapis.com/'",
+		"bearer_token_env_var = 'CLOUDSQL_MCP_TOKEN'",
 	} {
 		if !strings.Contains(string(payload), want) {
 			t.Fatalf("expected %q in codex config, got:\n%s", want, payload)
@@ -4466,6 +4530,7 @@ func TestRunWithStoreRingRenderCodexRemoteHTTP(t *testing.T) {
 		"--url", "https://sqladmin.googleapis.com/mcp",
 		"--client", "codex",
 		"--oauth-resource", "https://sqladmin.googleapis.com/",
+		"--bearer-token-env-var", "CLOUDSQL_MCP_TOKEN",
 		"--header", "x-goog-user-project=example-project"); result.code != 0 {
 		t.Fatalf("setup add cloud-sql failed: %s", result.stderr)
 	}
@@ -4480,6 +4545,7 @@ func TestRunWithStoreRingRenderCodexRemoteHTTP(t *testing.T) {
 	want := `[mcp_servers.cloud-sql]
 url = "https://sqladmin.googleapis.com/mcp"
 oauth_resource = "https://sqladmin.googleapis.com/"
+bearer_token_env_var = "CLOUDSQL_MCP_TOKEN"
 
 [mcp_servers.cloud-sql.http_headers]
 x-goog-user-project = "example-project"
@@ -4537,6 +4603,33 @@ func TestRunWithStoreRingRenderRemoteUnsupportedTarget(t *testing.T) {
 	}
 	if !strings.Contains(result.stderr, "uses http transport") || !strings.Contains(result.stderr, "does not support yet") {
 		t.Fatalf("expected unsupported remote warning, got: %s", result.stderr)
+	}
+}
+
+func TestRunWithStoreRingRenderRemoteUnsupportedAuth(t *testing.T) {
+	store := newTestStore(t)
+
+	if result := runCmd(store, "add", "cloud-sql",
+		"--transport", "http",
+		"--url", "https://sqladmin.googleapis.com/mcp",
+		"--client", "claude-code",
+		"--bearer-token-env-var", "CLOUDSQL_MCP_TOKEN"); result.code != 0 {
+		t.Fatalf("setup add cloud-sql failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "ring", "create", "cloudsql-readonly", "--member", "cloud-sql"); result.code != 0 {
+		t.Fatalf("ring create failed: %s", result.stderr)
+	}
+
+	result := runCmd(store, "ring", "render", "cloudsql-readonly", "--client", "claude-code")
+	if result.code != 0 {
+		t.Fatalf("ring render claude-code failed: %s", result.stderr)
+	}
+	if !strings.Contains(result.stdout, `"mcpServers": {}`) {
+		t.Fatalf("expected empty MCP config for unsupported remote auth, got:\n%s", result.stdout)
+	}
+	if !strings.Contains(result.stderr, "requires bearer_token_env_var auth") ||
+		!strings.Contains(result.stderr, "claude-code render does not support yet") {
+		t.Fatalf("expected unsupported auth warning, got: %s", result.stderr)
 	}
 }
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -16,13 +16,15 @@ madari remove <name>
 `madari add` defaults to `stdio`, where `--command` is required and is resolved
 to an absolute executable path. Remote manifests use `--transport http` or
 `--transport sse` with `--url`; optional remote metadata includes `--header`,
-`--secret-header`, `--timeout-ms`, and `--oauth-resource`. Remote manifests
-materialize for `codex` (`http` only), `claude-code`, and `gemini` (`http`
-and `sse`); the remaining targets and transports skip them until per-client
-support lands. Well-known credential headers, and names marked with
-`--secret-header`, are refused in repo-scoped configs. `madari list` and
-`madari doctor` show each server's transport and endpoint so remote entries
-are visible where materialization is pending.
+`--secret-header`, `--timeout-ms`, `--oauth-resource`, and
+`--bearer-token-env-var`. Remote manifests materialize for `codex` (`http`
+only), `claude-code`, and `gemini` (`http` and `sse`); the remaining targets,
+transports, and unsupported auth modes skip them until per-client support
+lands. Well-known credential headers, and names marked with `--secret-header`,
+are refused in repo-scoped configs. `--bearer-token-env-var` stores only the
+runtime env key that contains a bearer token. `madari list` and `madari doctor`
+show each server's transport and endpoint so remote entries are visible where
+materialization is pending.
 
 ## Install Workflow
 
@@ -64,7 +66,9 @@ Claude Code writes `type`/`url` entries with `headers` into its config
 Gemini writes `httpUrl` (Streamable HTTP) or `url` (SSE) entries with
 `headers`. `timeout_ms` is carried through as each client's per-server
 `timeout` field (milliseconds). `oauth_resource` has no equivalent in either
-client and is not emitted.
+client and is not emitted. Remote entries that require
+`bearer_token_env_var` stay pending for these clients until an equivalent
+auth config shape is validated.
 
 `codex` sync targets Codex's user config (`$CODEX_HOME/config.toml`, or
 `~/.codex/config.toml` when `CODEX_HOME` is unset). Static non-secret `[env]`
@@ -72,9 +76,10 @@ values are written under `[mcp_servers.<name>.env]`; `[required_env]` and
 `[secret_env]` keys are forwarded through `env_vars`, and static secret
 values are not written into Codex config. Codex also materializes managed
 remote Streamable HTTP entries as native `url` entries with optional
-`oauth_resource`, and manifest `[headers]` as Codex `http_headers`. `sse`
-manifests stay pending (Codex's documented remote support is Streamable
-HTTP), and `timeout_ms` has no Codex equivalent and is not emitted.
+`oauth_resource`, optional `bearer_token_env_var`, and manifest `[headers]`
+as Codex `http_headers`. `sse` manifests stay pending (Codex's documented
+remote support is Streamable HTTP), and `timeout_ms` has no Codex equivalent
+and is not emitted.
 
 `vibe` sync targets Vibe's user config (`$VIBE_HOME/config.toml`, or
 `~/.vibe/config.toml` when `VIBE_HOME` is unset). Static `[env]` values are
@@ -158,12 +163,13 @@ Render targets are independent from sync adapters. `claude-code`,
 Codex render output also emits `env_vars = [...]` for `[required_env]` and
 `[secret_env]` keys so runtime-provided environment values can be forwarded.
 Codex render also emits remote Streamable HTTP members as `url` entries with
-optional `oauth_resource` and `[headers]` as `http_headers`. Claude Code
-render emits remote members as `type`/`url`/`headers`; Gemini render emits
-`httpUrl` (Streamable HTTP) or `url` (SSE) with `headers`. Secret header
-values are never emitted by render — the warning names the headers to
-provide manually. Remote members are omitted with warnings for targets or
-transports without support (codex SSE, claude-desktop, vibe).
+optional `oauth_resource`, optional `bearer_token_env_var`, and `[headers]`
+as `http_headers`. Claude Code render emits remote members as
+`type`/`url`/`headers`; Gemini render emits `httpUrl` (Streamable HTTP) or
+`url` (SSE) with `headers`. Secret header values are never emitted by render —
+the warning names the headers to provide manually. Remote members are omitted
+with warnings for targets, transports, or auth modes without support (codex
+SSE, bearer-token-env auth outside Codex, claude-desktop, vibe).
 Ring skill members are not embedded in MCP render output; use `ring attach`
 for native skill materialization.
 Ephemeral-session recipe:

--- a/docs/manifest-spec.md
+++ b/docs/manifest-spec.md
@@ -19,6 +19,8 @@ Each managed server is stored as a TOML document.
   milliseconds. Emitted only for clients that support it.
 - `oauth_resource` (string, optional for `http`/`sse`): OAuth resource value
   for clients that support it.
+- `bearer_token_env_var` (string, optional for `http`/`sse`): runtime env key
+  containing a bearer token for clients that support env-referenced tokens.
 - `enabled` (bool, required): whether this server should be synced into clients.
 - `clients` (array of strings, required): client IDs.
 - `description` (string, optional): friendly description.
@@ -35,12 +37,19 @@ Known client IDs:
 sync-capable today. All are also render targets for `madari ring render`.
 Remote materialization is per client and per transport:
 
-- `codex`: `http` only, as native `url` entries plus optional OAuth metadata
-  and `[headers]` as `http_headers`.
+- `codex`: `http` only, as native `url` entries plus optional OAuth metadata,
+  optional `bearer_token_env_var`, and `[headers]` as `http_headers`.
 - `claude-code`: `http` and `sse`, as `type`/`url` entries with `headers`.
 - `gemini`: `http` (as `httpUrl`) and `sse` (as `url`), with `headers`.
 - `claude-desktop` and `vibe`: remote entries stay ineligible until their
   auth and config behavior is validated per client.
+
+Remote auth metadata is validated separately from transport support. For
+example, `claude-code` and `gemini` can materialize remote URLs, but entries
+that require `bearer_token_env_var` stay pending for those clients until an
+equivalent auth config shape is validated. `oauth_resource` is for clients and
+servers that support OAuth resource metadata; `bearer_token_env_var` stores
+only the env var name, never the bearer token value.
 
 ### `[headers]`
 
@@ -109,7 +118,7 @@ Remote HTTP server:
 name = "cloud-sql"
 transport = "http"
 url = "https://sqladmin.googleapis.com/mcp"
-oauth_resource = "https://sqladmin.googleapis.com/"
+bearer_token_env_var = "CLOUDSQL_MCP_TOKEN"
 enabled = true
 clients = ["codex"]
 description = "Official Cloud SQL remote MCP server"
@@ -124,6 +133,8 @@ description = "Official Cloud SQL remote MCP server"
 - `url` is required for `http` and `sse`.
 - Remote transports reject `command`, `args`, `[env]`, `[required_env]`, and
   `[secret_env]` because they are local process settings.
+- `bearer_token_env_var` is remote-only and must be a valid env key such as
+  `CLOUDSQL_MCP_TOKEN`.
 - `[secret_headers]` is remote-only; names must be valid header names and
   unique (case-insensitive).
 

--- a/internal/clients/claudecode/sync.go
+++ b/internal/clients/claudecode/sync.go
@@ -309,6 +309,9 @@ func entriesForTarget(manifests []registry.Manifest, userScope bool) map[string]
 			// ineligible
 		case manifest.IsRemote() && !supportsRemoteTransport(manifest.TransportType()):
 			// unsupported remote transports stay pending
+		case manifest.IsRemote() && manifest.RequiresBearerTokenEnv():
+			// bearer_token_env_var is not part of Claude Code .mcp.json.
+			// Keep the remote pending instead of emitting an unauthenticated URL.
 		case !userScope && manifest.HasSecretValue():
 			// covers static secret env values and secret header values;
 			// refusal at project scope keeps credentials out of .mcp.json

--- a/internal/clients/codex/sync.go
+++ b/internal/clients/codex/sync.go
@@ -259,13 +259,15 @@ func supportsRemoteTransport(transport string) bool {
 
 func materializeServer(manifest registry.Manifest) serverConfig {
 	if manifest.IsRemote() {
-		// Codex remote entries carry url, optional OAuth metadata, and
-		// static headers as http_headers. timeout_ms has no Codex
+		// Codex remote entries carry url, optional OAuth metadata,
+		// bearer-token env references, and static headers as http_headers.
+		// timeout_ms has no Codex
 		// equivalent and is deliberately not emitted (documented in the
 		// manifest spec).
 		entry := serverConfig{
-			URL:           manifest.URL,
-			OAuthResource: manifest.OAuthResource,
+			URL:               manifest.URL,
+			OAuthResource:     manifest.OAuthResource,
+			BearerTokenEnvVar: manifest.BearerTokenEnvVar,
 		}
 		if len(manifest.Headers) > 0 {
 			entry.HTTPHeaders = make(map[string]string, len(manifest.Headers))
@@ -330,6 +332,9 @@ func equalServer(a, b serverConfig) bool {
 		return false
 	}
 	if a.OAuthResource != b.OAuthResource {
+		return false
+	}
+	if a.BearerTokenEnvVar != b.BearerTokenEnvVar {
 		return false
 	}
 	if len(a.HTTPHeaders) != len(b.HTTPHeaders) {
@@ -450,6 +455,13 @@ func parseServer(name string, raw any) (serverConfig, error) {
 		}
 		entry.OAuthResource = oauthResource
 	}
+	if rawBearerTokenEnvVar, exists := table["bearer_token_env_var"]; exists {
+		bearerTokenEnvVar, ok := rawBearerTokenEnvVar.(string)
+		if !ok {
+			return serverConfig{}, fmt.Errorf("parse mcp_servers.%s.bearer_token_env_var: expected string", name)
+		}
+		entry.BearerTokenEnvVar = bearerTokenEnvVar
+	}
 	if headers, ok, err := optionalStringMap(table, "http_headers"); err != nil {
 		return serverConfig{}, fmt.Errorf("parse mcp_servers.%s.http_headers: %w", name, err)
 	} else if ok {
@@ -541,12 +553,13 @@ func optionalStringMap(table map[string]any, key string) (map[string]string, boo
 }
 
 type serverConfig struct {
-	Command       string            `toml:"command,omitempty"`
-	URL           string            `toml:"url,omitempty"`
-	OAuthResource string            `toml:"oauth_resource,omitempty"`
-	Enabled       *bool             `toml:"enabled,omitempty"`
-	Args          []string          `toml:"args,omitempty"`
-	EnvVars       []string          `toml:"env_vars,omitempty"`
-	Env           map[string]string `toml:"env,omitempty"`
-	HTTPHeaders   map[string]string `toml:"http_headers,omitempty"`
+	Command           string            `toml:"command,omitempty"`
+	URL               string            `toml:"url,omitempty"`
+	OAuthResource     string            `toml:"oauth_resource,omitempty"`
+	BearerTokenEnvVar string            `toml:"bearer_token_env_var,omitempty"`
+	Enabled           *bool             `toml:"enabled,omitempty"`
+	Args              []string          `toml:"args,omitempty"`
+	EnvVars           []string          `toml:"env_vars,omitempty"`
+	Env               map[string]string `toml:"env,omitempty"`
+	HTTPHeaders       map[string]string `toml:"http_headers,omitempty"`
 }

--- a/internal/clients/codex/sync_test.go
+++ b/internal/clients/codex/sync_test.go
@@ -618,6 +618,9 @@ args = ["run", "weather.py"]
 	if got.OAuthResource != "https://sqladmin.googleapis.com/" {
 		t.Fatalf("expected OAuth resource, got: %q", got.OAuthResource)
 	}
+	if got.BearerTokenEnvVar != "CLOUDSQL_MCP_TOKEN" {
+		t.Fatalf("expected bearer token env var, got: %q", got.BearerTokenEnvVar)
+	}
 	if got.HTTPHeaders["x-goog-user-project"] != "example-project" {
 		t.Fatalf("expected manifest headers as http_headers, got: %#v", got.HTTPHeaders)
 	}
@@ -709,12 +712,13 @@ func TestSyncKeepsSSEPending(t *testing.T) {
 
 func newCloudSQLManifest() registry.Manifest {
 	return registry.Manifest{
-		Name:          "cloud-sql",
-		Transport:     registry.TransportHTTP,
-		URL:           "https://sqladmin.googleapis.com/mcp",
-		OAuthResource: "https://sqladmin.googleapis.com/",
-		Enabled:       true,
-		Clients:       []string{Target},
+		Name:              "cloud-sql",
+		Transport:         registry.TransportHTTP,
+		URL:               "https://sqladmin.googleapis.com/mcp",
+		OAuthResource:     "https://sqladmin.googleapis.com/",
+		BearerTokenEnvVar: "CLOUDSQL_MCP_TOKEN",
+		Enabled:           true,
+		Clients:           []string{Target},
 	}
 }
 

--- a/internal/clients/gemini/sync.go
+++ b/internal/clients/gemini/sync.go
@@ -282,6 +282,9 @@ func entriesForTarget(manifests []registry.Manifest, userScope bool) map[string]
 			// ineligible
 		case manifest.IsRemote() && !supportsRemoteTransport(manifest.TransportType()):
 			// unsupported remote transports stay pending
+		case manifest.IsRemote() && manifest.RequiresBearerTokenEnv():
+			// bearer_token_env_var is not part of Gemini settings.json.
+			// Keep the remote pending instead of emitting an unauthenticated URL.
 		case !userScope && manifest.HasSecretValue():
 			// covers static secret env values and secret header values;
 			// refusal at project scope keeps credentials out of

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/ankitvg/madari/internal/clients"
+	"github.com/ankitvg/madari/internal/clients/codex"
 	"github.com/ankitvg/madari/internal/clients/syncshared"
 	"github.com/ankitvg/madari/internal/registry"
 	"github.com/pelletier/go-toml/v2"
@@ -38,14 +39,15 @@ type Issue struct {
 }
 
 type ServerReport struct {
-	Name      string
-	Enabled   bool
-	Clients   []string
-	Transport string
-	Command   string
-	URL       string
-	Status    Status
-	Issues    []Issue
+	Name              string
+	Enabled           bool
+	Clients           []string
+	Transport         string
+	Command           string
+	URL               string
+	BearerTokenEnvVar string
+	Status            Status
+	Issues            []Issue
 }
 
 type ManifestError struct {
@@ -370,14 +372,15 @@ func summarize(report Report) Summary {
 
 func inspectServer(manifest registry.Manifest, envLookup func(string) string, targets []string) ServerReport {
 	report := ServerReport{
-		Name:      manifest.Name,
-		Enabled:   manifest.Enabled,
-		Clients:   append([]string(nil), manifest.Clients...),
-		Transport: manifest.TransportType(),
-		Command:   manifest.Command,
-		URL:       manifest.URL,
-		Status:    StatusSkipped,
-		Issues:    []Issue{},
+		Name:              manifest.Name,
+		Enabled:           manifest.Enabled,
+		Clients:           append([]string(nil), manifest.Clients...),
+		Transport:         manifest.TransportType(),
+		Command:           manifest.Command,
+		URL:               manifest.URL,
+		BearerTokenEnvVar: manifest.BearerTokenEnvVar,
+		Status:            StatusSkipped,
+		Issues:            []Issue{},
 	}
 
 	if !manifest.Enabled || !hasTarget(manifest, targets) {
@@ -399,6 +402,17 @@ func inspectServer(manifest registry.Manifest, envLookup func(string) string, ta
 			Message:  "remote transport requires url",
 		})
 		report.Status = StatusError
+	}
+
+	if manifest.IsRemote() && manifest.RequiresBearerTokenEnv() && strings.TrimSpace(envLookup(manifest.BearerTokenEnvVar)) == "" {
+		report.Issues = append(report.Issues, Issue{
+			Severity: SeverityWarning,
+			Code:     "missing_bearer_token_env",
+			Message:  fmt.Sprintf("missing bearer token env key %s", manifest.BearerTokenEnvVar),
+		})
+		if report.Status == StatusReady {
+			report.Status = StatusWarning
+		}
 	}
 
 	for _, key := range manifest.RequiredEnv.Keys {
@@ -654,7 +668,7 @@ func hasTargetInManifests(manifests []registry.Manifest, target string, supports
 	for _, manifest := range manifests {
 		// Remote manifests only warrant a client config on disk when the
 		// target's adapter materializes their transport.
-		if manifest.IsRemote() && !supportsRemote(manifest.TransportType()) {
+		if manifest.IsRemote() && (!supportsRemote(manifest.TransportType()) || (manifest.RequiresBearerTokenEnv() && target != codex.Target)) {
 			continue
 		}
 		if manifest.HasClient(target) {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -317,6 +317,48 @@ func TestRunChecksClientConfigForRemoteCapableTarget(t *testing.T) {
 	}
 }
 
+func TestRunWarnsForMissingBearerTokenEnv(t *testing.T) {
+	tmp := t.TempDir()
+	store := registry.NewStore(filepath.Join(tmp, "servers"))
+
+	if err := store.Save(registry.Manifest{
+		Name:              "cloud-sql",
+		Transport:         registry.TransportHTTP,
+		URL:               "https://example.com/mcp",
+		BearerTokenEnvVar: "CLOUDSQL_MCP_TOKEN",
+		Enabled:           true,
+		Clients:           []string{"codex"},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+
+	adapter := testAdapter{
+		target:         "codex",
+		configPath:     filepath.Join(tmp, "config.toml"),
+		supportsRemote: true,
+	}
+	report, err := Run(store, Options{
+		Adapters: []clients.ClientAdapter{adapter},
+		EnvLookup: func(string) string {
+			return ""
+		},
+	})
+	if err != nil {
+		t.Fatalf("doctor run failed: %v", err)
+	}
+
+	if len(report.Servers) != 1 {
+		t.Fatalf("expected one server report, got: %+v", report.Servers)
+	}
+	server := report.Servers[0]
+	if server.Status != StatusWarning || server.BearerTokenEnvVar != "CLOUDSQL_MCP_TOKEN" {
+		t.Fatalf("expected warning with bearer token env detail, got: %+v", server)
+	}
+	if len(server.Issues) != 1 || server.Issues[0].Code != "missing_bearer_token_env" {
+		t.Fatalf("expected missing bearer env issue, got: %+v", server.Issues)
+	}
+}
+
 func TestRunUsesConfigPathOverride(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("unix fixture mode bits are used in this test")

--- a/internal/registry/manifest.go
+++ b/internal/registry/manifest.go
@@ -21,21 +21,22 @@ const (
 
 // Manifest is the canonical configuration for one local MCP server.
 type Manifest struct {
-	Name          string            `toml:"name" json:"name"`
-	Transport     string            `toml:"transport,omitempty" json:"transport,omitempty"`
-	Command       string            `toml:"command" json:"command"`
-	Args          []string          `toml:"args" json:"args"`
-	URL           string            `toml:"url,omitempty" json:"url,omitempty"`
-	Headers       map[string]string `toml:"headers,omitempty" json:"headers,omitempty"`
-	TimeoutMS     int               `toml:"timeout_ms,omitempty" json:"timeout_ms,omitempty"`
-	OAuthResource string            `toml:"oauth_resource,omitempty" json:"oauth_resource,omitempty"`
-	Enabled       bool              `toml:"enabled" json:"enabled"`
-	Clients       []string          `toml:"clients" json:"clients"`
-	Description   string            `toml:"description,omitempty" json:"description,omitempty"`
-	Env           map[string]string `toml:"env,omitempty" json:"env,omitempty"`
-	RequiredEnv   RequiredEnv       `toml:"required_env,omitempty" json:"required_env,omitempty"`
-	SecretEnv     SecretEnv         `toml:"secret_env,omitempty" json:"secret_env,omitempty"`
-	SecretHeaders SecretHeaders     `toml:"secret_headers,omitempty" json:"secret_headers,omitempty"`
+	Name              string            `toml:"name" json:"name"`
+	Transport         string            `toml:"transport,omitempty" json:"transport,omitempty"`
+	Command           string            `toml:"command" json:"command"`
+	Args              []string          `toml:"args" json:"args"`
+	URL               string            `toml:"url,omitempty" json:"url,omitempty"`
+	Headers           map[string]string `toml:"headers,omitempty" json:"headers,omitempty"`
+	TimeoutMS         int               `toml:"timeout_ms,omitempty" json:"timeout_ms,omitempty"`
+	OAuthResource     string            `toml:"oauth_resource,omitempty" json:"oauth_resource,omitempty"`
+	BearerTokenEnvVar string            `toml:"bearer_token_env_var,omitempty" json:"bearer_token_env_var,omitempty"`
+	Enabled           bool              `toml:"enabled" json:"enabled"`
+	Clients           []string          `toml:"clients" json:"clients"`
+	Description       string            `toml:"description,omitempty" json:"description,omitempty"`
+	Env               map[string]string `toml:"env,omitempty" json:"env,omitempty"`
+	RequiredEnv       RequiredEnv       `toml:"required_env,omitempty" json:"required_env,omitempty"`
+	SecretEnv         SecretEnv         `toml:"secret_env,omitempty" json:"secret_env,omitempty"`
+	SecretHeaders     SecretHeaders     `toml:"secret_headers,omitempty" json:"secret_headers,omitempty"`
 }
 
 // RequiredEnv describes environment variables that must be present at runtime.
@@ -167,6 +168,10 @@ func (m Manifest) IsRemote() bool {
 	}
 }
 
+func (m Manifest) RequiresBearerTokenEnv() bool {
+	return strings.TrimSpace(m.BearerTokenEnvVar) != ""
+}
+
 // Validate enforces manifest-level invariants.
 func (m Manifest) Validate() error {
 	var errs []string
@@ -192,6 +197,9 @@ func (m Manifest) Validate() error {
 		}
 		if strings.TrimSpace(m.OAuthResource) != "" {
 			errs = append(errs, "oauth_resource is only supported for remote transports")
+		}
+		if strings.TrimSpace(m.BearerTokenEnvVar) != "" {
+			errs = append(errs, "bearer_token_env_var is only supported for remote transports")
 		}
 		if len(m.SecretHeaders.Keys) > 0 {
 			errs = append(errs, "secret_headers is only supported for remote transports")
@@ -225,6 +233,14 @@ func (m Manifest) Validate() error {
 
 	if m.TimeoutMS < 0 {
 		errs = append(errs, "timeout_ms must be positive")
+	}
+
+	if key := strings.TrimSpace(m.BearerTokenEnvVar); key != "" {
+		if m.BearerTokenEnvVar != key {
+			errs = append(errs, "bearer_token_env_var must not have leading or trailing whitespace")
+		} else if !envKeyPattern.MatchString(key) {
+			errs = append(errs, fmt.Sprintf("invalid bearer_token_env_var key %q", key))
+		}
 	}
 
 	for key := range m.Headers {

--- a/internal/registry/manifest_test.go
+++ b/internal/registry/manifest_test.go
@@ -170,6 +170,13 @@ func TestManifestValidateErrors(t *testing.T) {
 			expects: "secret_headers is only supported for remote transports",
 		},
 		{
+			name: "stdio rejects bearer_token_env_var",
+			mutate: func(m *Manifest) {
+				m.BearerTokenEnvVar = "CLOUDSQL_MCP_TOKEN"
+			},
+			expects: "bearer_token_env_var is only supported for remote transports",
+		},
+		{
 			name: "remote rejects invalid secret_headers name",
 			mutate: func(m *Manifest) {
 				*m = Manifest{
@@ -210,6 +217,34 @@ func TestManifestValidateErrors(t *testing.T) {
 				}
 			},
 			expects: "timeout_ms must be positive",
+		},
+		{
+			name: "remote rejects invalid bearer_token_env_var",
+			mutate: func(m *Manifest) {
+				*m = Manifest{
+					Name:              "cloud-sql",
+					Transport:         TransportHTTP,
+					URL:               "https://sqladmin.googleapis.com/mcp",
+					BearerTokenEnvVar: "cloudsql-token",
+					Enabled:           true,
+					Clients:           []string{"codex"},
+				}
+			},
+			expects: "invalid bearer_token_env_var key",
+		},
+		{
+			name: "remote rejects padded bearer_token_env_var",
+			mutate: func(m *Manifest) {
+				*m = Manifest{
+					Name:              "cloud-sql",
+					Transport:         TransportHTTP,
+					URL:               "https://sqladmin.googleapis.com/mcp",
+					BearerTokenEnvVar: " CLOUDSQL_MCP_TOKEN ",
+					Enabled:           true,
+					Clients:           []string{"codex"},
+				}
+			},
+			expects: "bearer_token_env_var must not have leading or trailing whitespace",
 		},
 		{
 			name: "duplicate clients",
@@ -265,14 +300,15 @@ func TestManifestValidateErrors(t *testing.T) {
 
 func TestManifestValidateRemoteOK(t *testing.T) {
 	m := Manifest{
-		Name:          "cloud-sql",
-		Transport:     TransportHTTP,
-		URL:           "https://sqladmin.googleapis.com/mcp",
-		OAuthResource: "https://sqladmin.googleapis.com/",
-		TimeoutMS:     30000,
-		Headers:       map[string]string{"x-goog-user-project": "project-id"},
-		Enabled:       true,
-		Clients:       []string{"codex"},
+		Name:              "cloud-sql",
+		Transport:         TransportHTTP,
+		URL:               "https://sqladmin.googleapis.com/mcp",
+		OAuthResource:     "https://sqladmin.googleapis.com/",
+		BearerTokenEnvVar: "CLOUDSQL_MCP_TOKEN",
+		TimeoutMS:         30000,
+		Headers:           map[string]string{"x-goog-user-project": "project-id"},
+		Enabled:           true,
+		Clients:           []string{"codex"},
 	}
 	if err := m.Validate(); err != nil {
 		t.Fatalf("expected remote manifest to validate, got: %v", err)

--- a/internal/registry/parser.go
+++ b/internal/registry/parser.go
@@ -141,6 +141,9 @@ func MarshalManifest(m Manifest) ([]byte, error) {
 		if strings.TrimSpace(m.OAuthResource) != "" {
 			fmt.Fprintf(&b, "oauth_resource = %s\n", strconv.Quote(m.OAuthResource))
 		}
+		if strings.TrimSpace(m.BearerTokenEnvVar) != "" {
+			fmt.Fprintf(&b, "bearer_token_env_var = %s\n", strconv.Quote(m.BearerTokenEnvVar))
+		}
 	} else {
 		fmt.Fprintf(&b, "command = %s\n", strconv.Quote(m.Command))
 		fmt.Fprintf(&b, "args = %s\n", formatStringArray(m.Args))
@@ -231,6 +234,12 @@ func parseTopLevel(m *Manifest, key, value string) error {
 			return fmt.Errorf("invalid oauth_resource: %w", err)
 		}
 		m.OAuthResource = sv
+	case "bearer_token_env_var":
+		sv, err := parseString(value)
+		if err != nil {
+			return fmt.Errorf("invalid bearer_token_env_var: %w", err)
+		}
+		m.BearerTokenEnvVar = sv
 	case "timeout_ms":
 		iv, err := parseInt(value)
 		if err != nil {

--- a/internal/registry/parser_test.go
+++ b/internal/registry/parser_test.go
@@ -67,14 +67,15 @@ func TestParseAndMarshalManifestRoundTrip(t *testing.T) {
 
 func TestParseAndMarshalRemoteManifestRoundTrip(t *testing.T) {
 	in := Manifest{
-		Name:          "cloud-sql",
-		Transport:     TransportHTTP,
-		URL:           "https://sqladmin.googleapis.com/mcp",
-		TimeoutMS:     30000,
-		OAuthResource: "https://sqladmin.googleapis.com/",
-		Enabled:       true,
-		Clients:       []string{"codex"},
-		Description:   "Cloud SQL remote MCP",
+		Name:              "cloud-sql",
+		Transport:         TransportHTTP,
+		URL:               "https://sqladmin.googleapis.com/mcp",
+		TimeoutMS:         30000,
+		OAuthResource:     "https://sqladmin.googleapis.com/",
+		BearerTokenEnvVar: "CLOUDSQL_MCP_TOKEN",
+		Enabled:           true,
+		Clients:           []string{"codex"},
+		Description:       "Cloud SQL remote MCP",
 		Headers: map[string]string{
 			"x-goog-user-project": "example-project",
 			"x-routing-key":       "internal-value",
@@ -91,6 +92,7 @@ func TestParseAndMarshalRemoteManifestRoundTrip(t *testing.T) {
 		`url = "https://sqladmin.googleapis.com/mcp"`,
 		`timeout_ms = 30000`,
 		`oauth_resource = "https://sqladmin.googleapis.com/"`,
+		`bearer_token_env_var = "CLOUDSQL_MCP_TOKEN"`,
 		"[headers]",
 		`x-goog-user-project = "example-project"`,
 		"[secret_headers]",
@@ -108,7 +110,9 @@ func TestParseAndMarshalRemoteManifestRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)
 	}
-	if out.TransportType() != TransportHTTP || out.URL != in.URL || out.OAuthResource != in.OAuthResource {
+	if out.TransportType() != TransportHTTP || out.URL != in.URL ||
+		out.OAuthResource != in.OAuthResource ||
+		out.BearerTokenEnvVar != in.BearerTokenEnvVar {
 		t.Fatalf("remote roundtrip mismatch: got %#v", out)
 	}
 	if out.Headers["x-goog-user-project"] != "example-project" {

--- a/internal/registry/snapshot.go
+++ b/internal/registry/snapshot.go
@@ -23,7 +23,10 @@ const (
 	snapshotVersionV7 = 7
 	// SnapshotVersion 8 adds [secret_headers]; older importers reject by
 	// version instead of silently dropping the secrecy annotation.
-	SnapshotVersion = 8
+	snapshotVersionV8 = 8
+	// SnapshotVersion 9 adds bearer_token_env_var; older importers reject by
+	// version instead of silently dropping the runtime auth env reference.
+	SnapshotVersion = 9
 )
 
 type Snapshot struct {
@@ -317,7 +320,7 @@ func ImportSnapshot(store *Store, snapshot Snapshot, apply bool) (ImportResult, 
 }
 
 func (s Snapshot) Validate() error {
-	if s.Version != snapshotVersionV1 && s.Version != snapshotVersionV2 && s.Version != snapshotVersionV3 && s.Version != snapshotVersionV4 && s.Version != snapshotVersionV5 && s.Version != snapshotVersionV6 && s.Version != snapshotVersionV7 && s.Version != SnapshotVersion {
+	if s.Version != snapshotVersionV1 && s.Version != snapshotVersionV2 && s.Version != snapshotVersionV3 && s.Version != snapshotVersionV4 && s.Version != snapshotVersionV5 && s.Version != snapshotVersionV6 && s.Version != snapshotVersionV7 && s.Version != snapshotVersionV8 && s.Version != SnapshotVersion {
 		return fmt.Errorf("unsupported snapshot version %d (supported: %d)", s.Version, SnapshotVersion)
 	}
 	if s.Version == snapshotVersionV1 && len(s.Rings) > 0 {
@@ -335,8 +338,11 @@ func (s Snapshot) Validate() error {
 	if s.Version < snapshotVersionV7 && snapshotHasRemoteServers(s) {
 		return fmt.Errorf("snapshot version %d does not support remote transports", s.Version)
 	}
-	if s.Version < SnapshotVersion && snapshotHasSecretHeaders(s) {
+	if s.Version < snapshotVersionV8 && snapshotHasSecretHeaders(s) {
 		return fmt.Errorf("snapshot version %d does not support secret_headers", s.Version)
+	}
+	if s.Version < SnapshotVersion && snapshotHasBearerTokenEnv(s) {
+		return fmt.Errorf("snapshot version %d does not support bearer_token_env_var", s.Version)
 	}
 
 	seen := map[string]struct{}{}
@@ -413,7 +419,8 @@ func manifestsEqual(a, b Manifest) bool {
 	}
 
 	if a.TransportType() != b.TransportType() || a.URL != b.URL ||
-		a.TimeoutMS != b.TimeoutMS || a.OAuthResource != b.OAuthResource {
+		a.TimeoutMS != b.TimeoutMS || a.OAuthResource != b.OAuthResource ||
+		a.BearerTokenEnvVar != b.BearerTokenEnvVar {
 		return false
 	}
 
@@ -632,6 +639,15 @@ func snapshotHasRemoteServers(snapshot Snapshot) bool {
 func snapshotHasSecretHeaders(snapshot Snapshot) bool {
 	for _, server := range snapshot.Servers {
 		if len(server.SecretHeaders.Keys) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func snapshotHasBearerTokenEnv(snapshot Snapshot) bool {
+	for _, server := range snapshot.Servers {
+		if strings.TrimSpace(server.BearerTokenEnvVar) != "" {
 			return true
 		}
 	}

--- a/internal/registry/snapshot_test.go
+++ b/internal/registry/snapshot_test.go
@@ -234,6 +234,25 @@ func TestParseSnapshotV8AcceptsSecretHeaders(t *testing.T) {
 	}
 }
 
+func TestParseSnapshotV8RejectsBearerTokenEnv(t *testing.T) {
+	payload := []byte(`{"version":8,"servers":[{"name":"cloud-sql","transport":"http","url":"https://example.com/mcp","bearer_token_env_var":"CLOUDSQL_MCP_TOKEN","enabled":true,"clients":["codex"]}]}`)
+	_, err := ParseSnapshotJSON(payload)
+	if err == nil || !strings.Contains(err.Error(), "does not support bearer_token_env_var") {
+		t.Fatalf("expected v8 bearer-token-env error, got: %v", err)
+	}
+}
+
+func TestParseSnapshotV9AcceptsBearerTokenEnv(t *testing.T) {
+	payload := []byte(`{"version":9,"servers":[{"name":"cloud-sql","transport":"http","url":"https://example.com/mcp","bearer_token_env_var":"CLOUDSQL_MCP_TOKEN","enabled":true,"clients":["codex"]}]}`)
+	snapshot, err := ParseSnapshotJSON(payload)
+	if err != nil {
+		t.Fatalf("parse v9 snapshot with bearer_token_env_var: %v", err)
+	}
+	if len(snapshot.Servers) != 1 || snapshot.Servers[0].BearerTokenEnvVar != "CLOUDSQL_MCP_TOKEN" {
+		t.Fatalf("expected bearer_token_env_var to parse, got: %#v", snapshot.Servers)
+	}
+}
+
 func TestParseSnapshotV7AcceptsRemoteServers(t *testing.T) {
 	payload := []byte(`{"version":7,"servers":[{"name":"cloud-sql","transport":"http","url":"https://example.com/mcp","enabled":true,"clients":["codex"]}]}`)
 	snapshot, err := ParseSnapshotJSON(payload)


### PR DESCRIPTION
## Summary
- add `bearer_token_env_var` as a remote manifest field, CLI flag, and snapshot v9 field
- materialize the field for Codex sync and `madari ring render --client codex`
- keep bearer-token-env remote auth pending for non-Codex clients instead of emitting unauthenticated URLs
- document the Codex bearer-token-env flow while keeping `oauth_resource` for OAuth-capable servers

## Why
Cloud SQL MCP local testing showed the working Codex path uses a runtime bearer token env var rather than OAuth dynamic client registration. Madari should represent that auth mode directly without storing token values in manifests or repo-scoped configs.

## Validation
- `go test ./internal/registry ./internal/clients/codex ./cmd/madari`
- `go test ./internal/doctor ./internal/registry ./internal/clients/codex ./cmd/madari`
- `make build`
- `go test ./...`
- `git diff --check`