### PR TITLE
[codex] Add madari run dry-run planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,8 @@ Madari can sync MCP servers for:
 Remote (`http`/`sse`) servers currently materialize for `claude-code` and
 `gemini` (both transports) and `codex` (`http` only); other targets store
 remote manifests and report them as pending. Remote entries that require
-`bearer_token_env_var` currently materialize only for `codex`.
+`oauth_resource` or `bearer_token_env_var` currently materialize only for
+`codex`.
 
 Madari can materialize skills for:
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # madari (muh-DAA-ree)
 
 Madari is a local-first CLI for managing MCP capability setup across AI clients.
-It registers MCP servers, stores reusable skills, groups them into rings, and
-syncs only the entries it owns into client config files.
+It registers MCP servers, stores reusable skills, groups them into rings,
+plans ring-based agent launches, and syncs only the entries it owns into
+client config files.
 
 Madari is intentionally static: no daemon, proxy, or background mux. It helps
 the AI clients and agents you already use get the right capabilities with
@@ -98,6 +99,13 @@ madari ring render research --client codex
 claude --mcp-config <(madari ring render research --client claude-code)
 ```
 
+Or inspect the launch plan for one or more rings before starting a client:
+
+```bash
+madari run codex --ring research --dry-run -- \
+  "Use this ring to inspect the target context."
+```
+
 Use `madari help <command>` or `docs/cli-reference.md` for complete command
 syntax.
 
@@ -126,6 +134,11 @@ refuses to adopt or overwrite unmanaged config blocks.
 **Render** prints client-native MCP config to stdout without changing state. It
 is useful for temporary sessions and experiments.
 
+**Run** plans an ephemeral client launch from one or more rings. The first
+implementation is dry-run only: it resolves ring members, validates client
+support and runtime env requirements, and reports what would be made available
+without writing config files or starting the client.
+
 ## Safety Model
 
 - Local-first registry and human-readable config files
@@ -138,6 +151,8 @@ is useful for temporary sessions and experiments.
   `ring render` never emits them
 - Bearer token env references store only the env var name; the token value
   stays in the runtime environment
+- `madari run --dry-run` checks runtime env keys by name without printing
+  their values
 - Diagnostics through `madari doctor`, `madari status`, and `madari ring status`
 
 ## Supported Clients

--- a/cmd/madari/client_targets.go
+++ b/cmd/madari/client_targets.go
@@ -22,6 +22,9 @@ type clientTarget struct {
 	// ringRenderTimeout marks renderers that emit timeout_ms as the
 	// client's per-server timeout field for remote entries.
 	ringRenderTimeout bool
+	// remoteOAuthResource marks clients that can carry OAuth resource metadata
+	// for remote entries instead of dropping it from the materialized config.
+	remoteOAuthResource bool
 	// remoteBearerTokenEnv marks clients that can read remote bearer tokens
 	// from an env var reference without Madari storing the token value.
 	remoteBearerTokenEnv bool
@@ -50,6 +53,7 @@ var clientTargets = []clientTarget{
 		target:               codex.Target,
 		syncAdapter:          codex.Adapter{},
 		ringConfigRenderer:   renderCodexTOML,
+		remoteOAuthResource:  true,
 		remoteBearerTokenEnv: true,
 		skillRoots: skillTargetRoots{
 			project: defaultProjectSkillRoot(".agents", "skills"),
@@ -143,4 +147,9 @@ func supportsSkillMaterialization(target string) bool {
 func supportsRemoteBearerTokenEnv(target string) bool {
 	ct, ok := clientTargetByName(target)
 	return ok && ct.remoteBearerTokenEnv
+}
+
+func supportsRemoteOAuthResource(target string) bool {
+	ct, ok := clientTargetByName(target)
+	return ok && ct.remoteOAuthResource
 }

--- a/cmd/madari/json_output.go
+++ b/cmd/madari/json_output.go
@@ -118,6 +118,7 @@ type doctorServerJSON struct {
 	Clients           []string    `json:"clients"`
 	Command           string      `json:"command"`
 	URL               string      `json:"url,omitempty"`
+	OAuthResource     string      `json:"oauth_resource,omitempty"`
 	BearerTokenEnvVar string      `json:"bearer_token_env_var,omitempty"`
 	Status            string      `json:"status"`
 	Issues            []issueJSON `json:"issues"`

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -152,6 +152,8 @@ func (a cliApp) dispatch(args []string) error {
 		return a.cmdImport(args[1:])
 	case "sync":
 		return a.cmdSync(args[1:])
+	case "run":
+		return a.cmdRun(args[1:])
 	case "ring":
 		return a.cmdRing(args[1:])
 	case "skill":
@@ -1722,6 +1724,8 @@ func printCommandHelp(command string, out io.Writer) bool {
 		printEnableDisableHelp("disable", out)
 	case "sync":
 		printSyncHelp(out)
+	case "run":
+		printRunHelp(out)
 	case "ring":
 		printRingHelp(out)
 	case "skill":
@@ -1959,6 +1963,7 @@ func printHelp(out io.Writer) {
 	fmt.Fprintln(out, "  enable    Enable a server")
 	fmt.Fprintln(out, "  disable   Disable a server")
 	fmt.Fprintln(out, "  sync      Sync server manifests to a client config")
+	fmt.Fprintln(out, "  run       Plan an ephemeral client launch from rings")
 	fmt.Fprintln(out, "  ring      Manage rings (named capability sets of servers)")
 	fmt.Fprintln(out, "  skill     Manage Agent Skill packages")
 	fmt.Fprintln(out, "  clients   List sync client config readiness")
@@ -1978,6 +1983,7 @@ func printHelp(out io.Writer) {
 	fmt.Fprintln(out, "  madari disable stewreads")
 	fmt.Fprintln(out, "  madari sync claude-desktop --dry-run")
 	fmt.Fprintln(out, "  madari sync claude-code --dry-run")
+	fmt.Fprintln(out, "  madari run codex --ring research --dry-run -- \"Use this ring\"")
 	fmt.Fprintln(out, "  madari skill add --dir ./release")
 	fmt.Fprintln(out, "  madari skill render release")
 	fmt.Fprintln(out, "  madari skill render release --client codex")

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -904,6 +904,7 @@ func (a cliApp) cmdDoctor(args []string) error {
 				Clients:           nonNilStrings(server.Clients),
 				Command:           server.Command,
 				URL:               server.URL,
+				OAuthResource:     server.OAuthResource,
 				BearerTokenEnvVar: server.BearerTokenEnvVar,
 				Status:            string(server.Status),
 				Issues:            issues,
@@ -1402,7 +1403,7 @@ func manifestEndpoint(manifest registry.Manifest) string {
 func doctorEndpointDetail(server doctor.ServerReport) string {
 	switch server.Transport {
 	case registry.TransportHTTP, registry.TransportSSE:
-		pending := remotePendingTargets(server.Clients, server.Transport, server.BearerTokenEnvVar)
+		pending := remotePendingTargets(server.Clients, server.Transport, server.OAuthResource, server.BearerTokenEnvVar)
 		if len(pending) == 0 {
 			return fmt.Sprintf("url=%s", server.URL)
 		}
@@ -1414,13 +1415,13 @@ func doctorEndpointDetail(server doctor.ServerReport) string {
 
 // remotePendingTargets returns the manifest's sync targets whose adapters do
 // not materialize this remote transport/auth combination yet.
-func remotePendingTargets(targets []string, transport, bearerTokenEnvVar string) []string {
+func remotePendingTargets(targets []string, transport, oauthResource, bearerTokenEnvVar string) []string {
 	pending := []string{}
 	for _, target := range targets {
 		if _, known := syncAdapters[target]; !known {
 			continue
 		}
-		if !targetSupportsRemoteManifest(target, transport, bearerTokenEnvVar) {
+		if !targetSupportsRemoteManifest(target, transport, oauthResource, bearerTokenEnvVar) {
 			pending = append(pending, target)
 		}
 	}
@@ -1438,9 +1439,12 @@ type remoteUnsupportedDetail struct {
 	Auth      string
 }
 
-func targetSupportsRemoteManifest(target, transport, bearerTokenEnvVar string) bool {
+func targetSupportsRemoteManifest(target, transport, oauthResource, bearerTokenEnvVar string) bool {
 	adapter, known := syncAdapters[target]
 	if !known || !adapter.SupportsRemote(transport) {
+		return false
+	}
+	if strings.TrimSpace(oauthResource) != "" && !supportsRemoteOAuthResource(target) {
 		return false
 	}
 	if strings.TrimSpace(bearerTokenEnvVar) != "" && !supportsRemoteBearerTokenEnv(target) {
@@ -1453,6 +1457,12 @@ func unsupportedRemoteForTarget(manifest registry.Manifest, target string) (remo
 	adapter, known := syncAdapters[target]
 	if !known || !adapter.SupportsRemote(manifest.TransportType()) {
 		return remoteUnsupportedDetail{Transport: manifest.TransportType()}, true
+	}
+	if strings.TrimSpace(manifest.OAuthResource) != "" && !supportsRemoteOAuthResource(target) {
+		return remoteUnsupportedDetail{
+			Transport: manifest.TransportType(),
+			Auth:      "oauth_resource auth",
+		}, true
 	}
 	if manifest.RequiresBearerTokenEnv() && !supportsRemoteBearerTokenEnv(target) {
 		return remoteUnsupportedDetail{

--- a/cmd/madari/run_plan.go
+++ b/cmd/madari/run_plan.go
@@ -186,10 +186,11 @@ func (a cliApp) buildRunPlan(target string, ringNames []string, prompt string) (
 	for _, name := range serverNames {
 		rings := serverRings[name]
 		server := runPlanServer{
-			Name:   name,
-			Status: "ready",
-			Rings:  nonNilStrings(append([]string(nil), rings...)),
-			Issues: []string{},
+			Name:       name,
+			Status:     "ready",
+			RuntimeEnv: []string{},
+			Rings:      nonNilStrings(append([]string(nil), rings...)),
+			Issues:     []string{},
 		}
 		manifest, exists := manifestByName[name]
 		if !exists {

--- a/cmd/madari/run_plan.go
+++ b/cmd/madari/run_plan.go
@@ -1,0 +1,492 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/ankitvg/madari/internal/clients"
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+const runDryRunOnlyMessage = "madari run execution is not implemented yet; pass --dry-run to inspect the launch plan"
+
+type runPlanJSON struct {
+	SchemaVersion   int             `json:"schema_version"`
+	Command         string          `json:"command"`
+	Target          string          `json:"target"`
+	Rings           []string        `json:"rings"`
+	Ready           bool            `json:"ready"`
+	RunnerAvailable bool            `json:"runner_available"`
+	PromptProvided  bool            `json:"prompt_provided"`
+	Servers         []runPlanServer `json:"servers"`
+	Skills          []runPlanSkill  `json:"skills"`
+	Env             []runPlanEnv    `json:"env"`
+	Warnings        []string        `json:"warnings"`
+	Errors          []string        `json:"errors"`
+}
+
+type runLaunchPlan struct {
+	Target          string
+	Rings           []string
+	Ready           bool
+	RunnerAvailable bool
+	PromptProvided  bool
+	Servers         []runPlanServer
+	Skills          []runPlanSkill
+	Env             []runPlanEnv
+	Warnings        []string
+	Errors          []string
+}
+
+type runPlanServer struct {
+	Name       string   `json:"name"`
+	Transport  string   `json:"transport"`
+	Endpoint   string   `json:"endpoint"`
+	Status     string   `json:"status"`
+	Auth       string   `json:"auth,omitempty"`
+	RuntimeEnv []string `json:"runtime_env"`
+	Rings      []string `json:"rings"`
+	Issues     []string `json:"issues"`
+}
+
+type runPlanSkill struct {
+	Name   string   `json:"name"`
+	Status string   `json:"status"`
+	Rings  []string `json:"rings"`
+	Issues []string `json:"issues"`
+}
+
+type runPlanEnv struct {
+	Key     string   `json:"key"`
+	Present bool     `json:"present"`
+	Servers []string `json:"servers"`
+}
+
+func (a cliApp) cmdRun(args []string) error {
+	if len(args) == 0 {
+		return commandUsageError("run", "madari run <client> --ring <ring> [--ring <ring> ...] --dry-run -- <prompt>")
+	}
+	if isHelpToken(args[0]) {
+		printRunHelp(a.stdout)
+		return nil
+	}
+
+	target := strings.TrimSpace(args[0])
+	fs := flag.NewFlagSet("run", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var rings stringList
+	var dryRun bool
+	var jsonOutput bool
+	fs.Var(&rings, "ring", "Ring to include in the launch plan (repeatable)")
+	fs.BoolVar(&dryRun, "dry-run", false, "Inspect the launch plan without starting the client")
+	fs.BoolVar(&jsonOutput, "json", false, "Emit JSON instead of text")
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printRunHelp(a.stdout)
+			return nil
+		}
+		return commandInputError("run", err.Error())
+	}
+
+	if target == "" {
+		return commandInputError("run", "client is required")
+	}
+	if !dryRun {
+		return commandInputError("run", runDryRunOnlyMessage)
+	}
+	normalizedRings := normalizedRingNames(rings)
+	if len(normalizedRings) == 0 {
+		return commandInputError("run", "--ring is required")
+	}
+	prompt := strings.TrimSpace(strings.Join(fs.Args(), " "))
+	if prompt == "" {
+		return commandInputError("run", "prompt is required")
+	}
+
+	plan, err := a.buildRunPlan(target, normalizedRings, prompt)
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		if err := writeJSON(a.stdout, plan.toJSON()); err != nil {
+			return err
+		}
+	} else {
+		printRunPlan(a.stdout, plan)
+	}
+	if !plan.Ready {
+		return commandInputError("run", "launch plan is not ready")
+	}
+	return nil
+}
+
+func (a cliApp) buildRunPlan(target string, ringNames []string, prompt string) (runLaunchPlan, error) {
+	plan := runLaunchPlan{
+		Target:          target,
+		Rings:           nonNilStrings(normalizedRingNames(ringNames)),
+		RunnerAvailable: false,
+		PromptProvided:  strings.TrimSpace(prompt) != "",
+	}
+	addPlanError := func(message string) {
+		plan.Errors = append(plan.Errors, message)
+	}
+
+	if _, ok := clientTargetByName(target); !ok {
+		addPlanError(fmt.Sprintf("unsupported run target %q (supported: %s)", target, strings.Join(sortedClientTargetNames(), ", ")))
+		plan.finish()
+		return plan, nil
+	}
+	for ring, count := range countStrings(plan.Rings) {
+		if count > 1 {
+			addPlanError(fmt.Sprintf("duplicate ring %q", ring))
+		}
+	}
+
+	manifests, err := a.store.List()
+	if err != nil {
+		return runLaunchPlan{}, err
+	}
+	manifestByName := make(map[string]registry.Manifest, len(manifests))
+	for _, manifest := range manifests {
+		manifestByName[manifest.Name] = manifest
+	}
+
+	serverRings := map[string][]string{}
+	skillRings := map[string][]string{}
+	for _, name := range plan.Rings {
+		ring, err := a.store.GetRing(name)
+		if err != nil {
+			if errors.Is(err, registry.ErrRingNotFound) {
+				addPlanError(fmt.Sprintf("ring %q not found", name))
+				continue
+			}
+			return runLaunchPlan{}, err
+		}
+		for _, member := range ring.Members {
+			member = strings.TrimSpace(member)
+			if member != "" {
+				serverRings[member] = appendUniqueName(serverRings[member], name)
+			}
+		}
+		for _, skill := range ring.Skills {
+			skill = strings.TrimSpace(skill)
+			if skill != "" {
+				skillRings[skill] = appendUniqueName(skillRings[skill], name)
+			}
+		}
+	}
+
+	envRequirements := map[string][]string{}
+	serverNames := sortedStringSliceMapKeys(serverRings)
+	for _, name := range serverNames {
+		rings := serverRings[name]
+		server := runPlanServer{
+			Name:   name,
+			Status: "ready",
+			Rings:  nonNilStrings(append([]string(nil), rings...)),
+			Issues: []string{},
+		}
+		manifest, exists := manifestByName[name]
+		if !exists {
+			server.Status = "blocked"
+			server.Issues = append(server.Issues, "server is missing from the registry")
+			plan.Servers = append(plan.Servers, server)
+			addPlanError(fmt.Sprintf("ring member %s no longer exists in the registry", name))
+			continue
+		}
+		server.Transport = manifest.TransportType()
+		server.Endpoint = manifestEndpoint(manifest)
+		server.Auth = runPlanAuth(manifest)
+		server.RuntimeEnv = runtimeEnvKeys(manifest.RequiredEnv.Keys, manifest.SecretEnv.Keys)
+		if manifest.RequiresBearerTokenEnv() {
+			server.RuntimeEnv = runtimeEnvKeys(server.RuntimeEnv, []string{manifest.BearerTokenEnvVar})
+		}
+
+		if !manifest.Enabled {
+			server.Issues = append(server.Issues, "server is disabled")
+		}
+		if !manifest.HasClient(target) {
+			server.Issues = append(server.Issues, fmt.Sprintf("server does not target %s", target))
+		}
+		if manifest.IsRemote() {
+			if detail, unsupported := unsupportedRemoteForTarget(manifest, target); unsupported {
+				if detail.Auth != "" {
+					server.Issues = append(server.Issues, fmt.Sprintf("requires %s, which %s run does not support yet", detail.Auth, target))
+				} else {
+					server.Issues = append(server.Issues, fmt.Sprintf("uses %s transport, which %s run does not support yet", detail.Transport, target))
+				}
+			}
+		} else if err := clients.ValidateCommandPath(manifest.Command); err != nil {
+			server.Issues = append(server.Issues, err.Message)
+		}
+
+		for _, key := range server.RuntimeEnv {
+			envRequirements[key] = appendUniqueName(envRequirements[key], name)
+			if !runtimeEnvPresent(key) {
+				server.Issues = append(server.Issues, fmt.Sprintf("runtime env %s is missing", key))
+			}
+		}
+
+		if len(server.Issues) > 0 {
+			server.Status = "blocked"
+			for _, issue := range server.Issues {
+				addPlanError(fmt.Sprintf("server %s: %s", name, issue))
+			}
+		}
+		plan.Servers = append(plan.Servers, server)
+	}
+
+	if len(skillRings) > 0 && !supportsSkillMaterialization(target) {
+		addPlanError(fmt.Sprintf("%s does not support skill materialization (supported skill targets: %s)", target, strings.Join(supportedSkillTargets(), ", ")))
+	}
+	skillNames := sortedStringSliceMapKeys(skillRings)
+	for _, name := range skillNames {
+		skill := runPlanSkill{
+			Name:   name,
+			Status: "ready",
+			Rings:  nonNilStrings(append([]string(nil), skillRings[name]...)),
+			Issues: []string{},
+		}
+		if _, err := a.store.GetSkill(name); err != nil {
+			if errors.Is(err, registry.ErrSkillNotFound) {
+				skill.Issues = append(skill.Issues, "skill is missing from the registry")
+			} else {
+				return runLaunchPlan{}, err
+			}
+		}
+		if !supportsSkillMaterialization(target) {
+			skill.Issues = append(skill.Issues, fmt.Sprintf("%s does not support skill materialization", target))
+		}
+		if len(skill.Issues) > 0 {
+			skill.Status = "blocked"
+			for _, issue := range skill.Issues {
+				addPlanError(fmt.Sprintf("skill %s: %s", name, issue))
+			}
+		}
+		plan.Skills = append(plan.Skills, skill)
+	}
+
+	envKeys := sortedStringSliceMapKeys(envRequirements)
+	for _, key := range envKeys {
+		plan.Env = append(plan.Env, runPlanEnv{
+			Key:     key,
+			Present: runtimeEnvPresent(key),
+			Servers: nonNilStrings(envRequirements[key]),
+		})
+	}
+
+	plan.finish()
+	return plan, nil
+}
+
+func (p *runLaunchPlan) finish() {
+	p.Errors = nonNilStrings(sortedUniqueStrings(p.Errors))
+	p.Warnings = nonNilStrings(sortedUniqueStrings(p.Warnings))
+	p.Ready = len(p.Errors) == 0
+}
+
+func (p runLaunchPlan) toJSON() runPlanJSON {
+	return runPlanJSON{
+		SchemaVersion:   jsonSchemaVersion,
+		Command:         "run",
+		Target:          p.Target,
+		Rings:           nonNilStrings(p.Rings),
+		Ready:           p.Ready,
+		RunnerAvailable: p.RunnerAvailable,
+		PromptProvided:  p.PromptProvided,
+		Servers:         nonNilRunPlanServers(p.Servers),
+		Skills:          nonNilRunPlanSkills(p.Skills),
+		Env:             nonNilRunPlanEnv(p.Env),
+		Warnings:        nonNilStrings(p.Warnings),
+		Errors:          nonNilStrings(p.Errors),
+	}
+}
+
+func runPlanAuth(manifest registry.Manifest) string {
+	switch {
+	case manifest.RequiresBearerTokenEnv():
+		return "bearer_token_env_var"
+	case strings.TrimSpace(manifest.OAuthResource) != "":
+		return "oauth_resource"
+	default:
+		return ""
+	}
+}
+
+func normalizedRingNames(names []string) []string {
+	out := make([]string, 0, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+func countStrings(names []string) map[string]int {
+	counts := map[string]int{}
+	for _, name := range names {
+		counts[name]++
+	}
+	return counts
+}
+
+func sortedUniqueStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		seen[value] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for value := range seen {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedStringSliceMapKeys(values map[string][]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func runtimeEnvPresent(key string) bool {
+	value, ok := os.LookupEnv(key)
+	return ok && strings.TrimSpace(value) != ""
+}
+
+func nonNilRunPlanServers(servers []runPlanServer) []runPlanServer {
+	if servers == nil {
+		return []runPlanServer{}
+	}
+	return servers
+}
+
+func nonNilRunPlanSkills(skills []runPlanSkill) []runPlanSkill {
+	if skills == nil {
+		return []runPlanSkill{}
+	}
+	return skills
+}
+
+func nonNilRunPlanEnv(env []runPlanEnv) []runPlanEnv {
+	if env == nil {
+		return []runPlanEnv{}
+	}
+	return env
+}
+
+func printRunPlan(out io.Writer, plan runLaunchPlan) {
+	status := "ready"
+	if !plan.Ready {
+		status = "blocked"
+	}
+	fmt.Fprintf(out, "run target: %s\n", plan.Target)
+	fmt.Fprintf(out, "rings: %s\n", formatNameList(plan.Rings))
+	fmt.Fprintf(out, "status: %s\n", status)
+	fmt.Fprintln(out, "runner: unavailable (dry-run only)")
+	fmt.Fprintln(out)
+
+	fmt.Fprintln(out, "servers:")
+	if len(plan.Servers) == 0 {
+		fmt.Fprintln(out, "  -")
+	} else {
+		for _, server := range plan.Servers {
+			detail := fmt.Sprintf("  %s %s %s", server.Name, server.Status, server.Transport)
+			if server.Auth != "" {
+				detail += " auth=" + server.Auth
+			}
+			if len(server.RuntimeEnv) > 0 {
+				detail += " env=" + formatNameList(server.RuntimeEnv)
+			}
+			if len(server.Rings) > 0 {
+				detail += " rings=" + formatNameList(server.Rings)
+			}
+			fmt.Fprintln(out, detail)
+			for _, issue := range server.Issues {
+				fmt.Fprintf(out, "    issue: %s\n", issue)
+			}
+		}
+	}
+
+	fmt.Fprintln(out, "skills:")
+	if len(plan.Skills) == 0 {
+		fmt.Fprintln(out, "  -")
+	} else {
+		for _, skill := range plan.Skills {
+			detail := fmt.Sprintf("  %s %s", skill.Name, skill.Status)
+			if len(skill.Rings) > 0 {
+				detail += " rings=" + formatNameList(skill.Rings)
+			}
+			fmt.Fprintln(out, detail)
+			for _, issue := range skill.Issues {
+				fmt.Fprintf(out, "    issue: %s\n", issue)
+			}
+		}
+	}
+
+	fmt.Fprintln(out, "runtime env:")
+	if len(plan.Env) == 0 {
+		fmt.Fprintln(out, "  -")
+	} else {
+		for _, env := range plan.Env {
+			status := "missing"
+			if env.Present {
+				status = "present"
+			}
+			fmt.Fprintf(out, "  %s %s", env.Key, status)
+			if len(env.Servers) > 0 {
+				fmt.Fprintf(out, " servers=%s", formatNameList(env.Servers))
+			}
+			fmt.Fprintln(out)
+		}
+	}
+
+	fmt.Fprintln(out, "prompt: provided")
+	fmt.Fprintln(out, "execution: not implemented in this PR; dry-run only")
+	if len(plan.Warnings) > 0 {
+		fmt.Fprintln(out, "warnings:")
+		for _, warning := range plan.Warnings {
+			fmt.Fprintf(out, "  %s\n", warning)
+		}
+	}
+	if len(plan.Errors) > 0 {
+		fmt.Fprintln(out, "errors:")
+		for _, issue := range plan.Errors {
+			fmt.Fprintf(out, "  %s\n", issue)
+		}
+	}
+}
+
+func printRunHelp(out io.Writer) {
+	fmt.Fprintln(out, "Usage:")
+	fmt.Fprintln(out, "  madari run <client> --ring <ring> [--ring <ring> ...] --dry-run -- <prompt>")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Options:")
+	fmt.Fprintln(out, "  --ring <ring>             Ring to include in the launch plan (repeatable)")
+	fmt.Fprintln(out, "  --dry-run                 Inspect the launch plan without starting the client")
+	fmt.Fprintln(out, "  --json                    Emit JSON instead of text")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Description:")
+	fmt.Fprintln(out, "  Plan an ephemeral client launch from one or more rings. This first")
+	fmt.Fprintln(out, "  implementation is dry-run only: it validates ring members, target support,")
+	fmt.Fprintln(out, "  runtime env requirements, and skill materialization support, but does not")
+	fmt.Fprintln(out, "  write config files or start the client yet.")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Examples:")
+	fmt.Fprintln(out, "  madari run codex --ring cloudsql-readonly --dry-run -- \"Who are the top 5 ebook creators?\"")
+	fmt.Fprintln(out, "  madari run codex --ring cloudsql-readonly --ring research --dry-run --json -- \"Summarize the target plan\"")
+}

--- a/cmd/madari/run_plan_test.go
+++ b/cmd/madari/run_plan_test.go
@@ -199,6 +199,47 @@ func TestRunWithStoreRunPlanBlocksUnsupportedOAuthResource(t *testing.T) {
 	}
 }
 
+func TestRunWithStoreRunPlanMissingServerRuntimeEnvIsEmptyArray(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	if err := store.Save(registry.Manifest{
+		Name:    "helper",
+		Command: commandPath,
+		Enabled: true,
+		Clients: []string{"codex"},
+	}); err != nil {
+		t.Fatalf("setup helper failed: %v", err)
+	}
+	if result := runCmd(store, "ring", "create", "helpers", "--member", "helper"); result.code != 0 {
+		t.Fatalf("ring create failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "remove", "helper"); result.code != 0 {
+		t.Fatalf("remove helper failed: %s", result.stderr)
+	}
+
+	result := runCmd(store, "run", "codex", "--ring", "helpers", "--dry-run", "--json", "--", "prompt")
+	if result.code == 0 || !strings.Contains(result.stderr, "launch plan is not ready") {
+		t.Fatalf("expected blocked plan, got code=%d stdout=%s stderr=%s", result.code, result.stdout, result.stderr)
+	}
+	var raw struct {
+		Servers []map[string]any `json:"servers"`
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &raw); err != nil {
+		t.Fatalf("decode raw run plan: %v\n%s", err, result.stdout)
+	}
+	if len(raw.Servers) != 1 {
+		t.Fatalf("expected one server, got: %#v", raw.Servers)
+	}
+	runtimeEnv, ok := raw.Servers[0]["runtime_env"].([]any)
+	if !ok {
+		t.Fatalf("expected runtime_env to be an array, got %#v in %s", raw.Servers[0]["runtime_env"], result.stdout)
+	}
+	if len(runtimeEnv) != 0 {
+		t.Fatalf("expected empty runtime_env array, got %#v", runtimeEnv)
+	}
+}
+
 func TestRunWithStoreRunPlanBlocksUnsupportedSkillTarget(t *testing.T) {
 	store := newTestStore(t)
 	commandPath := mustCurrentExecutable(t)

--- a/cmd/madari/run_plan_test.go
+++ b/cmd/madari/run_plan_test.go
@@ -1,0 +1,264 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+func TestRunWithStoreRunPlanMultipleRings(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+	t.Setenv("CLOUDSQL_MCP_TOKEN", "test-token")
+	t.Setenv("LOCAL_TOKEN", "test-token")
+
+	if result := runCmd(store, "add", "cloud-sql",
+		"--transport", "http",
+		"--url", "https://sqladmin.googleapis.com/mcp",
+		"--client", "codex",
+		"--bearer-token-env-var", "CLOUDSQL_MCP_TOKEN"); result.code != 0 {
+		t.Fatalf("setup cloud-sql failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "add", "local-helper",
+		"--command", commandPath,
+		"--client", "codex",
+		"--required-env", "LOCAL_TOKEN"); result.code != 0 {
+		t.Fatalf("setup local-helper failed: %s", result.stderr)
+	}
+	skillSource := writeSkillFile(t, t.TempDir(), "release.md", "# Release\n")
+	if result := runCmd(store, "skill", "add", "release", "--file", skillSource, "--description", "Release workflow"); result.code != 0 {
+		t.Fatalf("skill add failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "ring", "create", "database", "--member", "cloud-sql", "--skill", "release"); result.code != 0 {
+		t.Fatalf("database ring create failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "ring", "create", "helpers", "--member", "cloud-sql", "--member", "local-helper"); result.code != 0 {
+		t.Fatalf("helpers ring create failed: %s", result.stderr)
+	}
+
+	result := runCmd(store, "run", "codex",
+		"--ring", "database",
+		"--ring", "helpers",
+		"--dry-run",
+		"--json",
+		"--",
+		"inspect the database")
+	if result.code != 0 {
+		t.Fatalf("run plan failed: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	plan := decodeRunPlan(t, result.stdout)
+	if !plan.Ready {
+		t.Fatalf("expected ready plan, got errors: %#v", plan.Errors)
+	}
+	if plan.RunnerAvailable {
+		t.Fatalf("PR 1 planner should not report a runner yet: %#v", plan)
+	}
+	if !slices.Equal(plan.Rings, []string{"database", "helpers"}) {
+		t.Fatalf("unexpected rings: %#v", plan.Rings)
+	}
+	if len(plan.Servers) != 2 {
+		t.Fatalf("expected deduped servers, got: %#v", plan.Servers)
+	}
+	cloud := findRunPlanServer(t, plan, "cloud-sql")
+	if cloud.Auth != "bearer_token_env_var" || !slices.Equal(cloud.Rings, []string{"database", "helpers"}) {
+		t.Fatalf("unexpected cloud-sql plan: %#v", cloud)
+	}
+	local := findRunPlanServer(t, plan, "local-helper")
+	if local.Transport != registry.TransportStdio || !slices.Equal(local.RuntimeEnv, []string{"LOCAL_TOKEN"}) {
+		t.Fatalf("unexpected local-helper plan: %#v", local)
+	}
+	if skill := findRunPlanSkill(t, plan, "release"); skill.Status != "ready" {
+		t.Fatalf("unexpected skill plan: %#v", skill)
+	}
+	if env := findRunPlanEnv(t, plan, "CLOUDSQL_MCP_TOKEN"); !env.Present {
+		t.Fatalf("expected CLOUDSQL_MCP_TOKEN present, got: %#v", env)
+	}
+	if env := findRunPlanEnv(t, plan, "LOCAL_TOKEN"); !env.Present {
+		t.Fatalf("expected LOCAL_TOKEN present, got: %#v", env)
+	}
+	stateDir := filepath.Join(filepath.Dir(store.ServersDir()), "state")
+	if _, err := os.Stat(stateDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("run plan should not create managed state, stat err=%v", err)
+	}
+}
+
+func TestRunWithStoreRunPlanRequiresDryRunRingAndPrompt(t *testing.T) {
+	store := newTestStore(t)
+
+	result := runCmd(store, "run", "codex", "--ring", "database", "--", "prompt")
+	if result.code == 0 || !strings.Contains(result.stderr, "execution is not implemented yet") {
+		t.Fatalf("expected dry-run-only error, got code=%d stdout=%s stderr=%s", result.code, result.stdout, result.stderr)
+	}
+	result = runCmd(store, "run", "codex", "--dry-run", "--", "prompt")
+	if result.code == 0 || !strings.Contains(result.stderr, "--ring is required") {
+		t.Fatalf("expected required ring error, got code=%d stdout=%s stderr=%s", result.code, result.stdout, result.stderr)
+	}
+	result = runCmd(store, "run", "codex", "--ring", " ", "--dry-run", "--", "prompt")
+	if result.code == 0 || !strings.Contains(result.stderr, "--ring is required") {
+		t.Fatalf("expected blank ring error, got code=%d stdout=%s stderr=%s", result.code, result.stdout, result.stderr)
+	}
+	result = runCmd(store, "run", "codex", "--ring", "database", "--dry-run")
+	if result.code == 0 || !strings.Contains(result.stderr, "prompt is required") {
+		t.Fatalf("expected required prompt error, got code=%d stdout=%s stderr=%s", result.code, result.stdout, result.stderr)
+	}
+}
+
+func TestRunWithStoreRunPlanBlocksMissingEnv(t *testing.T) {
+	store := newTestStore(t)
+	t.Setenv("CLOUDSQL_MCP_TOKEN", "")
+
+	if result := runCmd(store, "add", "cloud-sql",
+		"--transport", "http",
+		"--url", "https://sqladmin.googleapis.com/mcp",
+		"--client", "codex",
+		"--bearer-token-env-var", "CLOUDSQL_MCP_TOKEN"); result.code != 0 {
+		t.Fatalf("setup cloud-sql failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "ring", "create", "cloudsql-readonly", "--member", "cloud-sql"); result.code != 0 {
+		t.Fatalf("ring create failed: %s", result.stderr)
+	}
+
+	result := runCmd(store, "run", "codex", "--ring", "cloudsql-readonly", "--dry-run", "--json", "--", "prompt")
+	if result.code == 0 || !strings.Contains(result.stderr, "launch plan is not ready") {
+		t.Fatalf("expected blocked plan, got code=%d stdout=%s stderr=%s", result.code, result.stdout, result.stderr)
+	}
+	plan := decodeRunPlan(t, result.stdout)
+	if plan.Ready {
+		t.Fatalf("expected blocked plan, got: %#v", plan)
+	}
+	if env := findRunPlanEnv(t, plan, "CLOUDSQL_MCP_TOKEN"); env.Present {
+		t.Fatalf("expected missing env, got: %#v", env)
+	}
+	if !strings.Contains(strings.Join(plan.Errors, "\n"), "runtime env CLOUDSQL_MCP_TOKEN is missing") {
+		t.Fatalf("expected missing env error, got: %#v", plan.Errors)
+	}
+}
+
+func TestRunWithStoreRunPlanBlocksUnsupportedBearerAuth(t *testing.T) {
+	store := newTestStore(t)
+	t.Setenv("CLOUDSQL_MCP_TOKEN", "test-token")
+
+	if result := runCmd(store, "add", "cloud-sql",
+		"--transport", "http",
+		"--url", "https://sqladmin.googleapis.com/mcp",
+		"--client", "claude-code",
+		"--bearer-token-env-var", "CLOUDSQL_MCP_TOKEN"); result.code != 0 {
+		t.Fatalf("setup cloud-sql failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "ring", "create", "cloudsql-readonly", "--member", "cloud-sql"); result.code != 0 {
+		t.Fatalf("ring create failed: %s", result.stderr)
+	}
+
+	result := runCmd(store, "run", "claude-code", "--ring", "cloudsql-readonly", "--dry-run", "--json", "--", "prompt")
+	if result.code == 0 || !strings.Contains(result.stderr, "launch plan is not ready") {
+		t.Fatalf("expected blocked plan, got code=%d stdout=%s stderr=%s", result.code, result.stdout, result.stderr)
+	}
+	plan := decodeRunPlan(t, result.stdout)
+	if plan.Ready {
+		t.Fatalf("expected blocked plan, got: %#v", plan)
+	}
+	if !strings.Contains(strings.Join(plan.Errors, "\n"), "requires bearer_token_env_var auth") {
+		t.Fatalf("expected unsupported bearer auth error, got: %#v", plan.Errors)
+	}
+}
+
+func TestRunWithStoreRunPlanBlocksUnsupportedSkillTarget(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	if result := runCmd(store, "add", "desktop", "--command", commandPath, "--client", "claude-desktop"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+	skillSource := writeSkillFile(t, t.TempDir(), "release.md", "# Release\n")
+	if result := runCmd(store, "skill", "add", "release", "--file", skillSource, "--description", "Release workflow"); result.code != 0 {
+		t.Fatalf("skill add failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "ring", "create", "mixed", "--member", "desktop", "--skill", "release"); result.code != 0 {
+		t.Fatalf("ring create failed: %s", result.stderr)
+	}
+
+	result := runCmd(store, "run", "claude-desktop", "--ring", "mixed", "--dry-run", "--json", "--", "prompt")
+	if result.code == 0 || !strings.Contains(result.stderr, "launch plan is not ready") {
+		t.Fatalf("expected blocked plan, got code=%d stdout=%s stderr=%s", result.code, result.stdout, result.stderr)
+	}
+	plan := decodeRunPlan(t, result.stdout)
+	if plan.Ready {
+		t.Fatalf("expected blocked plan, got: %#v", plan)
+	}
+	if skill := findRunPlanSkill(t, plan, "release"); skill.Status != "blocked" {
+		t.Fatalf("expected blocked skill, got: %#v", skill)
+	}
+}
+
+func TestRunWithStoreRunPlanBlocksDisabledServerAndDuplicateRing(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+
+	if result := runCmd(store, "add", "helper", "--command", commandPath, "--client", "codex"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "ring", "create", "helpers", "--member", "helper"); result.code != 0 {
+		t.Fatalf("ring create failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "disable", "helper"); result.code != 0 {
+		t.Fatalf("disable failed: %s", result.stderr)
+	}
+
+	result := runCmd(store, "run", "codex", "--ring", "helpers", "--ring", "helpers", "--dry-run", "--json", "--", "prompt")
+	if result.code == 0 {
+		t.Fatalf("expected blocked plan, got stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	plan := decodeRunPlan(t, result.stdout)
+	errors := strings.Join(plan.Errors, "\n")
+	if !strings.Contains(errors, `duplicate ring "helpers"`) || !strings.Contains(errors, "server helper: server is disabled") {
+		t.Fatalf("expected duplicate and disabled errors, got: %#v", plan.Errors)
+	}
+}
+
+func decodeRunPlan(t *testing.T, payload string) runPlanJSON {
+	t.Helper()
+	var plan runPlanJSON
+	if err := json.Unmarshal([]byte(payload), &plan); err != nil {
+		t.Fatalf("decode run plan: %v\n%s", err, payload)
+	}
+	return plan
+}
+
+func findRunPlanServer(t *testing.T, plan runPlanJSON, name string) runPlanServer {
+	t.Helper()
+	for _, server := range plan.Servers {
+		if server.Name == name {
+			return server
+		}
+	}
+	t.Fatalf("server %q not found in %#v", name, plan.Servers)
+	return runPlanServer{}
+}
+
+func findRunPlanSkill(t *testing.T, plan runPlanJSON, name string) runPlanSkill {
+	t.Helper()
+	for _, skill := range plan.Skills {
+		if skill.Name == name {
+			return skill
+		}
+	}
+	t.Fatalf("skill %q not found in %#v", name, plan.Skills)
+	return runPlanSkill{}
+}
+
+func findRunPlanEnv(t *testing.T, plan runPlanJSON, key string) runPlanEnv {
+	t.Helper()
+	for _, env := range plan.Env {
+		if env.Key == key {
+			return env
+		}
+	}
+	t.Fatalf("env %q not found in %#v", key, plan.Env)
+	return runPlanEnv{}
+}

--- a/cmd/madari/run_plan_test.go
+++ b/cmd/madari/run_plan_test.go
@@ -168,6 +168,37 @@ func TestRunWithStoreRunPlanBlocksUnsupportedBearerAuth(t *testing.T) {
 	}
 }
 
+func TestRunWithStoreRunPlanBlocksUnsupportedOAuthResource(t *testing.T) {
+	store := newTestStore(t)
+
+	if result := runCmd(store, "add", "cloud-sql",
+		"--transport", "http",
+		"--url", "https://sqladmin.googleapis.com/mcp",
+		"--client", "claude-code",
+		"--oauth-resource", "https://sqladmin.googleapis.com/"); result.code != 0 {
+		t.Fatalf("setup cloud-sql failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "ring", "create", "cloudsql-readonly", "--member", "cloud-sql"); result.code != 0 {
+		t.Fatalf("ring create failed: %s", result.stderr)
+	}
+
+	result := runCmd(store, "run", "claude-code", "--ring", "cloudsql-readonly", "--dry-run", "--json", "--", "prompt")
+	if result.code == 0 || !strings.Contains(result.stderr, "launch plan is not ready") {
+		t.Fatalf("expected blocked plan, got code=%d stdout=%s stderr=%s", result.code, result.stdout, result.stderr)
+	}
+	plan := decodeRunPlan(t, result.stdout)
+	if plan.Ready {
+		t.Fatalf("expected blocked plan, got: %#v", plan)
+	}
+	cloud := findRunPlanServer(t, plan, "cloud-sql")
+	if cloud.Auth != "oauth_resource" || cloud.Status != "blocked" {
+		t.Fatalf("expected blocked oauth_resource server, got: %#v", cloud)
+	}
+	if !strings.Contains(strings.Join(plan.Errors, "\n"), "requires oauth_resource auth") {
+		t.Fatalf("expected unsupported oauth_resource error, got: %#v", plan.Errors)
+	}
+}
+
 func TestRunWithStoreRunPlanBlocksUnsupportedSkillTarget(t *testing.T) {
 	store := newTestStore(t)
 	commandPath := mustCurrentExecutable(t)

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -1384,6 +1384,9 @@ func TestRunWithStoreSubcommandHelpFlags(t *testing.T) {
 	if result := runCmd(store, "sync", "--help"); result.code != 0 || !strings.Contains(result.stdout, "madari sync <client>") {
 		t.Fatalf("expected sync --help to print command help, got code=%d stdout=%s stderr=%s", result.code, result.stdout, result.stderr)
 	}
+	if result := runCmd(store, "run", "--help"); result.code != 0 || !strings.Contains(result.stdout, "madari run <client>") {
+		t.Fatalf("expected run --help to print command help, got code=%d stdout=%s stderr=%s", result.code, result.stdout, result.stderr)
+	}
 	if result := runCmd(store, "skill", "--help"); result.code != 0 || !strings.Contains(result.stdout, "madari skill <subcommand>") {
 		t.Fatalf("expected skill --help to print command help, got code=%d stdout=%s stderr=%s", result.code, result.stdout, result.stderr)
 	}

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -2393,6 +2393,38 @@ func TestRunWithStoreDoctorMarksOAuthResourceRemotePending(t *testing.T) {
 	}
 }
 
+func TestRunWithStoreDoctorSkipsConfigForUnsupportedOAuthResourceRemote(t *testing.T) {
+	store := newTestStore(t)
+
+	if result := runCmd(store, "add", "cloud-sql",
+		"--transport", "http",
+		"--url", "https://sqladmin.googleapis.com/mcp",
+		"--client", "gemini",
+		"--oauth-resource", "https://sqladmin.googleapis.com/"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+
+	missingConfigPath := filepath.Join(t.TempDir(), ".gemini", "settings.json")
+	result := runCmd(store, "doctor", "--client-config", "gemini="+missingConfigPath)
+	if result.code != 0 {
+		t.Fatalf("doctor expected success, got code=%d stderr=%s stdout=%s", result.code, result.stderr, result.stdout)
+	}
+	if !strings.Contains(result.stdout, "url=https://sqladmin.googleapis.com/mcp sync=pending(gemini)") {
+		t.Fatalf("expected oauth_resource remote to be pending for gemini, got: %s", result.stdout)
+	}
+	if strings.Contains(result.stdout, "gemini config:") || strings.Contains(result.stdout, "config file not found") {
+		t.Fatalf("expected unsupported oauth_resource remote not to require gemini config inspection, got: %s", result.stdout)
+	}
+
+	result = runCmd(store, "status", "--client-config", "gemini="+missingConfigPath)
+	if result.code != 0 {
+		t.Fatalf("status expected success, got code=%d stderr=%s stdout=%s", result.code, result.stderr, result.stdout)
+	}
+	if strings.Contains(result.stdout, "gemini-config:") {
+		t.Fatalf("expected unsupported oauth_resource remote not to require gemini config status, got: %s", result.stdout)
+	}
+}
+
 func TestRunWithStoreDoctorAndStatusInspectCodexConfig(t *testing.T) {
 	store := newTestStore(t)
 	commandPath := mustCurrentExecutable(t)

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -2365,6 +2365,34 @@ func TestRunWithStoreDoctorAndStatusInspectGeminiConfig(t *testing.T) {
 	}
 }
 
+func TestRunWithStoreDoctorMarksOAuthResourceRemotePending(t *testing.T) {
+	store := newTestStore(t)
+
+	if result := runCmd(store, "add", "cloud-sql",
+		"--transport", "http",
+		"--url", "https://sqladmin.googleapis.com/mcp",
+		"--client", "gemini",
+		"--oauth-resource", "https://sqladmin.googleapis.com/"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+
+	configPath := filepath.Join(t.TempDir(), ".gemini", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{"mcpServers":{}}`), 0o644); err != nil {
+		t.Fatalf("write Gemini config fixture: %v", err)
+	}
+
+	result := runCmd(store, "doctor", "--client-config", "gemini="+configPath)
+	if result.code != 0 {
+		t.Fatalf("doctor expected success, got code=%d stderr=%s stdout=%s", result.code, result.stderr, result.stdout)
+	}
+	if !strings.Contains(result.stdout, "url=https://sqladmin.googleapis.com/mcp sync=pending(gemini)") {
+		t.Fatalf("expected oauth_resource remote to be pending for gemini, got: %s", result.stdout)
+	}
+}
+
 func TestRunWithStoreDoctorAndStatusInspectCodexConfig(t *testing.T) {
 	store := newTestStore(t)
 	commandPath := mustCurrentExecutable(t)
@@ -2807,6 +2835,35 @@ func TestRunWithStoreSyncReportsUnsupportedRemoteAuth(t *testing.T) {
 `, configPath)
 	if result.stdout != expected {
 		t.Fatalf("sync --json unsupported remote auth schema drift:\nwant:\n%s\ngot:\n%s", expected, result.stdout)
+	}
+}
+
+func TestRunWithStoreSyncReportsUnsupportedRemoteOAuthResource(t *testing.T) {
+	store := newTestStore(t)
+
+	if result := runCmd(store, "add", "cloud-sql",
+		"--transport", "http",
+		"--url", "https://sqladmin.googleapis.com/mcp",
+		"--client", "gemini",
+		"--oauth-resource", "https://sqladmin.googleapis.com/"); result.code != 0 {
+		t.Fatalf("setup add failed: %s", result.stderr)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "settings.json")
+	result := runCmd(store, "sync", "gemini", "--dry-run", "--config-path", configPath)
+	if result.code != 0 {
+		t.Fatalf("sync dry-run failed: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	if !strings.Contains(result.stdout, "unsupported remote: cloud-sql") {
+		t.Fatalf("expected unsupported remote summary, got: %s", result.stdout)
+	}
+	if strings.Contains(result.stdout, "added: cloud-sql") {
+		t.Fatalf("expected oauth-unsupported remote not to be added, got: %s", result.stdout)
+	}
+	if !strings.Contains(result.stderr, "cloud-sql requires oauth_resource auth") ||
+		!strings.Contains(result.stderr, "stored in registry") ||
+		!strings.Contains(result.stderr, "gemini sync does not materialize oauth_resource auth yet") {
+		t.Fatalf("expected unsupported oauth_resource warning, got: %s", result.stderr)
 	}
 }
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -111,6 +111,8 @@ madari ring render research --client gemini
 madari ring render research --client codex
 madari ring render research --client vibe
 madari ring status
+madari run codex --ring research --dry-run -- "Use this ring"
+madari run codex --ring research --ring release --dry-run --json -- "Use both rings"
 ```
 
 Rings are named capability sets of servers and skills stored at
@@ -188,6 +190,30 @@ ring was attached to a custom config. `madari doctor` reports
 the same conditions as `ring_issues` (missing ring file = error, dangling
 server member = warning).
 
+## Run Planner
+
+```bash
+madari run <client> --ring <ring> [--ring <ring> ...] --dry-run -- <prompt>
+madari run codex --ring cloudsql-readonly --dry-run -- "Who are the top 5 ebook creators?"
+madari run codex --ring cloudsql-readonly --ring research --dry-run --json -- "Inspect the combined plan"
+```
+
+`madari run` is the launch primitive for using one or more rings with a target
+client. In this first implementation it is planner-only and requires
+`--dry-run`; omitting `--dry-run` exits non-zero with guidance instead of
+starting a client.
+
+The planner resolves every selected ring, deduplicates shared server and skill
+members, validates the selected client can express each required capability,
+checks runtime env keys by name, and reports the launch plan. It does not write
+client config, create managed state, materialize skill packages, or start the
+client yet.
+
+Unlike `ring render`, `run` is fail-closed. A disabled member, missing member,
+unsupported remote transport or auth mode, missing runtime env key, or
+unsupported skill target blocks the plan instead of silently omitting that
+capability.
+
 ## Skills
 
 ```bash
@@ -226,7 +252,7 @@ releases direct ownership and removes the package only when no source owns it
 anymore; it refuses to delete packages modified since Madari last wrote them.
 Ring attach uses the same native skill materialization state with
 `ring:<name>` ownership sources. Skills are not written into MCP client configs
-and are not consumed by `run`.
+and are not materialized by the dry-run planner yet.
 
 ## Diagnostics
 
@@ -259,8 +285,8 @@ the next sync, attach, or detach.
 
 ## JSON Output
 
-`list`, `status`, `doctor`, `sync --dry-run`, `ring list`, `ring show`,
-`ring status`, `skill list`, and `skill show` accept `--json` and emit a
+`list`, `status`, `doctor`, `sync --dry-run`, `run --dry-run`, `ring list`,
+`ring show`, `ring status`, `skill list`, and `skill show` accept `--json` and emit a
 single JSON document on stdout with nothing else.
 Every payload carries the envelope fields `schema_version` (currently `1`)
 and `command`. Field additions are backward-compatible; renames or removals
@@ -273,6 +299,7 @@ madari list --json
 madari status --json
 madari doctor --json
 madari sync claude-code --dry-run --json
+madari run codex --ring research --dry-run --json -- "Use this ring"
 madari ring list --json
 madari ring show research --json
 madari ring status --json
@@ -281,7 +308,7 @@ madari skill show release --json
 ```
 
 `sync --json` requires `--dry-run`; the apply-mode output contract is not yet
-defined.
+defined. `run --json` also requires `--dry-run` until client execution lands.
 
 ### Schemas (schema_version 1)
 
@@ -422,6 +449,45 @@ itself.
   "skills_updated": [],
   "skills_removed": [],
   "skills_unchanged": []
+}
+```
+
+`madari run <client> --ring <ring> --dry-run --json`:
+
+```json
+{
+  "schema_version": 1,
+  "command": "run",
+  "target": "codex",
+  "rings": ["cloudsql-readonly"],
+  "ready": true,
+  "runner_available": false,
+  "prompt_provided": true,
+  "servers": [
+    {
+      "name": "cloud-sql",
+      "transport": "http",
+      "endpoint": "https://sqladmin.googleapis.com/mcp",
+      "status": "ready",
+      "auth": "bearer_token_env_var",
+      "runtime_env": ["CLOUDSQL_MCP_TOKEN"],
+      "rings": ["cloudsql-readonly"],
+      "issues": []
+    }
+  ],
+  "skills": [
+    {
+      "name": "cloudsql-readonly-query",
+      "status": "ready",
+      "rings": ["cloudsql-readonly"],
+      "issues": []
+    }
+  ],
+  "env": [
+    {"key": "CLOUDSQL_MCP_TOKEN", "present": true, "servers": ["cloud-sql"]}
+  ],
+  "warnings": [],
+  "errors": []
 }
 ```
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -66,9 +66,9 @@ Claude Code writes `type`/`url` entries with `headers` into its config
 Gemini writes `httpUrl` (Streamable HTTP) or `url` (SSE) entries with
 `headers`. `timeout_ms` is carried through as each client's per-server
 `timeout` field (milliseconds). `oauth_resource` has no equivalent in either
-client and is not emitted. Remote entries that require
-`bearer_token_env_var` stay pending for these clients until an equivalent
-auth config shape is validated.
+client, and neither client has a validated `bearer_token_env_var` equivalent.
+Remote entries that require either auth metadata shape stay pending for these
+clients until an equivalent config shape is validated.
 
 `codex` sync targets Codex's user config (`$CODEX_HOME/config.toml`, or
 `~/.codex/config.toml` when `CODEX_HOME` is unset). Static non-secret `[env]`

--- a/docs/manifest-spec.md
+++ b/docs/manifest-spec.md
@@ -46,10 +46,11 @@ Remote materialization is per client and per transport:
 
 Remote auth metadata is validated separately from transport support. For
 example, `claude-code` and `gemini` can materialize remote URLs, but entries
-that require `bearer_token_env_var` stay pending for those clients until an
-equivalent auth config shape is validated. `oauth_resource` is for clients and
-servers that support OAuth resource metadata; `bearer_token_env_var` stores
-only the env var name, never the bearer token value.
+that require `oauth_resource` or `bearer_token_env_var` stay pending for those
+clients until equivalent auth config shapes are validated. `oauth_resource` is
+for clients and servers that support OAuth resource metadata;
+`bearer_token_env_var` stores only the env var name, never the bearer token
+value.
 
 ### `[headers]`
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -285,7 +285,7 @@ func checkDrift(manifests []registry.Manifest, targets []DriftTarget, rings []re
 			continue
 		}
 
-		plan, err := target.Adapter.Sync(syncableForTarget(manifests, target.Adapter.Target()), clients.SyncOptions{
+		plan, err := target.Adapter.Sync(syncableForTarget(manifests, target.Adapter.Target(), target.Adapter.SupportsRemote), clients.SyncOptions{
 			ConfigPath: target.ConfigPath,
 			StatePath:  target.StatePath,
 			Rings:      rings,
@@ -316,13 +316,17 @@ func checkDrift(manifests []registry.Manifest, targets []DriftTarget, rings []re
 }
 
 // syncableForTarget mirrors the sync command's manifest filtering: entries
-// enabled for this target whose command fails validation never reach the
-// adapter, so the drift plan matches what `madari sync` would actually do.
-func syncableForTarget(manifests []registry.Manifest, target string) []registry.Manifest {
+// enabled for this target whose command or remote auth shape cannot be
+// materialized never reach the adapter as eligible, so the drift plan matches
+// what `madari sync` would actually do.
+func syncableForTarget(manifests []registry.Manifest, target string, supportsRemote func(transport string) bool) []registry.Manifest {
 	out := make([]registry.Manifest, 0, len(manifests))
 	for _, manifest := range manifests {
-		if manifest.Enabled && manifest.HasClient(target) && !manifest.IsRemote() {
-			if issue := validateAbsoluteExecutablePath(manifest.Command); issue != nil {
+		if manifest.Enabled && manifest.HasClient(target) {
+			switch {
+			case manifest.IsRemote() && !targetSupportsRemoteManifest(manifest, target, supportsRemote):
+				manifest.Enabled = false
+			case !manifest.IsRemote() && validateAbsoluteExecutablePath(manifest.Command) != nil:
 				continue
 			}
 		}
@@ -669,8 +673,8 @@ func hasTarget(manifest registry.Manifest, targets []string) bool {
 func hasTargetInManifests(manifests []registry.Manifest, target string, supportsRemote func(transport string) bool) bool {
 	for _, manifest := range manifests {
 		// Remote manifests only warrant a client config on disk when the
-		// target's adapter materializes their transport.
-		if manifest.IsRemote() && (!supportsRemote(manifest.TransportType()) || (manifest.RequiresBearerTokenEnv() && target != codex.Target)) {
+		// target's adapter materializes their transport and auth metadata.
+		if manifest.IsRemote() && !targetSupportsRemoteManifest(manifest, target, supportsRemote) {
 			continue
 		}
 		if manifest.HasClient(target) {
@@ -678,6 +682,22 @@ func hasTargetInManifests(manifests []registry.Manifest, target string, supports
 		}
 	}
 	return false
+}
+
+func targetSupportsRemoteManifest(manifest registry.Manifest, target string, supportsRemote func(transport string) bool) bool {
+	if !manifest.IsRemote() {
+		return true
+	}
+	if supportsRemote == nil || !supportsRemote(manifest.TransportType()) {
+		return false
+	}
+	if strings.TrimSpace(manifest.OAuthResource) != "" && target != codex.Target {
+		return false
+	}
+	if manifest.RequiresBearerTokenEnv() && target != codex.Target {
+		return false
+	}
+	return true
 }
 
 // validateAbsoluteExecutablePath wraps the shared command-validity check so

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -45,6 +45,7 @@ type ServerReport struct {
 	Transport         string
 	Command           string
 	URL               string
+	OAuthResource     string
 	BearerTokenEnvVar string
 	Status            Status
 	Issues            []Issue
@@ -378,6 +379,7 @@ func inspectServer(manifest registry.Manifest, envLookup func(string) string, ta
 		Transport:         manifest.TransportType(),
 		Command:           manifest.Command,
 		URL:               manifest.URL,
+		OAuthResource:     manifest.OAuthResource,
 		BearerTokenEnvVar: manifest.BearerTokenEnvVar,
 		Status:            StatusSkipped,
 		Issues:            []Issue{},

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ankitvg/madari/internal/clients"
 	"github.com/ankitvg/madari/internal/clients/claudecode"
+	"github.com/ankitvg/madari/internal/clients/gemini"
 	"github.com/ankitvg/madari/internal/registry"
 )
 
@@ -719,6 +720,72 @@ func TestRunDriftDetection(t *testing.T) {
 	}
 	if report.Summary.Warning < 1 {
 		t.Fatalf("expected drift to count as warning, got summary: %#v", report.Summary)
+	}
+}
+
+func TestRunDriftTreatsUnsupportedOAuthRemoteAsOrphaned(t *testing.T) {
+	tmp := t.TempDir()
+	store := registry.NewStore(filepath.Join(tmp, "servers"))
+	if err := store.Save(registry.Manifest{
+		Name:          "cloud-sql",
+		Transport:     registry.TransportHTTP,
+		URL:           "https://sqladmin.googleapis.com/mcp",
+		OAuthResource: "https://sqladmin.googleapis.com/",
+		Enabled:       true,
+		Clients:       []string{"gemini"},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+
+	configPath := filepath.Join(tmp, ".gemini", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+	config := `{
+  "mcpServers": {
+    "cloud-sql": {"httpUrl": "https://sqladmin.googleapis.com/mcp"}
+  }
+}
+`
+	if err := os.WriteFile(configPath, []byte(config), 0o644); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+
+	statePath := filepath.Join(tmp, "state", "gemini-managed.json")
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
+		t.Fatalf("create state dir: %v", err)
+	}
+	state := `{"version":2,"managed_servers":{"cloud-sql":["standalone"]}}`
+	if err := os.WriteFile(statePath, []byte(state), 0o644); err != nil {
+		t.Fatalf("write state fixture: %v", err)
+	}
+
+	adapter := gemini.Adapter{}
+	report, err := Run(store, Options{
+		Adapters: []clients.ClientAdapter{adapter},
+		ConfigPathOverrides: map[string]string{
+			"gemini": configPath,
+		},
+		DriftTargets: []DriftTarget{
+			{Adapter: adapter, StatePath: statePath, ConfigPath: configPath},
+		},
+	})
+	if err != nil {
+		t.Fatalf("doctor run failed: %v", err)
+	}
+
+	if len(report.Drift) != 1 {
+		t.Fatalf("expected one drift report, got: %#v", report.Drift)
+	}
+	dr := report.Drift[0]
+	if dr.Status != StatusWarning {
+		t.Fatalf("expected drift warning, got: %#v", dr)
+	}
+	if len(dr.Orphaned) != 1 || dr.Orphaned[0] != "cloud-sql" {
+		t.Fatalf("expected unsupported oauth remote to be orphaned, got: %#v", dr)
+	}
+	if len(dr.Stale) != 0 || len(dr.Missing) != 0 {
+		t.Fatalf("expected no stale or missing entries, got: %#v", dr)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds the first `madari run` primitive as a dry-run launch planner. This PR does not execute Codex or any other client yet; it validates what would be launched from one or more rings and reports the plan.

## What changed

- Added `madari run <client> --ring <ring> [--ring <ring> ...] --dry-run -- <prompt>`.
- Added strict launch-plan validation for ring existence, duplicate rings, server membership, enabled status, client targeting, remote transport/auth support, runtime env availability, and skill materialization support.
- Added text and JSON output for ready/blocked plans without printing secret values.
- Documented the dry-run-only planner in the README and CLI reference.

## Why

Cloud SQL ring testing showed that Madari can define and attach capabilities, but users still need to hand-write the final client launch command. This PR introduces the client-first run primitive and multiple-ring composition without taking on client process execution yet.

## Out of scope

- No `codex exec` invocation yet.
- No temp client config or temp skill materialization yet.
- No client-specific runner implementations yet.
- No Cloud SQL example update in this PR.

## Validation

- `make build`
- `go test ./...`
- `git diff --check origin/main..HEAD`
