### PR TITLE
Capability Policy V1: schema and compatibility contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # madari (muh-DAA-ree)
 
 Madari is a local-first CLI for managing MCP capability setup across AI clients.
-It registers MCP servers, stores reusable skills, groups them into rings,
-plans ring-based agent launches, and syncs only the entries it owns into
-client config files.
+It registers MCP servers and their optional access profiles, stores reusable
+skills, groups them into rings, plans ring-based agent launches, and syncs only
+the entries it owns into client config files.
 
 Madari is intentionally static: no daemon, proxy, or background mux. It helps
 the AI clients and agents you already use get the right capabilities with
@@ -116,7 +116,9 @@ syntax.
 
 **Servers** are MCP server capabilities. Madari stores stdio commands or remote
 HTTP/SSE URLs, environment or header metadata, supported clients, and ownership
-state.
+state. A server may also declare one portable `[access]` profile with an exact
+tool allowlist, an optional deny list, requested OAuth scopes, and default or
+per-tool approval behavior.
 
 **Skills** are official Agent Skill packages: directories with `SKILL.md`
 frontmatter and optional bundled files such as `references/`, `scripts/`, and
@@ -124,11 +126,13 @@ frontmatter and optional bundled files such as `references/`, `scripts/`, and
 rings, where Madari materializes the full package for the target.
 
 **Rings** are named capability sets. A ring can contain server members and skill
-members, then attach to a client as one unit. Rings can also carry an advisory
-contract for delegation: when to use the ring, what context to provide, and
-what outputs to expect. Contracts can be managed from standalone TOML files with
-`madari ring contract`. Ring ownership is reference counted, so overlapping
-rings and standalone entries detach cleanly in any order.
+members, then attach to a client as one unit. A ring `[policy]` can require exact
+compilation of every server member's access profile for the selected target.
+Rings can also carry an advisory contract for delegation: when to use the ring,
+what context to provide, and what outputs to expect. Contracts never authorize
+tool access. They can be managed from standalone TOML files with `madari ring
+contract`. Ring ownership is reference counted, so overlapping rings and
+standalone entries detach cleanly in any order.
 
 **Sync** writes managed server entries into client config files. Madari backs up
 before writing, skips ineligible entries instead of aborting the whole sync, and
@@ -151,6 +155,13 @@ MCP servers still receive the caller's non-secret `HOME`, `USERPROFILE`, and
 secret declarations for those isolated env keys are blocked. Other clients
 remain dry-run only for now.
 
+Capability Policy Contract V1 preserves existing behavior for manifests without
+`[access]` and rings without `[policy]`. In the schema-and-compatibility stage,
+policy capability declarations for sync/attach, render, and run are all
+unsupported. A policy-required operation therefore fails during preflight,
+before client config, managed state, skill files, render output, or execution can
+change. Target compilers opt into those surfaces in later implementation stages.
+
 ## Safety Model
 
 - Local-first registry and human-readable config files
@@ -165,6 +176,12 @@ remain dry-run only for now.
   stays in the runtime environment
 - `madari run` checks runtime env keys by name without printing their values;
   Codex execution passes bearer-token env var names, not token values
+- Policy-required operations fail closed instead of approximating or dropping
+  an access restriction
+- OAuth scopes are requested and client-configured; Madari cannot prove that an
+  OAuth provider granted them
+- Tool approval behavior controls client prompts and is not an authorization
+  boundary
 - Diagnostics through `madari doctor`, `madari status`, and `madari ring status`
 
 ## Supported Clients
@@ -183,6 +200,12 @@ remote manifests and report them as pending. Remote entries that require
 `oauth_resource` or `bearer_token_env_var` currently materialize only for
 `codex`.
 
+Transport, auth, and skill support are separate from capability-policy support.
+The initial policy-contract release declares policy compilation unsupported for
+every client on persistent sync/attach, render, and run surfaces. Legacy
+operations remain available; rings with `[policy] enforcement = "required"`
+block until a target compiler explicitly supports the selected surface.
+
 Madari can materialize skills for:
 
 - `claude-code`
@@ -195,6 +218,7 @@ Madari can materialize skills for:
 - `docs/cli-reference.md`
 - `docs/architecture.md`
 - `docs/manifest-spec.md`
+- `docs/adr/003-capability-policy-contract-v1.md`
 - `docs/troubleshooting.md`
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -154,13 +154,17 @@ MCP servers still receive the caller's non-secret `HOME`, `USERPROFILE`, and
 `CODEX_HOME` values when present so home-based server credentials keep working;
 secret declarations for those isolated env keys are blocked. Other clients
 remain dry-run only for now.
+Every access-bearing Codex run requires a stable Codex CLI 0.139.x release and
+passes the complete profile through one strict ephemeral config override. A
+required ring upgrades that supported profile from advisory to exact
+enforcement and blocks before temporary skill materialization on any downgrade.
 
 Capability Policy Contract V1 preserves existing behavior for manifests without
-`[access]` and rings without `[policy]`. In the schema-and-compatibility stage,
-policy capability declarations for sync/attach, render, and run are all
-unsupported. A policy-required operation therefore fails during preflight,
-before client config, managed state, skill files, render output, or execution can
-change. Target compilers opt into those surfaces in later implementation stages.
+`[access]` and rings without `[policy]`. Codex compiles all five V1 access fields
+for persistent sync/attach, render, and ephemeral run. Required operations fail
+during preflight if a member, native field, or installed Codex version cannot
+represent the contract exactly. Other target policy surfaces remain unsupported
+until their own compilers land.
 
 ## Safety Model
 
@@ -201,10 +205,10 @@ remote manifests and report them as pending. Remote entries that require
 `codex`.
 
 Transport, auth, and skill support are separate from capability-policy support.
-The initial policy-contract release declares policy compilation unsupported for
-every client on persistent sync/attach, render, and run surfaces. Legacy
+Codex supports exact policy compilation on persistent sync/attach, render, and
+run. Every policy surface for other clients remains unsupported. Legacy
 operations remain available; rings with `[policy] enforcement = "required"`
-block until a target compiler explicitly supports the selected surface.
+block whenever the selected target surface lacks an exact compiler.
 
 Madari can materialize skills for:
 

--- a/cmd/madari/access_flags.go
+++ b/cmd/madari/access_flags.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+// accessFlags is shared by add and install so both server-registration paths
+// expose the same portable access-profile vocabulary.
+type accessFlags struct {
+	allowedTools    stringList
+	deniedTools     stringList
+	oauthScopes     stringList
+	defaultApproval optionalStringFlag
+	toolApprovals   stringList
+}
+
+func (f *accessFlags) register(fs *flag.FlagSet, includeOAuthScopes bool) {
+	fs.Var(&f.allowedTools, "allow-tool", "Allowed MCP tool name (repeatable)")
+	fs.Var(&f.deniedTools, "deny-tool", "Denied MCP tool name (repeatable)")
+	if includeOAuthScopes {
+		fs.Var(&f.oauthScopes, "oauth-scope", "Requested OAuth scope (repeatable)")
+	}
+	fs.Var(&f.defaultApproval, "default-tool-approval", "Default portable tool approval behavior")
+	fs.Var(&f.toolApprovals, "tool-approval", "Per-tool approval TOOL=BEHAVIOR (repeatable)")
+}
+
+func (f accessFlags) profile() (*registry.AccessProfile, error) {
+	if len(f.allowedTools) == 0 && len(f.deniedTools) == 0 && len(f.oauthScopes) == 0 &&
+		!f.defaultApproval.set && len(f.toolApprovals) == 0 {
+		return nil, nil
+	}
+
+	profile := &registry.AccessProfile{}
+	if len(f.allowedTools) > 0 {
+		values := append([]string(nil), f.allowedTools...)
+		profile.AllowedTools = &values
+	}
+	if len(f.deniedTools) > 0 {
+		values := append([]string(nil), f.deniedTools...)
+		profile.DeniedTools = &values
+	}
+	if len(f.oauthScopes) > 0 {
+		values := append([]string(nil), f.oauthScopes...)
+		profile.OAuthScopes = &values
+	}
+	if f.defaultApproval.set {
+		value := strings.TrimSpace(f.defaultApproval.value)
+		if value == "" {
+			return nil, fmt.Errorf("invalid default tool approval %q: behavior must be non-empty", f.defaultApproval.value)
+		}
+		approval := registry.ApprovalBehavior(value)
+		profile.DefaultApproval = &approval
+	}
+	if len(f.toolApprovals) > 0 {
+		approvals := make(map[string]registry.ApprovalBehavior, len(f.toolApprovals))
+		for _, assignment := range f.toolApprovals {
+			tool, value, ok := strings.Cut(assignment, "=")
+			tool = strings.TrimSpace(tool)
+			value = strings.TrimSpace(value)
+			if !ok || tool == "" || value == "" {
+				return nil, fmt.Errorf("invalid tool approval %q, expected TOOL=BEHAVIOR", assignment)
+			}
+			if _, exists := approvals[tool]; exists {
+				return nil, fmt.Errorf("duplicate tool approval for %q", tool)
+			}
+			approvals[tool] = registry.ApprovalBehavior(value)
+		}
+		profile.ToolApprovals = &approvals
+	}
+	return profile, nil
+}
+
+type optionalStringFlag struct {
+	value string
+	set   bool
+}
+
+func (f *optionalStringFlag) String() string {
+	return f.value
+}
+
+func (f *optionalStringFlag) Set(value string) error {
+	f.value = value
+	f.set = true
+	return nil
+}

--- a/cmd/madari/capability_policy_cli_test.go
+++ b/cmd/madari/capability_policy_cli_test.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+func TestCapabilityPolicyAddFlagsAndListJSON(t *testing.T) {
+	store := newTestStore(t)
+	result := runCmd(
+		store,
+		"add", "docs.api",
+		"--transport", "http",
+		"--url", "https://example.com/mcp",
+		"--client", "codex",
+		"--allow-tool", "issues.get",
+		"--allow-tool", "issues.list",
+		"--deny-tool", "issues.delete",
+		"--oauth-scope", "issues:read",
+		"--default-tool-approval", "always-prompt",
+		"--tool-approval", "issues.get=always-allow",
+	)
+	if result.code != 0 {
+		t.Fatalf("add with access profile failed: %s", result.stderr)
+	}
+
+	manifest, err := store.Get("docs.api")
+	if err != nil {
+		t.Fatalf("load access manifest: %v", err)
+	}
+	if manifest.Access == nil || manifest.Access.AllowedTools == nil || manifest.Access.DeniedTools == nil ||
+		manifest.Access.OAuthScopes == nil || manifest.Access.DefaultApproval == nil || manifest.Access.ToolApprovals == nil {
+		t.Fatalf("access profile lost CLI field presence: %#v", manifest.Access)
+	}
+	if got, want := *manifest.Access.AllowedTools, []string{"issues.get", "issues.list"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("allowed tools mismatch: got %#v want %#v", got, want)
+	}
+	if *manifest.Access.DefaultApproval != registry.ApprovalBehaviorAlwaysPrompt ||
+		(*manifest.Access.ToolApprovals)["issues.get"] != registry.ApprovalBehaviorAlwaysAllow {
+		t.Fatalf("approval mapping mismatch: %#v", manifest.Access)
+	}
+
+	list := runCmd(store, "list", "--json")
+	if list.code != 0 {
+		t.Fatalf("list JSON failed: %s", list.stderr)
+	}
+	payload := decodeJSONObject(t, list.stdout)
+	server := findCapabilityPolicyServer(t, payload, "docs.api")
+	access, ok := server["access"].(map[string]any)
+	if !ok {
+		t.Fatalf("list JSON missing access object: %#v", server)
+	}
+	assertJSONKeys(t, access, "allowed_tools", "denied_tools", "oauth_scopes", "default_approval", "tool_approvals")
+	if access["default_approval"] != "always-prompt" {
+		t.Fatalf("unexpected access JSON: %#v", access)
+	}
+}
+
+func TestCapabilityPolicyInstallFlags(t *testing.T) {
+	store := newTestStore(t)
+	result := runCmd(
+		store,
+		"install", "docs-mcp",
+		"--skip-install",
+		"--no-sync",
+		"--command", mustCurrentExecutable(t),
+		"--allow-tool", "read",
+		"--default-tool-approval", "automatic",
+		"--tool-approval", "read=always-allow",
+	)
+	if result.code != 0 {
+		t.Fatalf("install with access profile failed: %s", result.stderr)
+	}
+	manifest, err := store.Get("docs")
+	if err != nil {
+		t.Fatalf("load installed manifest: %v", err)
+	}
+	if manifest.Access == nil || manifest.Access.AllowedTools == nil || manifest.Access.DefaultApproval == nil {
+		t.Fatalf("install lost access profile: %#v", manifest.Access)
+	}
+}
+
+func TestCapabilityPolicyCLIRejectsInvalidAccessFlags(t *testing.T) {
+	commandPath := mustCurrentExecutable(t)
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "raw client approval",
+			args: []string{"add", "raw-mode", "--command", commandPath, "--client", "codex", "--allow-tool", "read", "--default-tool-approval", "prompt"},
+			want: "invalid default_approval",
+		},
+		{
+			name: "blank approval",
+			args: []string{"add", "blank-mode", "--command", commandPath, "--client", "codex", "--default-tool-approval="},
+			want: "behavior must be non-empty",
+		},
+		{
+			name: "stdio oauth scope",
+			args: []string{"add", "stdio-scope", "--command", commandPath, "--client", "codex", "--allow-tool", "read", "--oauth-scope", "docs:read"},
+			want: "oauth_scopes requires a remote transport",
+		},
+		{
+			name: "duplicate tool approval",
+			args: []string{"add", "duplicate-approval", "--command", commandPath, "--client", "codex", "--allow-tool", "read", "--tool-approval", "read=automatic", "--tool-approval", "read=always-prompt"},
+			want: `duplicate tool approval for "read"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := runCmd(newTestStore(t), tt.args...)
+			if result.code == 0 || !strings.Contains(result.stderr, tt.want) {
+				t.Fatalf("expected %q refusal, code=%d stdout=%s stderr=%s", tt.want, result.code, result.stdout, result.stderr)
+			}
+		})
+	}
+}
+
+func TestCapabilityPolicyJSONPreservesAbsenceAndExplicitClear(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+	if err := store.Save(registry.Manifest{Name: "legacy", Command: commandPath, Enabled: true, Clients: []string{"codex"}}); err != nil {
+		t.Fatalf("save legacy manifest: %v", err)
+	}
+	emptyTools := []string{}
+	emptyApprovals := map[string]registry.ApprovalBehavior{}
+	if err := store.Save(registry.Manifest{
+		Name:    "cleared",
+		Command: commandPath,
+		Enabled: true,
+		Clients: []string{"codex"},
+		Access: &registry.AccessProfile{
+			AllowedTools:  &emptyTools,
+			ToolApprovals: &emptyApprovals,
+		},
+	}); err != nil {
+		t.Fatalf("save explicit-clear manifest: %v", err)
+	}
+
+	result := runCmd(store, "list", "--json")
+	if result.code != 0 {
+		t.Fatalf("list JSON failed: %s", result.stderr)
+	}
+	payload := decodeJSONObject(t, result.stdout)
+	legacy := findCapabilityPolicyServer(t, payload, "legacy")
+	if _, exists := legacy["access"]; exists {
+		t.Fatalf("legacy access absence collapsed: %#v", legacy)
+	}
+	cleared := findCapabilityPolicyServer(t, payload, "cleared")
+	access := cleared["access"].(map[string]any)
+	if values, ok := access["allowed_tools"].([]any); !ok || len(values) != 0 {
+		t.Fatalf("explicit empty allowlist not preserved: %#v", access)
+	}
+	if values, ok := access["tool_approvals"].(map[string]any); !ok || len(values) != 0 {
+		t.Fatalf("explicit empty tool approval table not preserved: %#v", access)
+	}
+}
+
+func TestCapabilityPolicyRingCreateShowAndJSON(t *testing.T) {
+	store := newTestStore(t)
+	if result := runCmd(store, "add", "docs", "--command", mustCurrentExecutable(t), "--client", "codex", "--allow-tool", "read"); result.code != 0 {
+		t.Fatalf("server setup failed: %s", result.stderr)
+	}
+	if result := runCmd(store, "ring", "create", "restricted", "--member", "docs", "--enforcement", "required"); result.code != 0 {
+		t.Fatalf("required ring create failed: %s", result.stderr)
+	}
+	ring, err := store.GetRing("restricted")
+	if err != nil || !ring.RequiresPolicyEnforcement() {
+		t.Fatalf("required ring policy not stored: ring=%#v err=%v", ring, err)
+	}
+
+	show := runCmd(store, "ring", "show", "restricted")
+	if show.code != 0 || !strings.Contains(show.stdout, "policy:\n  enforcement: required") {
+		t.Fatalf("ring show missing policy: stdout=%s stderr=%s", show.stdout, show.stderr)
+	}
+	showJSON := runCmd(store, "ring", "show", "restricted", "--json")
+	if showJSON.code != 0 {
+		t.Fatalf("ring show JSON failed: %s", showJSON.stderr)
+	}
+	payload := decodeJSONObject(t, showJSON.stdout)
+	policy := payload["ring"].(map[string]any)["policy"].(map[string]any)
+	if policy["enforcement"] != "required" {
+		t.Fatalf("unexpected policy JSON: %#v", policy)
+	}
+
+	for _, args := range [][]string{
+		{"ring", "create", "blank", "--member", "docs", "--enforcement="},
+		{"ring", "create", "optional", "--member", "docs", "--enforcement", "optional"},
+	} {
+		result := runCmd(store, args...)
+		if result.code == 0 || !strings.Contains(result.stderr, "enforcement") {
+			t.Fatalf("invalid enforcement should fail: args=%#v stdout=%s stderr=%s", args, result.stdout, result.stderr)
+		}
+	}
+}
+
+func TestCapabilityPolicyHelp(t *testing.T) {
+	store := newTestStore(t)
+	add := runCmd(store, "add", "--help")
+	for _, want := range []string{"--allow-tool", "--oauth-scope", "--default-tool-approval", "always-prompt"} {
+		if add.code != 0 || !strings.Contains(add.stdout, want) {
+			t.Fatalf("add help missing %q: code=%d stdout=%s", want, add.code, add.stdout)
+		}
+	}
+	install := runCmd(store, "install", "--help")
+	if install.code != 0 || !strings.Contains(install.stdout, "--allow-tool") || strings.Contains(install.stdout, "--oauth-scope") {
+		t.Fatalf("install access help mismatch: code=%d stdout=%s", install.code, install.stdout)
+	}
+	ring := runCmd(store, "ring", "create", "--help")
+	if ring.code != 0 || !strings.Contains(ring.stdout, "--enforcement required") {
+		t.Fatalf("ring create help missing enforcement: code=%d stdout=%s", ring.code, ring.stdout)
+	}
+}
+
+func findCapabilityPolicyServer(t *testing.T, payload map[string]any, name string) map[string]any {
+	t.Helper()
+	servers, ok := payload["servers"].([]any)
+	if !ok {
+		t.Fatalf("JSON payload has no servers array: %#v", payload)
+	}
+	for _, raw := range servers {
+		server := raw.(map[string]any)
+		if server["name"] == name {
+			return server
+		}
+	}
+	t.Fatalf("server %q not found in JSON: %#v", name, payload)
+	return nil
+}

--- a/cmd/madari/codex_policy_render_test.go
+++ b/cmd/madari/codex_policy_render_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	codexclient "github.com/ankitvg/madari/internal/clients/codex"
+	"github.com/ankitvg/madari/internal/registry"
+	"github.com/pelletier/go-toml/v2"
+)
+
+func TestRenderCodexTOMLCompilesPolicyWithDottedNamesDeterministically(t *testing.T) {
+	access := codexclient.CompileAccess(codexPolicyRenderAccess())
+	servers := map[string]renderedServer{
+		"z-last": {
+			Command: "/bin/z-last",
+		},
+		"docs.server": {
+			Transport:   registry.TransportHTTP,
+			URL:         "https://example.com/mcp",
+			CodexAccess: &access,
+		},
+	}
+
+	var out strings.Builder
+	if err := renderCodexTOML(&out, servers); err != nil {
+		t.Fatalf("render Codex policy: %v", err)
+	}
+	want := `[mcp_servers."docs.server"]
+url = "https://example.com/mcp"
+enabled_tools = ["tools.inherit", "tools.read", "tools.write"]
+disabled_tools = ["tools.delete", "tools.remove"]
+scopes = ["repo.read", "repo.write"]
+default_tools_approval_mode = "prompt"
+
+[mcp_servers."docs.server".tools."tools.read"]
+approval_mode = "auto"
+
+[mcp_servers."docs.server".tools."tools.write"]
+approval_mode = "approve"
+
+[mcp_servers.z-last]
+command = "/bin/z-last"
+`
+	if out.String() != want {
+		t.Fatalf("Codex policy render drift:\nwant:\n%s\ngot:\n%s", want, out.String())
+	}
+	if strings.Contains(out.String(), `approval_mode = "inherit"`) || strings.Contains(out.String(), `approval_mode = ""`) {
+		t.Fatalf("portable inherit must omit the native per-tool override:\n%s", out.String())
+	}
+}
+
+func TestRenderCodexTOMLEscapesDeleteControlInToolNames(t *testing.T) {
+	tool := "read\x7f"
+	allowed := []string{tool}
+	approvals := map[string]string{tool: "prompt"}
+	access := codexclient.CompiledAccess{EnabledTools: &allowed, ToolApprovals: &approvals}
+	servers := map[string]renderedServer{
+		"docs": {Command: "/bin/docs", CodexAccess: &access},
+	}
+	var out strings.Builder
+	if err := renderCodexTOML(&out, servers); err != nil {
+		t.Fatalf("render Codex policy: %v", err)
+	}
+	if strings.ContainsRune(out.String(), '\x7f') || !strings.Contains(out.String(), `read\u007F`) {
+		t.Fatalf("DEL control was not deterministically escaped:\n%s", out.String())
+	}
+	var parsed map[string]any
+	if err := toml.Unmarshal([]byte(out.String()), &parsed); err != nil {
+		t.Fatalf("escaped policy output is invalid TOML: %v\n%s", err, out.String())
+	}
+}
+
+func TestRequiredCodexRingRenderCompilesEveryAccessField(t *testing.T) {
+	store := newTestStore(t)
+	manifest := registry.Manifest{
+		Name:      "docs.server",
+		Transport: registry.TransportHTTP,
+		URL:       "https://example.com/mcp",
+		Enabled:   true,
+		Clients:   []string{"codex"},
+		Access:    codexPolicyRenderAccess(),
+	}
+	if err := store.Save(manifest); err != nil {
+		t.Fatalf("save policy manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{
+		Name:    "restricted",
+		Members: []string{manifest.Name},
+		Policy: &registry.RingPolicy{
+			Enforcement: registry.PolicyEnforcementRequired,
+		},
+	}); err != nil {
+		t.Fatalf("save policy ring: %v", err)
+	}
+
+	result := runCmd(store, "ring", "render", "restricted", "--client", "codex")
+	if result.code != 0 {
+		t.Fatalf("required Codex policy render failed: %s", result.stderr)
+	}
+	for _, want := range []string{
+		`enabled_tools = ["tools.inherit", "tools.read", "tools.write"]`,
+		`disabled_tools = ["tools.delete", "tools.remove"]`,
+		`scopes = ["repo.read", "repo.write"]`,
+		`default_tools_approval_mode = "prompt"`,
+		`[mcp_servers."docs.server".tools."tools.read"]`,
+		`approval_mode = "auto"`,
+		`[mcp_servers."docs.server".tools."tools.write"]`,
+		`approval_mode = "approve"`,
+	} {
+		if !strings.Contains(result.stdout, want) {
+			t.Fatalf("render missing %q:\n%s", want, result.stdout)
+		}
+	}
+	if result.stderr != "" {
+		t.Fatalf("unexpected required render warning: %s", result.stderr)
+	}
+}
+
+func TestRequiredCodexRingRenderRejectsUnsupportedMemberBeforeOutput(t *testing.T) {
+	store := newTestStore(t)
+	allowed := []string{"events.read"}
+	manifest := registry.Manifest{
+		Name:      "events",
+		Transport: registry.TransportSSE,
+		URL:       "https://example.com/sse",
+		Enabled:   true,
+		Clients:   []string{"codex"},
+		Access:    &registry.AccessProfile{AllowedTools: &allowed},
+	}
+	if err := store.Save(manifest); err != nil {
+		t.Fatalf("save SSE manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{
+		Name:    "restricted",
+		Members: []string{manifest.Name},
+		Policy:  &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
+	}); err != nil {
+		t.Fatalf("save required ring: %v", err)
+	}
+
+	result := runCmd(store, "ring", "render", "restricted", "--client", "codex")
+	if result.code == 0 || !strings.Contains(result.stderr, "uses sse transport") {
+		t.Fatalf("expected fail-closed SSE refusal: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	if result.stdout != "" {
+		t.Fatalf("required render emitted partial output: %s", result.stdout)
+	}
+}
+
+func codexPolicyRenderAccess() *registry.AccessProfile {
+	allowed := []string{"tools.write", "tools.inherit", "tools.read"}
+	denied := []string{"tools.remove", "tools.delete"}
+	scopes := []string{"repo.write", "repo.read"}
+	defaultApproval := registry.ApprovalBehaviorAlwaysPrompt
+	toolApprovals := map[string]registry.ApprovalBehavior{
+		"tools.write":   registry.ApprovalBehaviorAlwaysAllow,
+		"tools.inherit": registry.ApprovalBehaviorInherit,
+		"tools.read":    registry.ApprovalBehaviorAutomatic,
+	}
+	return &registry.AccessProfile{
+		AllowedTools:    &allowed,
+		DeniedTools:     &denied,
+		OAuthScopes:     &scopes,
+		DefaultApproval: &defaultApproval,
+		ToolApprovals:   &toolApprovals,
+	}
+}

--- a/cmd/madari/json_output.go
+++ b/cmd/madari/json_output.go
@@ -22,14 +22,23 @@ type listJSON struct {
 }
 
 type serverJSON struct {
-	Name              string   `json:"name"`
-	Enabled           bool     `json:"enabled"`
-	Transport         string   `json:"transport"`
-	Command           string   `json:"command"`
-	URL               string   `json:"url,omitempty"`
-	BearerTokenEnvVar string   `json:"bearer_token_env_var,omitempty"`
-	Clients           []string `json:"clients"`
-	Sources           []string `json:"sources"`
+	Name              string      `json:"name"`
+	Enabled           bool        `json:"enabled"`
+	Transport         string      `json:"transport"`
+	Command           string      `json:"command"`
+	URL               string      `json:"url,omitempty"`
+	BearerTokenEnvVar string      `json:"bearer_token_env_var,omitempty"`
+	Clients           []string    `json:"clients"`
+	Access            *accessJSON `json:"access,omitempty"`
+	Sources           []string    `json:"sources"`
+}
+
+type accessJSON struct {
+	AllowedTools    *[]string          `json:"allowed_tools,omitempty"`
+	DeniedTools     *[]string          `json:"denied_tools,omitempty"`
+	OAuthScopes     *[]string          `json:"oauth_scopes,omitempty"`
+	DefaultApproval *string            `json:"default_approval,omitempty"`
+	ToolApprovals   *map[string]string `json:"tool_approvals,omitempty"`
 }
 
 type statusJSON struct {
@@ -120,6 +129,7 @@ type doctorServerJSON struct {
 	URL               string      `json:"url,omitempty"`
 	OAuthResource     string      `json:"oauth_resource,omitempty"`
 	BearerTokenEnvVar string      `json:"bearer_token_env_var,omitempty"`
+	Access            *accessJSON `json:"access,omitempty"`
 	Status            string      `json:"status"`
 	Issues            []issueJSON `json:"issues"`
 }
@@ -179,7 +189,12 @@ type ringJSON struct {
 	Members     []string          `json:"members"`
 	Skills      []string          `json:"skills"`
 	Description string            `json:"description"`
+	Policy      *ringPolicyJSON   `json:"policy,omitempty"`
 	Contract    *ringContractJSON `json:"contract,omitempty"`
+}
+
+type ringPolicyJSON struct {
+	Enforcement string `json:"enforcement"`
 }
 
 type ringContractJSON struct {
@@ -212,7 +227,45 @@ func ringToJSON(ring registry.Ring) ringJSON {
 			ExpectedOutputs: nonNilStrings(ring.Contract.ExpectedOutputs),
 		}
 	}
+	if ring.Policy != nil {
+		out.Policy = &ringPolicyJSON{Enforcement: ring.Policy.Enforcement}
+	}
 	return out
+}
+
+func accessToJSON(access *registry.AccessProfile) *accessJSON {
+	if access == nil {
+		return nil
+	}
+	out := &accessJSON{
+		AllowedTools: copySortedStringPointer(access.AllowedTools),
+		DeniedTools:  copySortedStringPointer(access.DeniedTools),
+		OAuthScopes:  copySortedStringPointer(access.OAuthScopes),
+	}
+	if access.DefaultApproval != nil {
+		value := string(*access.DefaultApproval)
+		out.DefaultApproval = &value
+	}
+	if access.ToolApprovals != nil {
+		values := make(map[string]string, len(*access.ToolApprovals))
+		for tool, approval := range *access.ToolApprovals {
+			values[tool] = string(approval)
+		}
+		out.ToolApprovals = &values
+	}
+	return out
+}
+
+func copySortedStringPointer(values *[]string) *[]string {
+	if values == nil {
+		return nil
+	}
+	out := append([]string(nil), (*values)...)
+	sort.Strings(out)
+	if out == nil {
+		out = []string{}
+	}
+	return &out
 }
 
 type ringStatusJSON struct {

--- a/cmd/madari/json_output.go
+++ b/cmd/madari/json_output.go
@@ -110,14 +110,15 @@ func ringIssuesToJSON(issues []doctor.RingIssue) []ringIssueJSON {
 }
 
 type driftJSON struct {
-	Target     string   `json:"target"`
-	Scope      string   `json:"scope"`
-	ConfigPath string   `json:"config_path"`
-	Status     string   `json:"status"`
-	Stale      []string `json:"stale"`
-	Missing    []string `json:"missing"`
-	Orphaned   []string `json:"orphaned"`
-	Issue      string   `json:"issue"`
+	Target      string   `json:"target"`
+	Scope       string   `json:"scope"`
+	ConfigPath  string   `json:"config_path"`
+	Status      string   `json:"status"`
+	Stale       []string `json:"stale"`
+	PolicyStale []string `json:"policy_stale"`
+	Missing     []string `json:"missing"`
+	Orphaned    []string `json:"orphaned"`
+	Issue       string   `json:"issue"`
 }
 
 type doctorServerJSON struct {
@@ -161,6 +162,7 @@ type syncJSON struct {
 	DryRun            bool     `json:"dry_run"`
 	Added             []string `json:"added"`
 	Updated           []string `json:"updated"`
+	PolicyUpdated     []string `json:"policy_updated"`
 	Removed           []string `json:"removed"`
 	Unchanged         []string `json:"unchanged"`
 	Skipped           []string `json:"skipped"`
@@ -383,14 +385,15 @@ func driftToJSON(reports []doctor.DriftReport) []driftJSON {
 			scope = "default"
 		}
 		out = append(out, driftJSON{
-			Target:     dr.Target,
-			Scope:      scope,
-			ConfigPath: dr.ConfigPath,
-			Status:     string(dr.Status),
-			Stale:      nonNilStrings(dr.Stale),
-			Missing:    nonNilStrings(dr.Missing),
-			Orphaned:   nonNilStrings(dr.Orphaned),
-			Issue:      dr.Issue,
+			Target:      dr.Target,
+			Scope:       scope,
+			ConfigPath:  dr.ConfigPath,
+			Status:      string(dr.Status),
+			Stale:       nonNilStrings(dr.Stale),
+			PolicyStale: nonNilStrings(dr.PolicyStale),
+			Missing:     nonNilStrings(dr.Missing),
+			Orphaned:    nonNilStrings(dr.Orphaned),
+			Issue:       dr.Issue,
 		})
 	}
 	return out

--- a/cmd/madari/policy_drift_output_test.go
+++ b/cmd/madari/policy_drift_output_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/ankitvg/madari/internal/doctor"
+)
+
+func TestDriftJSONReportsPolicyStale(t *testing.T) {
+	payload := driftToJSON([]doctor.DriftReport{{
+		Target:      "codex",
+		Status:      doctor.StatusWarning,
+		Stale:       []string{"docs.api", "issues"},
+		PolicyStale: []string{"docs.api"},
+	}})
+	if len(payload) != 1 {
+		t.Fatalf("expected one drift payload, got: %#v", payload)
+	}
+	data, err := json.Marshal(payload[0])
+	if err != nil {
+		t.Fatalf("marshal drift JSON: %v", err)
+	}
+	if !bytes.Contains(data, []byte(`"policy_stale":["docs.api"]`)) {
+		t.Fatalf("expected policy_stale JSON field, got: %s", data)
+	}
+}
+
+func TestPrintPolicyDriftText(t *testing.T) {
+	var out bytes.Buffer
+	printPolicyDriftDetail(
+		&out,
+		"codex (user scope)",
+		"madari sync codex --scope user",
+		doctor.StatusWarning,
+		[]string{"docs.api", "issues"},
+	)
+	want := "codex (user scope) policy drift: [warn] stale=docs.api,issues (fix: madari sync codex --scope user)\n"
+	if got := out.String(); got != want {
+		t.Fatalf("doctor policy drift output mismatch:\nwant: %q\n got: %q", want, got)
+	}
+
+	out.Reset()
+	printPolicyDriftSummary(&out, "codex-user", "madari sync codex --scope user", []string{"docs.api", "issues"})
+	want = "codex-user-policy-drift: stale=2 (fix: madari sync codex --scope user)\n"
+	if got := out.String(); got != want {
+		t.Fatalf("status policy drift output mismatch:\nwant: %q\n got: %q", want, got)
+	}
+}
+
+func TestPrintPolicyDriftTextOmitsEmptySubset(t *testing.T) {
+	var out bytes.Buffer
+	printPolicyDriftDetail(&out, "codex", "madari sync codex", doctor.StatusReady, nil)
+	printPolicyDriftSummary(&out, "codex", "madari sync codex", []string{})
+	if got := out.String(); got != "" {
+		t.Fatalf("expected legacy text output to remain unchanged, got: %q", got)
+	}
+}

--- a/cmd/madari/policy_preflight.go
+++ b/cmd/madari/policy_preflight.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/ankitvg/madari/internal/policy"
 	"github.com/ankitvg/madari/internal/registry"
 )
@@ -17,18 +14,5 @@ func preflightRequiredRingPolicy(ring registry.Ring, manifests []registry.Manife
 // blocks sync because Madari cannot know whether that attached ring required
 // enforcement; detach-by-name remains available as the recovery path.
 func preflightAttachedRequiredRingPolicies(rings []registry.Ring, attached []string, manifests []registry.Manifest, target string) error {
-	byName := make(map[string]registry.Ring, len(rings))
-	for _, ring := range rings {
-		byName[ring.Name] = ring
-	}
-	for _, name := range sortedUniqueStrings(attached) {
-		ring, exists := byName[strings.TrimSpace(name)]
-		if !exists {
-			return fmt.Errorf("attached ring %q is missing; restore its definition or detach it before sync so policy requirements cannot be bypassed", name)
-		}
-		if err := preflightRequiredRingPolicy(ring, manifests, target, policy.SurfacePersistent); err != nil {
-			return err
-		}
-	}
-	return nil
+	return policy.ValidateAttachedRequiredRings(rings, attached, manifests, target, policy.SurfacePersistent)
 }

--- a/cmd/madari/policy_preflight.go
+++ b/cmd/madari/policy_preflight.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ankitvg/madari/internal/policy"
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+func preflightRequiredRingPolicy(ring registry.Ring, manifests []registry.Manifest, target string, surface policy.Surface) error {
+	return policy.ValidateRequiredRing(ring, manifests, target, surface).Err()
+}
+
+// preflightAttachedRequiredRingPolicies checks only rings whose ownership
+// source is currently recorded for the selected target. A missing definition
+// blocks sync because Madari cannot know whether that attached ring required
+// enforcement; detach-by-name remains available as the recovery path.
+func preflightAttachedRequiredRingPolicies(rings []registry.Ring, attached []string, manifests []registry.Manifest, target string) error {
+	byName := make(map[string]registry.Ring, len(rings))
+	for _, ring := range rings {
+		byName[ring.Name] = ring
+	}
+	for _, name := range sortedUniqueStrings(attached) {
+		ring, exists := byName[strings.TrimSpace(name)]
+		if !exists {
+			return fmt.Errorf("attached ring %q is missing; restore its definition or detach it before sync so policy requirements cannot be bypassed", name)
+		}
+		if err := preflightRequiredRingPolicy(ring, manifests, target, policy.SurfacePersistent); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/madari/policy_preflight.go
+++ b/cmd/madari/policy_preflight.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/ankitvg/madari/internal/policy"
 	"github.com/ankitvg/madari/internal/registry"
 )
@@ -15,4 +18,35 @@ func preflightRequiredRingPolicy(ring registry.Ring, manifests []registry.Manife
 // enforcement; detach-by-name remains available as the recovery path.
 func preflightAttachedRequiredRingPolicies(rings []registry.Ring, attached []string, manifests []registry.Manifest, target string) error {
 	return policy.ValidateAttachedRequiredRings(rings, attached, manifests, target, policy.SurfacePersistent)
+}
+
+func hasAttachedRequiredRingPolicy(rings []registry.Ring, attached []string) bool {
+	attachedSet := make(map[string]bool, len(attached))
+	for _, name := range attached {
+		attachedSet[strings.TrimSpace(name)] = true
+	}
+	for _, ring := range rings {
+		if attachedSet[ring.Name] && ring.RequiresPolicyEnforcement() {
+			return true
+		}
+	}
+	return false
+}
+
+func preflightRequiredRingServerOwnership(rings []registry.Ring, policyAttached, serverAttached []string, target string) error {
+	policySet := make(map[string]bool, len(policyAttached))
+	for _, name := range policyAttached {
+		policySet[strings.TrimSpace(name)] = true
+	}
+	serverSet := make(map[string]bool, len(serverAttached))
+	for _, name := range serverAttached {
+		serverSet[strings.TrimSpace(name)] = true
+	}
+	for _, ring := range rings {
+		if !policySet[ring.Name] || serverSet[ring.Name] || !ring.RequiresPolicyEnforcement() || len(ring.Members) == 0 {
+			continue
+		}
+		return fmt.Errorf("ring %q requires policy enforcement and is attached only through skills; run `madari ring attach %s %s` to establish server ownership before sync", ring.Name, ring.Name, target)
+	}
+	return nil
 }

--- a/cmd/madari/policy_preflight_test.go
+++ b/cmd/madari/policy_preflight_test.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+func TestPolicyRequiredRingAttachFailsBeforeConfigStateOrSkillMutation(t *testing.T) {
+	store := newTestStore(t)
+	projectDir := t.TempDir()
+	chdirForTest(t, projectDir)
+	savePolicyTestManifest(t, store, "docs", "codex")
+
+	skillSource := writeSkillFile(t, t.TempDir(), "release.md", "# Release\n")
+	if result := runCmd(store, "skill", "add", "release", "--file", skillSource, "--description", "Release workflow"); result.code != 0 {
+		t.Fatalf("skill setup failed: %s", result.stderr)
+	}
+	savePolicyTestRing(t, store, "restricted", []string{"docs"}, []string{"release"}, true)
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	result := runCmd(store, "ring", "attach", "restricted", "codex", "--config-path", configPath)
+	if result.code == 0 {
+		t.Fatalf("expected required policy attach to fail closed: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	for _, want := range []string{
+		`ring "restricted" requires policy enforcement`,
+		"codex persistent policy support is unsupported",
+		"[access].allowed_tools",
+	} {
+		if !strings.Contains(result.stderr, want) {
+			t.Fatalf("attach error missing %q: %s", want, result.stderr)
+		}
+	}
+	if _, err := os.Stat(configPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("config must not be mutated after policy refusal: %v", err)
+	}
+	statePath := (cliApp{store: store}).ringOpStatePath("codex", "")
+	if _, err := os.Stat(statePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("managed state must not be mutated after policy refusal: %v", err)
+	}
+	skillPath := filepath.Join(projectDir, ".agents", "skills", "release", registry.SkillFileName)
+	if _, err := os.Stat(skillPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("skill must not be materialized after policy refusal: %v", err)
+	}
+}
+
+func TestPolicyRequiredRingRenderFailsWithoutPartialOutput(t *testing.T) {
+	store := newTestStore(t)
+	savePolicyTestManifest(t, store, "docs", "codex")
+	savePolicyTestRing(t, store, "restricted", []string{"docs"}, nil, true)
+
+	result := runCmd(store, "ring", "render", "restricted", "--client", "codex")
+	if result.code == 0 {
+		t.Fatalf("expected required policy render to fail closed: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	if result.stdout != "" {
+		t.Fatalf("required policy render must emit no partial config, got: %s", result.stdout)
+	}
+	if !strings.Contains(result.stderr, "codex render policy support is unsupported") {
+		t.Fatalf("unexpected render error: %s", result.stderr)
+	}
+}
+
+func TestPolicyRequiredAttachedRingSyncFailsBeforeConfigStateOrSkillMutation(t *testing.T) {
+	store := newTestStore(t)
+	projectDir := t.TempDir()
+	chdirForTest(t, projectDir)
+	savePolicyTestManifest(t, store, "docs", "codex")
+	savePolicyTestRing(t, store, "restricted", []string{"docs"}, nil, false)
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if result := runCmd(store, "ring", "attach", "restricted", "codex", "--config-path", configPath); result.code != 0 {
+		t.Fatalf("advisory ring attach failed: %s", result.stderr)
+	}
+	statePath := (cliApp{store: store}).ringOpStatePath("codex", "")
+	configBefore, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read attached config: %v", err)
+	}
+	stateBefore, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read attached state: %v", err)
+	}
+
+	skillSource := writeSkillFile(t, t.TempDir(), "release.md", "# Release\n")
+	if result := runCmd(store, "skill", "add", "release", "--file", skillSource, "--description", "Release workflow"); result.code != 0 {
+		t.Fatalf("skill setup failed: %s", result.stderr)
+	}
+	savePolicyTestRing(t, store, "restricted", []string{"docs"}, []string{"release"}, true)
+
+	manifest, err := store.Get("docs")
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	manifest.Args = []string{"--changed"}
+	if err := store.Save(manifest); err != nil {
+		t.Fatalf("update manifest: %v", err)
+	}
+
+	result := runCmd(store, "sync", "codex", "--config-path", configPath)
+	if result.code == 0 || !strings.Contains(result.stderr, "codex persistent policy support is unsupported") {
+		t.Fatalf("expected attached required ring sync refusal: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	assertPolicyTestFileUnchanged(t, configPath, configBefore)
+	assertPolicyTestFileUnchanged(t, statePath, stateBefore)
+	skillPath := filepath.Join(projectDir, ".agents", "skills", "release", registry.SkillFileName)
+	if _, err := os.Stat(skillPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("sync must not materialize skills after policy refusal: %v", err)
+	}
+}
+
+func TestPolicyRequiredRingMakesRunPlanNotReady(t *testing.T) {
+	store := newTestStore(t)
+	savePolicyTestManifest(t, store, "docs", "codex")
+	savePolicyTestRing(t, store, "restricted", []string{"docs"}, nil, true)
+
+	plan, err := (cliApp{store: store}).buildRunPlan("codex", []string{"restricted"}, "inspect the docs")
+	if err != nil {
+		t.Fatalf("build run plan: %v", err)
+	}
+	if plan.Ready {
+		t.Fatalf("required policy must block execution while run compiler is unsupported: %#v", plan)
+	}
+	if !containsPolicyTestSubstring(plan.Errors, "codex run policy support is unsupported") {
+		t.Fatalf("run plan missing policy support error: %#v", plan.Errors)
+	}
+}
+
+func TestPolicyRequiredSkillOnlyRingFailsBeforeSkillMaterialization(t *testing.T) {
+	store := newTestStore(t)
+	projectDir := t.TempDir()
+	chdirForTest(t, projectDir)
+	skillSource := writeSkillFile(t, t.TempDir(), "release.md", "# Release\n")
+	if result := runCmd(store, "skill", "add", "release", "--file", skillSource, "--description", "Release workflow"); result.code != 0 {
+		t.Fatalf("skill setup failed: %s", result.stderr)
+	}
+	savePolicyTestRing(t, store, "workflow", nil, []string{"release"}, true)
+
+	result := runCmd(store, "ring", "attach", "workflow", "codex")
+	if result.code == 0 || !strings.Contains(result.stderr, "codex persistent has no lossless policy compiler yet") {
+		t.Fatalf("expected skill-only required ring refusal: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	skillPath := filepath.Join(projectDir, ".agents", "skills", "release", registry.SkillFileName)
+	if _, err := os.Stat(skillPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("skill-only required ring must fail before materialization: %v", err)
+	}
+
+	plan, err := (cliApp{store: store}).buildRunPlan("codex", []string{"workflow"}, "prepare release")
+	if err != nil {
+		t.Fatalf("build run plan: %v", err)
+	}
+	if plan.Ready || !containsPolicyTestSubstring(plan.Errors, "codex run has no lossless policy compiler yet") {
+		t.Fatalf("skill-only required run must be blocked: %#v", plan)
+	}
+}
+
+func TestSyncFailsClosedWhenAttachedRingDefinitionIsMissing(t *testing.T) {
+	store := newTestStore(t)
+	commandPath := mustCurrentExecutable(t)
+	if err := store.Save(registry.Manifest{
+		Name:    "docs",
+		Command: commandPath,
+		Enabled: true,
+		Clients: []string{"codex"},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{Name: "research", Members: []string{"docs"}}); err != nil {
+		t.Fatalf("save ring: %v", err)
+	}
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if result := runCmd(store, "ring", "attach", "research", "codex", "--config-path", configPath); result.code != 0 {
+		t.Fatalf("attach ring: %s", result.stderr)
+	}
+	statePath := (cliApp{store: store}).ringOpStatePath("codex", "")
+	configBefore, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	stateBefore, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if err := store.RemoveRing("research"); err != nil {
+		t.Fatalf("remove ring definition: %v", err)
+	}
+	manifest, err := store.Get("docs")
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	manifest.Args = []string{"--changed"}
+	if err := store.Save(manifest); err != nil {
+		t.Fatalf("update manifest: %v", err)
+	}
+
+	result := runCmd(store, "sync", "codex", "--config-path", configPath)
+	if result.code == 0 || !strings.Contains(result.stderr, `attached ring "research" is missing`) {
+		t.Fatalf("expected missing attached ring refusal: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	assertPolicyTestFileUnchanged(t, configPath, configBefore)
+	assertPolicyTestFileUnchanged(t, statePath, stateBefore)
+
+	detach := runCmd(store, "ring", "detach", "research", "codex", "--config-path", configPath)
+	if detach.code != 0 {
+		t.Fatalf("detach must remain available for missing-ring recovery: %s", detach.stderr)
+	}
+}
+
+func savePolicyTestManifest(t *testing.T, store *registry.Store, name, target string) {
+	t.Helper()
+	allowed := []string{"read"}
+	manifest := registry.Manifest{
+		Name:    name,
+		Command: mustCurrentExecutable(t),
+		Enabled: true,
+		Clients: []string{target},
+		Access: &registry.AccessProfile{
+			AllowedTools: &allowed,
+		},
+	}
+	if err := store.Save(manifest); err != nil {
+		t.Fatalf("save policy manifest: %v", err)
+	}
+}
+
+func savePolicyTestRing(t *testing.T, store *registry.Store, name string, members, skills []string, required bool) {
+	t.Helper()
+	ring := registry.Ring{Name: name, Members: members, Skills: skills}
+	if required {
+		ring.Policy = &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired}
+	}
+	if err := store.SaveRing(ring); err != nil {
+		t.Fatalf("save policy ring: %v", err)
+	}
+}
+
+func assertPolicyTestFileUnchanged(t *testing.T, path string, before []byte) {
+	t.Helper()
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s after policy refusal: %v", path, err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("file %s changed after policy refusal", path)
+	}
+}
+
+func containsPolicyTestSubstring(values []string, want string) bool {
+	for _, value := range values {
+		if strings.Contains(value, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/madari/policy_preflight_test.go
+++ b/cmd/madari/policy_preflight_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -15,6 +16,14 @@ func TestPolicyRequiredRingAttachFailsBeforeConfigStateOrSkillMutation(t *testin
 	projectDir := t.TempDir()
 	chdirForTest(t, projectDir)
 	savePolicyTestManifest(t, store, "docs", "codex")
+	manifest, err := store.Get("docs")
+	if err != nil {
+		t.Fatalf("load policy manifest: %v", err)
+	}
+	manifest.Command = filepath.Join(t.TempDir(), "missing-command")
+	if err := store.Save(manifest); err != nil {
+		t.Fatalf("save invalid command manifest: %v", err)
+	}
 
 	skillSource := writeSkillFile(t, t.TempDir(), "release.md", "# Release\n")
 	if result := runCmd(store, "skill", "add", "release", "--file", skillSource, "--description", "Release workflow"); result.code != 0 {
@@ -29,8 +38,7 @@ func TestPolicyRequiredRingAttachFailsBeforeConfigStateOrSkillMutation(t *testin
 	}
 	for _, want := range []string{
 		`ring "restricted" requires policy enforcement`,
-		"codex persistent policy support is unsupported",
-		"[access].allowed_tools",
+		`member "docs" cannot execute on Codex`,
 	} {
 		if !strings.Contains(result.stderr, want) {
 			t.Fatalf("attach error missing %q: %s", want, result.stderr)
@@ -49,19 +57,154 @@ func TestPolicyRequiredRingAttachFailsBeforeConfigStateOrSkillMutation(t *testin
 	}
 }
 
-func TestPolicyRequiredRingRenderFailsWithoutPartialOutput(t *testing.T) {
+func TestPolicyRequiredRingAttachNativeFidelityFailsBeforeSkillMutation(t *testing.T) {
 	store := newTestStore(t)
+	projectDir := t.TempDir()
+	chdirForTest(t, projectDir)
 	savePolicyTestManifest(t, store, "docs", "codex")
+	if err := store.SaveRing(registry.Ring{Name: "base", Members: []string{"docs"}}); err != nil {
+		t.Fatalf("save base ring: %v", err)
+	}
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if result := runCmd(store, "ring", "attach", "base", "codex", "--config-path", configPath); result.code != 0 {
+		t.Fatalf("attach base ring: %s", result.stderr)
+	}
+	serverStatePath := (cliApp{store: store}).ringOpStatePath("codex", "")
+	unknownConfig := "[mcp_servers.docs]\ncommand = " + tomlString(mustCurrentExecutable(t)) + "\nfuture_policy = \"strict\"\n"
+	if err := os.WriteFile(configPath, []byte(unknownConfig), 0o600); err != nil {
+		t.Fatalf("write unknown native policy: %v", err)
+	}
+	serverStateBefore, err := os.ReadFile(serverStatePath)
+	if err != nil {
+		t.Fatalf("read server state: %v", err)
+	}
+
+	skillSource := writeSkillFile(t, t.TempDir(), "release.md", "# Release\n")
+	if result := runCmd(store, "skill", "add", "release", "--file", skillSource, "--description", "Release workflow"); result.code != 0 {
+		t.Fatalf("skill setup failed: %s", result.stderr)
+	}
+	savePolicyTestRing(t, store, "restricted", []string{"docs"}, []string{"release"}, true)
+
+	result := runCmd(store, "ring", "attach", "restricted", "codex", "--config-path", configPath)
+	if result.code == 0 || !strings.Contains(result.stderr, "future_policy") {
+		t.Fatalf("expected native fidelity refusal: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	assertPolicyTestFileUnchanged(t, configPath, []byte(unknownConfig))
+	assertPolicyTestFileUnchanged(t, serverStatePath, serverStateBefore)
+	skillPath := filepath.Join(projectDir, ".agents", "skills", "release", registry.SkillFileName)
+	if _, err := os.Stat(skillPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("native fidelity preflight materialized skill: %v", err)
+	}
+	skillStatePath := (cliApp{store: store}).skillAttachmentStatePath("codex", "")
+	if _, err := os.Stat(skillStatePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("native fidelity preflight wrote skill state: %v", err)
+	}
+}
+
+func TestPolicyRequiredCodexAttachPreservesServerAndSkillRefcounts(t *testing.T) {
+	store := newTestStore(t)
+	projectDir := t.TempDir()
+	chdirForTest(t, projectDir)
+	allowed := []string{"read", "write"}
+	denied := []string{"delete"}
+	defaultApproval := registry.ApprovalBehaviorAlwaysPrompt
+	toolApprovals := map[string]registry.ApprovalBehavior{"read": registry.ApprovalBehaviorAlwaysAllow}
+	if err := store.Save(registry.Manifest{
+		Name: "docs", Command: mustCurrentExecutable(t), Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{
+			AllowedTools: &allowed, DeniedTools: &denied,
+			DefaultApproval: &defaultApproval, ToolApprovals: &toolApprovals,
+		},
+	}); err != nil {
+		t.Fatalf("save policy manifest: %v", err)
+	}
+	skillSource := writeSkillFile(t, t.TempDir(), "release.md", "# Release\n")
+	if result := runCmd(store, "skill", "add", "release", "--file", skillSource, "--description", "Release workflow"); result.code != 0 {
+		t.Fatalf("skill setup failed: %s", result.stderr)
+	}
+	for _, name := range []string{"r1", "r2"} {
+		savePolicyTestRing(t, store, name, []string{"docs"}, []string{"release"}, true)
+	}
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	for _, name := range []string{"r1", "r2"} {
+		result := runCmd(store, "ring", "attach", name, "codex", "--config-path", configPath)
+		if result.code != 0 {
+			t.Fatalf("attach %s: %s", name, result.stderr)
+		}
+	}
+	config, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read Codex config: %v", err)
+	}
+	for _, want := range []string{
+		`enabled_tools = ['read', 'write']`,
+		`disabled_tools = ['delete']`,
+		`default_tools_approval_mode = 'prompt'`,
+		`approval_mode = 'approve'`,
+	} {
+		if !strings.Contains(string(config), want) {
+			t.Fatalf("Codex policy config missing %q:\n%s", want, config)
+		}
+	}
+	serverStatePath := (cliApp{store: store}).ringOpStatePath("codex", "")
+	serverState, err := os.ReadFile(serverStatePath)
+	if err != nil {
+		t.Fatalf("read server state: %v", err)
+	}
+	skillStatePath := (cliApp{store: store}).skillAttachmentStatePath("codex", "")
+	skillState, err := os.ReadFile(skillStatePath)
+	if err != nil {
+		t.Fatalf("read skill state: %v", err)
+	}
+	for _, source := range []string{`"ring:r1"`, `"ring:r2"`} {
+		if !strings.Contains(string(serverState), source) || !strings.Contains(string(skillState), source) {
+			t.Fatalf("missing overlapping source %s: server=%s skill=%s", source, serverState, skillState)
+		}
+	}
+	skillPath := filepath.Join(projectDir, ".agents", "skills", "release", registry.SkillFileName)
+	if _, err := os.Stat(skillPath); err != nil {
+		t.Fatalf("required attach did not materialize skill: %v", err)
+	}
+
+	if result := runCmd(store, "ring", "detach", "r1", "codex", "--config-path", configPath); result.code != 0 {
+		t.Fatalf("detach r1: %s", result.stderr)
+	}
+	config, err = os.ReadFile(configPath)
+	if err != nil || !strings.Contains(string(config), "mcp_servers.docs") {
+		t.Fatalf("shared server removed while r2 owns it: err=%v config=%s", err, config)
+	}
+	if _, err := os.Stat(skillPath); err != nil {
+		t.Fatalf("shared skill removed while r2 owns it: %v", err)
+	}
+
+	if result := runCmd(store, "ring", "detach", "r2", "codex", "--config-path", configPath); result.code != 0 {
+		t.Fatalf("detach r2: %s", result.stderr)
+	}
+	config, err = os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config after detach: %v", err)
+	}
+	if strings.Contains(string(config), "mcp_servers.docs") {
+		t.Fatalf("last detach retained server: %s", config)
+	}
+	if _, err := os.Stat(skillPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("last detach retained skill: %v", err)
+	}
+}
+
+func TestPolicyRequiredRingRenderFailsForUnsupportedTargetWithoutPartialOutput(t *testing.T) {
+	store := newTestStore(t)
+	savePolicyTestManifest(t, store, "docs", "gemini")
 	savePolicyTestRing(t, store, "restricted", []string{"docs"}, nil, true)
 
-	result := runCmd(store, "ring", "render", "restricted", "--client", "codex")
+	result := runCmd(store, "ring", "render", "restricted", "--client", "gemini")
 	if result.code == 0 {
 		t.Fatalf("expected required policy render to fail closed: stdout=%s stderr=%s", result.stdout, result.stderr)
 	}
 	if result.stdout != "" {
 		t.Fatalf("required policy render must emit no partial config, got: %s", result.stdout)
 	}
-	if !strings.Contains(result.stderr, "codex render policy support is unsupported") {
+	if !strings.Contains(result.stderr, "gemini render policy support is unsupported") {
 		t.Fatalf("unexpected render error: %s", result.stderr)
 	}
 }
@@ -78,6 +221,10 @@ func TestPolicyRequiredAttachedRingSyncFailsBeforeConfigStateOrSkillMutation(t *
 		t.Fatalf("advisory ring attach failed: %s", result.stderr)
 	}
 	statePath := (cliApp{store: store}).ringOpStatePath("codex", "")
+	configWithUnknownPolicy := "[mcp_servers.docs]\ncommand = " + tomlString(mustCurrentExecutable(t)) + "\nfuture_policy = \"strict\"\n"
+	if err := os.WriteFile(configPath, []byte(configWithUnknownPolicy), 0o600); err != nil {
+		t.Fatalf("write unknown native policy fixture: %v", err)
+	}
 	configBefore, err := os.ReadFile(configPath)
 	if err != nil {
 		t.Fatalf("read attached config: %v", err)
@@ -103,15 +250,15 @@ func TestPolicyRequiredAttachedRingSyncFailsBeforeConfigStateOrSkillMutation(t *
 	}
 
 	result := runCmd(store, "sync", "codex", "--config-path", configPath)
-	if result.code == 0 || !strings.Contains(result.stderr, "codex persistent policy support is unsupported") {
+	if result.code == 0 || !strings.Contains(result.stderr, "behavior-affecting native fields") || !strings.Contains(result.stderr, "future_policy") {
 		t.Fatalf("expected attached required ring sync refusal: stdout=%s stderr=%s", result.stdout, result.stderr)
 	}
 	doctorResult := runCmd(store, "doctor", "--client-config", "codex="+configPath)
-	if doctorResult.code == 0 || !strings.Contains(doctorResult.stdout, "codex drift: [error] policy preflight:") || !strings.Contains(doctorResult.stdout, "codex persistent policy support is unsupported") {
+	if doctorResult.code == 0 || !strings.Contains(doctorResult.stdout, "codex drift: [error] compute sync plan:") || !strings.Contains(doctorResult.stdout, "future_policy") {
 		t.Fatalf("doctor hid attached policy preflight failure: stdout=%s stderr=%s", doctorResult.stdout, doctorResult.stderr)
 	}
 	statusResult := runCmd(store, "status", "--client-config", "codex="+configPath)
-	if statusResult.code == 0 || !strings.Contains(statusResult.stdout, "codex-drift: error policy preflight:") || !strings.Contains(statusResult.stdout, "codex persistent policy support is unsupported") {
+	if statusResult.code == 0 || !strings.Contains(statusResult.stdout, "codex-drift: error compute sync plan:") || !strings.Contains(statusResult.stdout, "future_policy") {
 		t.Fatalf("status hid attached policy preflight failure: stdout=%s stderr=%s", statusResult.stdout, statusResult.stderr)
 	}
 	assertPolicyTestFileUnchanged(t, configPath, configBefore)
@@ -122,8 +269,9 @@ func TestPolicyRequiredAttachedRingSyncFailsBeforeConfigStateOrSkillMutation(t *
 	}
 }
 
-func TestPolicyRequiredRingMakesRunPlanNotReady(t *testing.T) {
+func TestPolicyRequiredRingMakesCodexRunPlanExact(t *testing.T) {
 	store := newTestStore(t)
+	installFakeCodex(t, 0)
 	savePolicyTestManifest(t, store, "docs", "codex")
 	savePolicyTestRing(t, store, "restricted", []string{"docs"}, nil, true)
 
@@ -131,16 +279,20 @@ func TestPolicyRequiredRingMakesRunPlanNotReady(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build run plan: %v", err)
 	}
-	if plan.Ready {
-		t.Fatalf("required policy must block execution while run compiler is unsupported: %#v", plan)
+	if !plan.Ready {
+		t.Fatalf("required Codex policy run should be ready: %#v", plan)
 	}
-	if !containsPolicyTestSubstring(plan.Errors, "codex run policy support is unsupported") {
-		t.Fatalf("run plan missing policy support error: %#v", plan.Errors)
+	if len(plan.Servers) != 1 || plan.Servers[0].Policy.SupportState != "supported" || plan.Servers[0].Policy.EnforcementClassification != "exact" {
+		t.Fatalf("run plan missing exact policy classification: %#v", plan.Servers)
+	}
+	if plan.Servers[0].Policy.Effective == nil || !reflect.DeepEqual(plan.Servers[0].Policy.Effective.EnabledTools, []string{"read"}) {
+		t.Fatalf("run plan missing effective policy: %#v", plan.Servers[0].Policy)
 	}
 }
 
-func TestPolicyRequiredSkillOnlyRingFailsBeforeSkillMaterialization(t *testing.T) {
+func TestPolicyRequiredSkillOnlyRingAttachesAndRunCompilesAfterMemberEdit(t *testing.T) {
 	store := newTestStore(t)
+	installFakeCodex(t, 0)
 	projectDir := t.TempDir()
 	chdirForTest(t, projectDir)
 	skillSource := writeSkillFile(t, t.TempDir(), "release.md", "# Release\n")
@@ -150,20 +302,30 @@ func TestPolicyRequiredSkillOnlyRingFailsBeforeSkillMaterialization(t *testing.T
 	savePolicyTestRing(t, store, "workflow", nil, []string{"release"}, true)
 
 	result := runCmd(store, "ring", "attach", "workflow", "codex")
-	if result.code == 0 || !strings.Contains(result.stderr, "codex persistent has no lossless policy compiler yet") {
-		t.Fatalf("expected skill-only required ring refusal: stdout=%s stderr=%s", result.stdout, result.stderr)
+	if result.code != 0 {
+		t.Fatalf("skill-only required ring attach failed: stdout=%s stderr=%s", result.stdout, result.stderr)
 	}
 	skillPath := filepath.Join(projectDir, ".agents", "skills", "release", registry.SkillFileName)
-	if _, err := os.Stat(skillPath); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("skill-only required ring must fail before materialization: %v", err)
+	if _, err := os.Stat(skillPath); err != nil {
+		t.Fatalf("skill-only required ring should materialize with the persistent compiler: %v", err)
+	}
+	savePolicyTestManifest(t, store, "docs", "codex")
+	savePolicyTestRing(t, store, "workflow", []string{"docs"}, []string{"release"}, true)
+	syncResult := runCmd(store, "sync", "codex")
+	if syncResult.code == 0 || !strings.Contains(syncResult.stderr, "attached only through skills") {
+		t.Fatalf("expected missing server ownership refusal: stdout=%s stderr=%s", syncResult.stdout, syncResult.stderr)
+	}
+	serverStatePath := (cliApp{store: store}).ringOpStatePath("codex", "")
+	if _, err := os.Stat(serverStatePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("failed policy sync created server state: %v", err)
 	}
 
 	plan, err := (cliApp{store: store}).buildRunPlan("codex", []string{"workflow"}, "prepare release")
 	if err != nil {
 		t.Fatalf("build run plan: %v", err)
 	}
-	if plan.Ready || !containsPolicyTestSubstring(plan.Errors, "codex run has no lossless policy compiler yet") {
-		t.Fatalf("skill-only required run must be blocked: %#v", plan)
+	if !plan.Ready || len(plan.Servers) != 1 || plan.Servers[0].Policy.EnforcementClassification != "exact" {
+		t.Fatalf("required run should compile independently of persistent ownership: %#v", plan)
 	}
 }
 

--- a/cmd/madari/policy_preflight_test.go
+++ b/cmd/madari/policy_preflight_test.go
@@ -290,6 +290,46 @@ func TestPolicyRequiredRingMakesCodexRunPlanExact(t *testing.T) {
 	}
 }
 
+func TestPolicyDiagnosticsPreflightSkillOnlyAttachedRing(t *testing.T) {
+	store := newTestStore(t)
+	projectDir := t.TempDir()
+	chdirForTest(t, projectDir)
+	skillSource := writeSkillFile(t, t.TempDir(), "release.md", "# Release\n")
+	if result := runCmd(store, "skill", "add", "release", "--file", skillSource, "--description", "Release workflow"); result.code != 0 {
+		t.Fatalf("skill setup failed: %s", result.stderr)
+	}
+	savePolicyTestRing(t, store, "workflow", nil, []string{"release"}, false)
+	if result := runCmd(store, "ring", "attach", "workflow", "codex"); result.code != 0 {
+		t.Fatalf("advisory skill-only ring attach failed: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+
+	if err := store.Save(registry.Manifest{
+		Name: "docs", Command: mustCurrentExecutable(t), Enabled: true, Clients: []string{"codex"},
+	}); err != nil {
+		t.Fatalf("save unbounded policy manifest: %v", err)
+	}
+	savePolicyTestRing(t, store, "workflow", []string{"docs"}, []string{"release"}, true)
+	serverStatePath := (cliApp{store: store}).ringOpStatePath("codex", "")
+	if _, err := os.Stat(serverStatePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("skill-only attachment unexpectedly created server state: %v", err)
+	}
+
+	syncResult := runCmd(store, "sync", "codex")
+	if syncResult.code == 0 || !strings.Contains(syncResult.stderr, "non-empty [access].allowed_tools allowlist") {
+		t.Fatalf("expected required policy sync refusal: stdout=%s stderr=%s", syncResult.stdout, syncResult.stderr)
+	}
+	doctorResult := runCmd(store, "doctor")
+	if doctorResult.code == 0 || !strings.Contains(doctorResult.stdout, "codex drift: [error] policy preflight:") ||
+		!strings.Contains(doctorResult.stdout, "non-empty [access].allowed_tools allowlist") {
+		t.Fatalf("doctor hid skill-only policy attachment: stdout=%s stderr=%s", doctorResult.stdout, doctorResult.stderr)
+	}
+	statusResult := runCmd(store, "status")
+	if statusResult.code == 0 || !strings.Contains(statusResult.stdout, "codex-drift: error policy preflight:") ||
+		!strings.Contains(statusResult.stdout, "non-empty [access].allowed_tools allowlist") {
+		t.Fatalf("status hid skill-only policy attachment: stdout=%s stderr=%s", statusResult.stdout, statusResult.stderr)
+	}
+}
+
 func TestPolicyRequiredSkillOnlyRingAttachesAndRunCompilesAfterMemberEdit(t *testing.T) {
 	store := newTestStore(t)
 	installFakeCodex(t, 0)

--- a/cmd/madari/policy_preflight_test.go
+++ b/cmd/madari/policy_preflight_test.go
@@ -106,6 +106,14 @@ func TestPolicyRequiredAttachedRingSyncFailsBeforeConfigStateOrSkillMutation(t *
 	if result.code == 0 || !strings.Contains(result.stderr, "codex persistent policy support is unsupported") {
 		t.Fatalf("expected attached required ring sync refusal: stdout=%s stderr=%s", result.stdout, result.stderr)
 	}
+	doctorResult := runCmd(store, "doctor", "--client-config", "codex="+configPath)
+	if doctorResult.code == 0 || !strings.Contains(doctorResult.stdout, "codex drift: [error] policy preflight:") || !strings.Contains(doctorResult.stdout, "codex persistent policy support is unsupported") {
+		t.Fatalf("doctor hid attached policy preflight failure: stdout=%s stderr=%s", doctorResult.stdout, doctorResult.stderr)
+	}
+	statusResult := runCmd(store, "status", "--client-config", "codex="+configPath)
+	if statusResult.code == 0 || !strings.Contains(statusResult.stdout, "codex-drift: error policy preflight:") || !strings.Contains(statusResult.stdout, "codex persistent policy support is unsupported") {
+		t.Fatalf("status hid attached policy preflight failure: stdout=%s stderr=%s", statusResult.stdout, statusResult.stderr)
+	}
 	assertPolicyTestFileUnchanged(t, configPath, configBefore)
 	assertPolicyTestFileUnchanged(t, statePath, stateBefore)
 	skillPath := filepath.Join(projectDir, ".agents", "skills", "release", registry.SkillFileName)

--- a/cmd/madari/render_targets.go
+++ b/cmd/madari/render_targets.go
@@ -6,21 +6,23 @@ import (
 	"sort"
 	"strings"
 
+	codexclient "github.com/ankitvg/madari/internal/clients/codex"
 	"github.com/ankitvg/madari/internal/registry"
 )
 
 // renderedServer is the self-contained client config entry ring render emits.
 type renderedServer struct {
-	Transport         string            `json:"type,omitempty"`
-	Command           string            `json:"command,omitempty"`
-	Args              []string          `json:"args,omitempty"`
-	URL               string            `json:"url,omitempty"`
-	Headers           map[string]string `json:"headers,omitempty"`
-	TimeoutMS         int               `json:"timeout,omitempty"`
-	OAuthResource     string            `json:"-"`
-	BearerTokenEnvVar string            `json:"-"`
-	Env               map[string]string `json:"env,omitempty"`
-	RuntimeEnvKeys    []string          `json:"-"`
+	Transport         string                      `json:"type,omitempty"`
+	Command           string                      `json:"command,omitempty"`
+	Args              []string                    `json:"args,omitempty"`
+	URL               string                      `json:"url,omitempty"`
+	Headers           map[string]string           `json:"headers,omitempty"`
+	TimeoutMS         int                         `json:"timeout,omitempty"`
+	OAuthResource     string                      `json:"-"`
+	BearerTokenEnvVar string                      `json:"-"`
+	Env               map[string]string           `json:"env,omitempty"`
+	RuntimeEnvKeys    []string                    `json:"-"`
+	CodexAccess       *codexclient.CompiledAccess `json:"-"`
 }
 
 type ringRenderTarget struct {
@@ -97,6 +99,7 @@ func renderCodexTOML(out io.Writer, servers map[string]renderedServer) error {
 			if entry.BearerTokenEnvVar != "" {
 				fmt.Fprintf(out, "bearer_token_env_var = %s\n", tomlString(entry.BearerTokenEnvVar))
 			}
+			renderCodexAccessFields(out, entry.CodexAccess)
 			if len(entry.Headers) > 0 {
 				fmt.Fprintln(out)
 				fmt.Fprintf(out, "[mcp_servers.%s.http_headers]\n", tomlKey(name))
@@ -112,6 +115,7 @@ func renderCodexTOML(out io.Writer, servers map[string]renderedServer) error {
 			if len(entry.RuntimeEnvKeys) > 0 {
 				fmt.Fprintf(out, "env_vars = %s\n", tomlStringArray(entry.RuntimeEnvKeys))
 			}
+			renderCodexAccessFields(out, entry.CodexAccess)
 			if len(entry.Env) > 0 {
 				fmt.Fprintln(out)
 				fmt.Fprintf(out, "[mcp_servers.%s.env]\n", tomlKey(name))
@@ -120,8 +124,47 @@ func renderCodexTOML(out io.Writer, servers map[string]renderedServer) error {
 				}
 			}
 		}
+		renderCodexToolApprovals(out, name, entry.CodexAccess)
 	}
 	return nil
+}
+
+func renderCodexAccessFields(out io.Writer, access *codexclient.CompiledAccess) {
+	if access == nil {
+		return
+	}
+	// Render output is self-contained, so explicit clears have the same
+	// effective value as omission. Persistent sync consumes the pointer
+	// presence on CompiledAccess to remove an existing native override.
+	if access.EnabledTools != nil && len(*access.EnabledTools) > 0 {
+		fmt.Fprintf(out, "enabled_tools = %s\n", tomlStringArray(*access.EnabledTools))
+	}
+	if access.DisabledTools != nil && len(*access.DisabledTools) > 0 {
+		fmt.Fprintf(out, "disabled_tools = %s\n", tomlStringArray(*access.DisabledTools))
+	}
+	if access.Scopes != nil && len(*access.Scopes) > 0 {
+		fmt.Fprintf(out, "scopes = %s\n", tomlStringArray(*access.Scopes))
+	}
+	if access.DefaultApproval != nil && *access.DefaultApproval != "" {
+		fmt.Fprintf(out, "default_tools_approval_mode = %s\n", tomlString(*access.DefaultApproval))
+	}
+}
+
+func renderCodexToolApprovals(out io.Writer, server string, access *codexclient.CompiledAccess) {
+	if access == nil || access.ToolApprovals == nil {
+		return
+	}
+	tools := sortedMapKeys(*access.ToolApprovals)
+	for _, tool := range tools {
+		approval := (*access.ToolApprovals)[tool]
+		if approval == "" {
+			// Portable inherit removes the target-native override.
+			continue
+		}
+		fmt.Fprintln(out)
+		fmt.Fprintf(out, "[mcp_servers.%s.tools.%s]\n", tomlKey(server), tomlKey(tool))
+		fmt.Fprintf(out, "approval_mode = %s\n", tomlString(approval))
+	}
 }
 
 func renderVibeTOML(out io.Writer, servers map[string]renderedServer) error {
@@ -243,7 +286,7 @@ func tomlString(value string) string {
 		case '\\':
 			b.WriteString(`\\`)
 		default:
-			if r < 0x20 {
+			if r < 0x20 || r == 0x7f {
 				fmt.Fprintf(&b, `\u%04X`, r)
 				continue
 			}

--- a/cmd/madari/ring.go
+++ b/cmd/madari/ring.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ankitvg/madari/internal/clients"
 	"github.com/ankitvg/madari/internal/clients/syncshared"
+	"github.com/ankitvg/madari/internal/policy"
 	"github.com/ankitvg/madari/internal/registry"
 )
 
@@ -385,6 +386,9 @@ func (a cliApp) cmdRingRender(args []string) error {
 	if err != nil {
 		return err
 	}
+	if err := preflightRequiredRingPolicy(ring, manifests, target, policy.SurfaceRender); err != nil {
+		return commandInputError("ring render", err.Error())
+	}
 	byName := make(map[string]registry.Manifest, len(manifests))
 	for _, manifest := range manifests {
 		byName[manifest.Name] = manifest
@@ -580,6 +584,9 @@ func (a cliApp) cmdRingAttach(args []string) error {
 	manifests, err := a.store.List()
 	if err != nil {
 		return err
+	}
+	if err := preflightRequiredRingPolicy(ring, manifests, target, policy.SurfacePersistent); err != nil {
+		return commandInputError("ring attach", err.Error())
 	}
 	rings, err := a.store.ListRings()
 	if err != nil {
@@ -993,7 +1000,7 @@ func printRingSkillSummary(out io.Writer, result skillAttachResult) {
 
 func (a cliApp) cmdRingCreate(args []string) error {
 	if len(args) == 0 {
-		return commandUsageError("ring create", "madari ring create <name> [--member <server> ...] [--skill <skill> ...] [--description <text>]")
+		return commandUsageError("ring create", "madari ring create <name> [--member <server> ...] [--skill <skill> ...] [--description <text>] [--enforcement required]")
 	}
 	if isHelpToken(args[0]) {
 		printRingCreateHelp(a.stdout)
@@ -1006,9 +1013,11 @@ func (a cliApp) cmdRingCreate(args []string) error {
 	var members stringList
 	var skills stringList
 	var description string
+	var enforcement string
 	fs.Var(&members, "member", "Ring member server name (repeatable)")
 	fs.Var(&skills, "skill", "Ring member skill name (repeatable)")
 	fs.StringVar(&description, "description", "", "Ring description")
+	fs.StringVar(&enforcement, "enforcement", "", "Policy enforcement (required)")
 	if err := fs.Parse(args[1:]); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			printRingCreateHelp(a.stdout)
@@ -1019,12 +1028,24 @@ func (a cliApp) cmdRingCreate(args []string) error {
 	if fs.NArg() != 0 {
 		return commandUnexpectedArgsError("ring create", fs.Args())
 	}
+	enforcementSet := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "enforcement" {
+			enforcementSet = true
+		}
+	})
+	if enforcementSet && strings.TrimSpace(enforcement) == "" {
+		return commandInputError("ring create", "--enforcement must be non-empty (supported: required)")
+	}
 
 	ring := registry.Ring{
 		Name:        name,
 		Members:     append([]string(nil), members...),
 		Skills:      append([]string(nil), skills...),
 		Description: description,
+	}
+	if enforcement = strings.TrimSpace(enforcement); enforcementSet {
+		ring.Policy = &registry.RingPolicy{Enforcement: enforcement}
 	}
 	if err := a.store.AddRing(ring); err != nil {
 		return err
@@ -1144,8 +1165,17 @@ func (a cliApp) cmdRingShow(args []string) error {
 			fmt.Fprintf(a.stdout, "  - %s\n", skill)
 		}
 	}
+	printRingPolicy(a.stdout, ring.Policy)
 	printRingContract(a.stdout, ring.Contract)
 	return nil
+}
+
+func printRingPolicy(out io.Writer, policy *registry.RingPolicy) {
+	if policy == nil {
+		return
+	}
+	fmt.Fprintln(out, "policy:")
+	fmt.Fprintf(out, "  enforcement: %s\n", policy.Enforcement)
 }
 
 func printRingContract(out io.Writer, contract *registry.RingContract) {
@@ -1360,16 +1390,19 @@ func printRingHelp(out io.Writer) {
 
 func printRingCreateHelp(out io.Writer) {
 	fmt.Fprintln(out, "Usage:")
-	fmt.Fprintln(out, "  madari ring create <name> [--member <server> ...] [--skill <skill> ...] [--description <text>]")
+	fmt.Fprintln(out, "  madari ring create <name> [--member <server> ...] [--skill <skill> ...] [--description <text>] [--enforcement required]")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Options:")
 	fmt.Fprintln(out, "  --member <server>          Ring member server name (repeatable)")
 	fmt.Fprintln(out, "  --skill <skill>            Ring member skill name (repeatable)")
 	fmt.Fprintln(out, "  --description <text>       Ring description")
+	fmt.Fprintln(out, "  --enforcement required    Require exact access-policy compilation")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Description:")
 	fmt.Fprintln(out, "  Create a ring referencing existing registry servers and skills by name.")
 	fmt.Fprintln(out, "  At least one server member or skill member is required.")
+	fmt.Fprintln(out, "  Required enforcement needs a non-empty allowed_tools list on every server")
+	fmt.Fprintln(out, "  and fails until the selected target surface has a lossless compiler.")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Examples:")
 	fmt.Fprintln(out, "  madari ring create research --member stewreads --member arxiv")
@@ -1425,7 +1458,7 @@ func printRingListHelp(out io.Writer) {
 	fmt.Fprintln(out, "  --json                     Emit JSON instead of text")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Description:")
-	fmt.Fprintln(out, "  List configured rings with server members, skill members, and description.")
+	fmt.Fprintln(out, "  List configured rings with server members, skill members, description, and policy in JSON output.")
 }
 
 func printRingShowHelp(out io.Writer) {
@@ -1436,7 +1469,7 @@ func printRingShowHelp(out io.Writer) {
 	fmt.Fprintln(out, "  --json                     Emit JSON instead of text")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Description:")
-	fmt.Fprintln(out, "  Show one ring's server members, skill members, and description.")
+	fmt.Fprintln(out, "  Show one ring's server members, skill members, description, and required policy.")
 }
 
 func printRingContractHelp(out io.Writer) {

--- a/cmd/madari/ring.go
+++ b/cmd/madari/ring.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/ankitvg/madari/internal/clients"
+	codexclient "github.com/ankitvg/madari/internal/clients/codex"
 	"github.com/ankitvg/madari/internal/clients/syncshared"
 	"github.com/ankitvg/madari/internal/policy"
 	"github.com/ankitvg/madari/internal/registry"
@@ -393,6 +394,9 @@ func (a cliApp) cmdRingRender(args []string) error {
 	for _, manifest := range manifests {
 		byName[manifest.Name] = manifest
 	}
+	if err := preflightRequiredRingRenderEntries(ring, byName, target); err != nil {
+		return commandInputError("ring render", err.Error())
+	}
 
 	// Render mutates nothing: no state, no refcounts, no config files. The
 	// output is a self-contained config for ephemeral use (for example
@@ -438,7 +442,7 @@ func (a cliApp) cmdRingRender(args []string) error {
 				}
 				fmt.Fprintf(a.stderr, "warning: ring member %s: secret header values omitted from render: %s\n", member, strings.Join(secretNames, ", "))
 			}
-			servers[member] = renderedServer{
+			entry := renderedServer{
 				Transport:         manifest.TransportType(),
 				URL:               manifest.URL,
 				Headers:           headers,
@@ -446,6 +450,8 @@ func (a cliApp) cmdRingRender(args []string) error {
 				OAuthResource:     manifest.OAuthResource,
 				BearerTokenEnvVar: manifest.BearerTokenEnvVar,
 			}
+			entry.CodexAccess = compiledCodexAccessForRender(manifest, target)
+			servers[member] = entry
 			continue
 		}
 		if err := clients.ValidateCommandPath(manifest.Command); err != nil {
@@ -453,7 +459,10 @@ func (a cliApp) cmdRingRender(args []string) error {
 			continue
 		}
 
-		entry := renderedServer{Command: manifest.Command}
+		entry := renderedServer{
+			Command:     manifest.Command,
+			CodexAccess: compiledCodexAccessForRender(manifest, target),
+		}
 		if len(manifest.Args) > 0 {
 			entry.Args = append([]string(nil), manifest.Args...)
 		}
@@ -484,6 +493,48 @@ func (a cliApp) cmdRingRender(args []string) error {
 	}
 
 	return renderTarget.render(a.stdout, servers)
+}
+
+func compiledCodexAccessForRender(manifest registry.Manifest, target string) *codexclient.CompiledAccess {
+	if target != codexclient.Target || manifest.Access == nil {
+		return nil
+	}
+	compiled := codexclient.CompileAccess(manifest.Access)
+	return &compiled
+}
+
+// preflightRequiredRingRenderEntries closes the legacy render path's
+// omit-and-warn behavior for a required ring. Generic policy preflight checks
+// member existence, enabled state, target selection, and access bounds; this
+// target-materialization pass rejects members that render would otherwise omit
+// because their transport/auth shape or executable cannot be represented.
+func preflightRequiredRingRenderEntries(ring registry.Ring, manifests map[string]registry.Manifest, target string) error {
+	if !ring.RequiresPolicyEnforcement() {
+		return nil
+	}
+	members := append([]string(nil), ring.Members...)
+	sort.Strings(members)
+	for _, member := range members {
+		member = strings.TrimSpace(member)
+		manifest, exists := manifests[member]
+		if !exists || !manifest.Enabled || !manifest.HasClient(target) {
+			// The generic policy preflight reports these conditions first.
+			continue
+		}
+		if manifest.IsRemote() {
+			if detail, unsupported := unsupportedRemoteForTarget(manifest, target); unsupported {
+				if detail.Auth != "" {
+					return fmt.Errorf("ring %q requires exact policy rendering, but member %q uses unsupported %s for %s", ring.Name, member, detail.Auth, target)
+				}
+				return fmt.Errorf("ring %q requires exact policy rendering, but member %q uses unsupported %s transport for %s", ring.Name, member, detail.Transport, target)
+			}
+			continue
+		}
+		if err := clients.ValidateCommandPath(manifest.Command); err != nil {
+			return fmt.Errorf("ring %q requires exact policy rendering, but member %q cannot be rendered: %s", ring.Name, member, err.Message)
+		}
+	}
+	return nil
 }
 
 func printRingRenderHelp(out io.Writer) {
@@ -606,14 +657,14 @@ func (a cliApp) cmdRingAttach(args []string) error {
 		Rings:      rings,
 		Scope:      scope,
 	}
-	if len(ring.Skills) > 0 && !dryRun {
-		if _, err := a.attachRingSkills(ring, target, scope, true); err != nil {
-			return err
-		}
-	}
 	if len(ring.Members) > 0 && !dryRun {
 		opts.DryRun = true
 		if _, err := adapter.AttachRing(ring, syncable, opts); err != nil {
+			return err
+		}
+	}
+	if len(ring.Skills) > 0 && !dryRun {
+		if _, err := a.attachRingSkills(ring, target, scope, true); err != nil {
 			return err
 		}
 	}

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -555,23 +555,43 @@ func (a cliApp) managedStateRefs() []managedStateRef {
 
 // driftTargets enumerates the managed-state/config pairs doctor and status
 // diff for drift; clients with user scope get one per scope.
-func (a cliApp) driftTargets(adapters []clients.ClientAdapter, configPathOverrides map[string]string) []doctor.DriftTarget {
+func (a cliApp) driftTargets(adapters []clients.ClientAdapter, configPathOverrides map[string]string) ([]doctor.DriftTarget, error) {
 	targets := make([]doctor.DriftTarget, 0, len(adapters)+1)
 	for _, adapter := range adapters {
+		skillRings := func(scope string) ([]string, error) {
+			if !supportsSkillMaterialization(adapter.Target()) {
+				return nil, nil
+			}
+			state, err := loadSkillAttachmentState(a.skillAttachmentStatePath(adapter.Target(), scope))
+			if err != nil {
+				return nil, err
+			}
+			return attachedSkillRings(state), nil
+		}
+		projectSkillRings, err := skillRings("")
+		if err != nil {
+			return nil, err
+		}
 		targets = append(targets, doctor.DriftTarget{
-			Adapter:    adapter,
-			StatePath:  a.managedStatePath(adapter.Target()),
-			ConfigPath: configPathOverrides[adapter.Target()],
+			Adapter:            adapter,
+			StatePath:          a.managedStatePath(adapter.Target()),
+			ConfigPath:         configPathOverrides[adapter.Target()],
+			SkillAttachedRings: projectSkillRings,
 		})
 		if targetSupportsUserScope(adapter.Target()) {
+			userSkillRings, err := skillRings(clients.ScopeUser)
+			if err != nil {
+				return nil, err
+			}
 			targets = append(targets, doctor.DriftTarget{
-				Adapter:   adapter,
-				Scope:     clients.ScopeUser,
-				StatePath: a.managedUserStatePath(adapter.Target()),
+				Adapter:            adapter,
+				Scope:              clients.ScopeUser,
+				StatePath:          a.managedUserStatePath(adapter.Target()),
+				SkillAttachedRings: userSkillRings,
 			})
 		}
 	}
-	return targets
+	return targets, nil
 }
 
 // managedSourcesByServer unions managed-state sources per server name across
@@ -908,11 +928,15 @@ func (a cliApp) cmdDoctor(args []string) error {
 	if err != nil {
 		return err
 	}
+	driftTargets, err := a.driftTargets(adapters, configPathOverrides)
+	if err != nil {
+		return err
+	}
 	report, err := doctor.Run(a.store, doctor.Options{
 		Adapters:            adapters,
 		ConfigPathOverrides: configPathOverrides,
 		ServerTargets:       supportedDoctorServerTargets(),
-		DriftTargets:        a.driftTargets(adapters, configPathOverrides),
+		DriftTargets:        driftTargets,
 		Rings:               rings,
 	})
 	if err != nil {
@@ -1106,11 +1130,15 @@ func (a cliApp) cmdStatus(args []string) error {
 	if err != nil {
 		return err
 	}
+	driftTargets, err := a.driftTargets(adapters, configPathOverrides)
+	if err != nil {
+		return err
+	}
 	report, err := doctor.Run(a.store, doctor.Options{
 		Adapters:            adapters,
 		ConfigPathOverrides: configPathOverrides,
 		ServerTargets:       supportedDoctorServerTargets(),
-		DriftTargets:        a.driftTargets(adapters, configPathOverrides),
+		DriftTargets:        driftTargets,
 		Rings:               rings,
 	})
 	if err != nil {

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -750,18 +750,29 @@ func (a cliApp) cmdSync(args []string) error {
 	if err := preflightAttachedRequiredRingPolicies(rings, policyAttachedRings, manifests, target); err != nil {
 		return commandInputError("sync", err.Error())
 	}
-	if !dryRun {
-		if _, err := a.syncRingSkills(target, scope, rings, true, attachedRingsBeforeSync); err != nil {
-			return err
-		}
+	if err := preflightRequiredRingServerOwnership(rings, policyAttachedRings, attachedRingsBeforeSync, target); err != nil {
+		return commandInputError("sync", err.Error())
 	}
-	result, err := adapter.Sync(syncable, clients.SyncOptions{
+	syncOpts := clients.SyncOptions{
 		ConfigPath: configPath,
 		StatePath:  statePath,
 		Rings:      rings,
 		Scope:      scope,
 		DryRun:     dryRun,
-	})
+	}
+	if !dryRun && hasAttachedRequiredRingPolicy(rings, policyAttachedRings) {
+		preflightOpts := syncOpts
+		preflightOpts.DryRun = true
+		if _, err := adapter.Sync(syncable, preflightOpts); err != nil {
+			return err
+		}
+	}
+	if !dryRun {
+		if _, err := a.syncRingSkills(target, scope, rings, true, attachedRingsBeforeSync); err != nil {
+			return err
+		}
+	}
+	result, err := adapter.Sync(syncable, syncOpts)
 	if err != nil {
 		return err
 	}
@@ -778,6 +789,7 @@ func (a cliApp) cmdSync(args []string) error {
 			DryRun:            result.DryRun,
 			Added:             nonNilStrings(result.Added),
 			Updated:           nonNilStrings(result.Updated),
+			PolicyUpdated:     nonNilStrings(result.PolicyUpdated),
 			Removed:           nonNilStrings(result.Removed),
 			Unchanged:         nonNilStrings(result.Unchanged),
 			Skipped:           nonNilStrings(skipped),
@@ -1002,6 +1014,7 @@ func (a cliApp) cmdDoctor(args []string) error {
 			formatNameList(dr.Orphaned),
 			fix,
 		)
+		printPolicyDriftDetail(a.stdout, label, fix, dr.Status, dr.PolicyStale)
 	}
 
 	for _, issue := range report.RingIssues {
@@ -1212,6 +1225,7 @@ func (a cliApp) cmdStatus(args []string) error {
 			continue
 		}
 		fmt.Fprintf(a.stdout, "%s-drift: stale=%d missing=%d orphaned=%d (fix: %s)\n", label, len(dr.Stale), len(dr.Missing), len(dr.Orphaned), fix)
+		printPolicyDriftSummary(a.stdout, label, fix, dr.PolicyStale)
 	}
 	if len(report.ManifestErrors) > 0 {
 		fmt.Fprintf(a.stdout, "manifest-errors: %d\n", len(report.ManifestErrors))
@@ -1692,6 +1706,20 @@ func formatNameList(names []string) string {
 		return "-"
 	}
 	return strings.Join(names, ",")
+}
+
+func printPolicyDriftDetail(out io.Writer, label, fix string, status doctor.Status, stale []string) {
+	if len(stale) == 0 {
+		return
+	}
+	fmt.Fprintf(out, "%s policy drift: [%s] stale=%s (fix: %s)\n", label, status, formatNameList(stale), fix)
+}
+
+func printPolicyDriftSummary(out io.Writer, label, fix string, stale []string) {
+	if len(stale) == 0 {
+		return
+	}
+	fmt.Fprintf(out, "%s-policy-drift: stale=%d (fix: %s)\n", label, len(stale), fix)
 }
 
 func printSyncSummary(stdout, stderr io.Writer, target, configPath string, dryRun bool, added, updated, removed, unchanged, skipped []string, unsupportedRemote []unsupportedRemoteManifest, refused []string) {

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -193,6 +193,7 @@ func (a cliApp) cmdInstall(args []string) error {
 	var envPairs stringList
 	var requiredEnv stringList
 	var secretEnv stringList
+	var accessOptions accessFlags
 
 	fs.StringVar(&name, "name", "", "Server name (defaults from package)")
 	fs.StringVar(&command, "command", "", "Server command (defaults to package name)")
@@ -207,6 +208,7 @@ func (a cliApp) cmdInstall(args []string) error {
 	fs.Var(&envPairs, "env", "Environment variable KEY=VALUE (repeatable)")
 	fs.Var(&requiredEnv, "required-env", "Required runtime env key (repeatable)")
 	fs.Var(&secretEnv, "secret-env", "Secret env key barred from repo-scoped configs (repeatable)")
+	accessOptions.register(fs, false)
 
 	if err := fs.Parse(args[1:]); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -217,6 +219,13 @@ func (a cliApp) cmdInstall(args []string) error {
 	}
 	if fs.NArg() != 0 {
 		return commandUnexpectedArgsError("install", fs.Args())
+	}
+	accessProfile, err := accessOptions.profile()
+	if err != nil {
+		return commandInputError("install", err.Error())
+	}
+	if err := accessProfile.Validate(); err != nil {
+		return commandInputError("install", err.Error())
 	}
 
 	manager = strings.TrimSpace(strings.ToLower(manager))
@@ -275,6 +284,7 @@ func (a cliApp) cmdInstall(args []string) error {
 		Env:         env,
 		RequiredEnv: registry.RequiredEnv{Keys: append([]string(nil), requiredEnv...)},
 		SecretEnv:   registry.SecretEnv{Keys: append([]string(nil), secretEnv...)},
+		Access:      accessProfile,
 	}
 
 	if err := a.store.Add(manifest); err != nil {
@@ -336,6 +346,7 @@ func (a cliApp) cmdAdd(args []string) error {
 	var requiredEnv stringList
 	var secretEnv stringList
 	var secretHeaders stringList
+	var accessOptions accessFlags
 
 	fs.StringVar(&command, "command", "", "Server command")
 	fs.StringVar(&transport, "transport", "", "Server transport (stdio, http, or sse; default: stdio)")
@@ -352,6 +363,7 @@ func (a cliApp) cmdAdd(args []string) error {
 	fs.Var(&requiredEnv, "required-env", "Required environment key (repeatable)")
 	fs.Var(&secretEnv, "secret-env", "Secret env key barred from repo-scoped configs (repeatable)")
 	fs.Var(&secretHeaders, "secret-header", "Secret header name barred from repo-scoped configs (repeatable)")
+	accessOptions.register(fs, true)
 
 	if err := fs.Parse(args[1:]); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -374,6 +386,13 @@ func (a cliApp) cmdAdd(args []string) error {
 	headers, err := parseHeaderPairs(headerPairs)
 	if err != nil {
 		return err
+	}
+	accessProfile, err := accessOptions.profile()
+	if err != nil {
+		return commandInputError("add", err.Error())
+	}
+	if err := accessProfile.Validate(); err != nil {
+		return commandInputError("add", err.Error())
 	}
 
 	transport = strings.TrimSpace(strings.ToLower(transport))
@@ -409,6 +428,7 @@ func (a cliApp) cmdAdd(args []string) error {
 		RequiredEnv:       registry.RequiredEnv{Keys: append([]string(nil), requiredEnv...)},
 		SecretEnv:         registry.SecretEnv{Keys: append([]string(nil), secretEnv...)},
 		SecretHeaders:     registry.SecretHeaders{Keys: append([]string(nil), secretHeaders...)},
+		Access:            accessProfile,
 	}
 
 	if err := a.store.Add(manifest); err != nil {
@@ -469,6 +489,7 @@ func (a cliApp) cmdList(args []string) error {
 				URL:               manifest.URL,
 				BearerTokenEnvVar: manifest.BearerTokenEnvVar,
 				Clients:           nonNilStrings(clients),
+				Access:            accessToJSON(manifest.Access),
 				Sources:           nonNilStrings(managedSources[manifest.Name]),
 			})
 		}
@@ -713,13 +734,21 @@ func (a cliApp) cmdSync(args []string) error {
 	if scope == clients.ScopeUser {
 		statePath = a.managedUserStatePath(target)
 	}
-	attachedRingsBeforeSync := []string{}
+	state, err := syncshared.LoadManagedState(statePath)
+	if err != nil {
+		return err
+	}
+	attachedRingsBeforeSync := syncshared.AttachedRings(state)
+	policyAttachedRings := attachedRingsBeforeSync
 	if supportsSkillMaterialization(target) {
-		state, err := syncshared.LoadManagedState(statePath)
+		skillState, err := loadSkillAttachmentState(a.skillAttachmentStatePath(target, scope))
 		if err != nil {
 			return err
 		}
-		attachedRingsBeforeSync = syncshared.AttachedRings(state)
+		policyAttachedRings = unionStrings(policyAttachedRings, attachedSkillRings(skillState))
+	}
+	if err := preflightAttachedRequiredRingPolicies(rings, policyAttachedRings, manifests, target); err != nil {
+		return commandInputError("sync", err.Error())
 	}
 	if !dryRun {
 		if _, err := a.syncRingSkills(target, scope, rings, true, attachedRingsBeforeSync); err != nil {
@@ -906,6 +935,7 @@ func (a cliApp) cmdDoctor(args []string) error {
 				URL:               server.URL,
 				OAuthResource:     server.OAuthResource,
 				BearerTokenEnvVar: server.BearerTokenEnvVar,
+				Access:            accessToJSON(server.Access),
 				Status:            string(server.Status),
 				Issues:            issues,
 			})
@@ -1806,6 +1836,13 @@ func printAddHelp(out io.Writer) {
 	fmt.Fprintln(out, "  --env KEY=VALUE            Environment variable (repeatable)")
 	fmt.Fprintln(out, "  --required-env <KEY>       Required runtime env key (repeatable)")
 	fmt.Fprintln(out, "  --secret-env <KEY>         Secret env key barred from repo-scoped configs (repeatable)")
+	fmt.Fprintln(out, "  --allow-tool <NAME>        Exact allowed MCP tool name (repeatable)")
+	fmt.Fprintln(out, "  --deny-tool <NAME>         Denied MCP tool name (repeatable)")
+	fmt.Fprintln(out, "  --oauth-scope <SCOPE>      Requested OAuth scope (repeatable; remote transports only)")
+	fmt.Fprintln(out, "  --default-tool-approval <BEHAVIOR>")
+	fmt.Fprintln(out, "                             inherit, automatic, always-prompt, or always-allow")
+	fmt.Fprintln(out, "  --tool-approval TOOL=BEHAVIOR")
+	fmt.Fprintln(out, "                             Per-tool portable approval behavior (repeatable)")
 	fmt.Fprintln(out, "  --description <text>       Server description")
 	fmt.Fprintln(out, "  --disabled                 Add server in disabled state")
 	fmt.Fprintln(out)
@@ -1828,6 +1865,12 @@ func printInstallHelp(out io.Writer) {
 	fmt.Fprintln(out, "  --env KEY=VALUE            Environment variable (repeatable)")
 	fmt.Fprintln(out, "  --required-env <KEY>       Required runtime env key (repeatable)")
 	fmt.Fprintln(out, "  --secret-env <KEY>         Secret env key barred from repo-scoped configs (repeatable)")
+	fmt.Fprintln(out, "  --allow-tool <NAME>        Exact allowed MCP tool name (repeatable)")
+	fmt.Fprintln(out, "  --deny-tool <NAME>         Denied MCP tool name (repeatable)")
+	fmt.Fprintln(out, "  --default-tool-approval <BEHAVIOR>")
+	fmt.Fprintln(out, "                             inherit, automatic, always-prompt, or always-allow")
+	fmt.Fprintln(out, "  --tool-approval TOOL=BEHAVIOR")
+	fmt.Fprintln(out, "                             Per-tool portable approval behavior (repeatable)")
 	fmt.Fprintln(out, "  --description <text>       Server description")
 	fmt.Fprintln(out, "  --disabled                 Add server in disabled state")
 	fmt.Fprintln(out, "  --skip-install             Skip package installation")

--- a/cmd/madari/run_codex.go
+++ b/cmd/madari/run_codex.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	codexclient "github.com/ankitvg/madari/internal/clients/codex"
 	"github.com/ankitvg/madari/internal/clients/syncshared"
 	"github.com/ankitvg/madari/internal/registry"
 )
@@ -19,6 +20,11 @@ func runCodex(a cliApp, plan runLaunchPlan, prompt string) error {
 	codexPath, err := exec.LookPath("codex")
 	if err != nil {
 		return fmt.Errorf("codex not found in PATH; install Codex CLI or use --dry-run to inspect the launch plan")
+	}
+	if runPlanUsesPolicyContract(plan) {
+		if err := validateCodexPolicyRunCompatibility(); err != nil {
+			return err
+		}
 	}
 
 	workingDir, err := os.Getwd()
@@ -48,7 +54,11 @@ func runCodex(a cliApp, plan runLaunchPlan, prompt string) error {
 		return err
 	}
 
-	args := []string{"exec", "--ephemeral", "--ignore-user-config", "--skip-git-repo-check", "--sandbox", "read-only", "--cd", runRoot}
+	args := []string{"exec"}
+	if runPlanHasDeclaredAccess(plan) {
+		args = append(args, "--strict-config")
+	}
+	args = append(args, "--ephemeral", "--ignore-user-config", "--skip-git-repo-check", "--sandbox", "read-only", "--cd", runRoot)
 	for _, override := range overrides {
 		args = append(args, "-c", override)
 	}
@@ -63,6 +73,22 @@ func runCodex(a cliApp, plan runLaunchPlan, prompt string) error {
 		return fmt.Errorf("run codex exec: %w", err)
 	}
 	return nil
+}
+
+func runPlanUsesPolicyContract(plan runLaunchPlan) bool {
+	if plan.PolicyRequired {
+		return true
+	}
+	return runPlanHasDeclaredAccess(plan)
+}
+
+func runPlanHasDeclaredAccess(plan runLaunchPlan) bool {
+	for _, server := range plan.Servers {
+		if server.Policy.Declared != nil || server.Manifest.Access != nil {
+			return true
+		}
+	}
+	return false
 }
 
 var codexAdminSkillRoots = []string{
@@ -189,17 +215,29 @@ func withEnvValue(env []string, key, value string) []string {
 }
 
 func codexRunConfigOverrides(store *registry.Store, plan runLaunchPlan, workingDir string) ([]string, error) {
-	manifests, err := store.List()
-	if err != nil {
-		return nil, err
-	}
 	callerEnv, err := codexCallerIsolatedEnv()
 	if err != nil {
 		return nil, err
 	}
-	byName := make(map[string]registry.Manifest, len(manifests))
-	for _, manifest := range manifests {
-		byName[manifest.Name] = manifest
+	byName := make(map[string]registry.Manifest, len(plan.Servers))
+	needsStoreFallback := false
+	for _, server := range plan.Servers {
+		if server.Manifest.Name == server.Name {
+			byName[server.Name] = server.Manifest
+		} else {
+			needsStoreFallback = true
+		}
+	}
+	if needsStoreFallback {
+		manifests, err := store.List()
+		if err != nil {
+			return nil, err
+		}
+		for _, manifest := range manifests {
+			if _, planned := byName[manifest.Name]; !planned {
+				byName[manifest.Name] = manifest
+			}
+		}
 	}
 
 	names := make([]string, 0, len(plan.Servers))
@@ -261,6 +299,7 @@ func codexRunServerConfigValue(manifest registry.Manifest, workingDir string, ca
 		if len(manifest.Headers) > 0 {
 			fields = append(fields, fmt.Sprintf("http_headers = %s", tomlInlineStringMap(manifest.Headers)))
 		}
+		fields = append(fields, codexRunAccessConfigFields(manifest.Access)...)
 		return "{ " + strings.Join(fields, ", ") + " }", nil
 	}
 	if issues := codexRunServerPlanIssues(manifest); len(issues) > 0 {
@@ -278,7 +317,39 @@ func codexRunServerConfigValue(manifest registry.Manifest, workingDir string, ca
 	if env := codexRunStaticEnv(manifest, callerEnv); len(env) > 0 {
 		fields = append(fields, fmt.Sprintf("env = %s", tomlInlineStringMap(env)))
 	}
+	fields = append(fields, codexRunAccessConfigFields(manifest.Access)...)
 	return "{ " + strings.Join(fields, ", ") + " }", nil
+}
+
+func codexRunAccessConfigFields(access *registry.AccessProfile) []string {
+	compiled := codexclient.CompileAccess(access)
+	fields := make([]string, 0, 5)
+	if compiled.EnabledTools != nil && len(*compiled.EnabledTools) > 0 {
+		fields = append(fields, fmt.Sprintf("enabled_tools = %s", tomlStringArray(*compiled.EnabledTools)))
+	}
+	if compiled.DisabledTools != nil && len(*compiled.DisabledTools) > 0 {
+		fields = append(fields, fmt.Sprintf("disabled_tools = %s", tomlStringArray(*compiled.DisabledTools)))
+	}
+	if compiled.Scopes != nil && len(*compiled.Scopes) > 0 {
+		fields = append(fields, fmt.Sprintf("scopes = %s", tomlStringArray(*compiled.Scopes)))
+	}
+	if compiled.DefaultApproval != nil && *compiled.DefaultApproval != "" {
+		fields = append(fields, fmt.Sprintf("default_tools_approval_mode = %s", tomlString(*compiled.DefaultApproval)))
+	}
+	if compiled.ToolApprovals != nil {
+		tools := make([]string, 0, len(*compiled.ToolApprovals))
+		for _, tool := range sortedMapKeys(*compiled.ToolApprovals) {
+			approval := (*compiled.ToolApprovals)[tool]
+			if approval == "" {
+				continue
+			}
+			tools = append(tools, fmt.Sprintf("%s = { approval_mode = %s }", tomlKey(tool), tomlString(approval)))
+		}
+		if len(tools) > 0 {
+			fields = append(fields, "tools = { "+strings.Join(tools, ", ")+" }")
+		}
+	}
+	return fields
 }
 
 func codexRunServerPlanIssues(manifest registry.Manifest) []string {

--- a/cmd/madari/run_codex_test.go
+++ b/cmd/madari/run_codex_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/ankitvg/madari/internal/registry"
+	"github.com/pelletier/go-toml/v2"
 )
 
 func TestRunWithStoreCodexRunExecutesWithRingServersAndPrompt(t *testing.T) {
@@ -423,6 +424,60 @@ func TestCodexRunServerConfigValueBlocksSecretIsolatedEnvKeys(t *testing.T) {
 	}
 }
 
+func TestCodexRunConfigOverridesCompilePolicyDeterministically(t *testing.T) {
+	store := newTestStore(t)
+	allowed := []string{"tools.write", "tools.inherit", "tools.read\x7f"}
+	denied := []string{"tools.remove", "tools.delete"}
+	scopes := []string{"repo.write", "repo.read"}
+	defaultApproval := registry.ApprovalBehaviorAlwaysPrompt
+	toolApprovals := map[string]registry.ApprovalBehavior{
+		"tools.write":    registry.ApprovalBehaviorAlwaysAllow,
+		"tools.inherit":  registry.ApprovalBehaviorInherit,
+		"tools.read\x7f": registry.ApprovalBehaviorAutomatic,
+	}
+	if err := store.Save(registry.Manifest{
+		Name: "docs.server", Transport: registry.TransportHTTP, URL: "https://example.com/mcp",
+		Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{
+			AllowedTools: &allowed, DeniedTools: &denied, OAuthScopes: &scopes,
+			DefaultApproval: &defaultApproval, ToolApprovals: &toolApprovals,
+		},
+	}); err != nil {
+		t.Fatalf("save policy server: %v", err)
+	}
+	empty := []string{}
+	inherit := registry.ApprovalBehaviorInherit
+	clearApprovals := map[string]registry.ApprovalBehavior{"tools.clear": registry.ApprovalBehaviorInherit}
+	if err := store.Save(registry.Manifest{
+		Name: "z-last", Transport: registry.TransportHTTP, URL: "https://example.com/last",
+		Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{
+			AllowedTools: &empty, DeniedTools: &empty, OAuthScopes: &empty,
+			DefaultApproval: &inherit, ToolApprovals: &clearApprovals,
+		},
+	}); err != nil {
+		t.Fatalf("save explicit-clear server: %v", err)
+	}
+
+	overrides, err := codexRunConfigOverrides(store, runLaunchPlan{
+		Servers: []runPlanServer{{Name: "z-last"}, {Name: "docs.server"}},
+	}, t.TempDir())
+	if err != nil {
+		t.Fatalf("compile Codex run overrides: %v", err)
+	}
+	want := `mcp_servers={ "docs.server" = { url = "https://example.com/mcp", required = true, enabled_tools = ["tools.inherit", "tools.read\u007F", "tools.write"], disabled_tools = ["tools.delete", "tools.remove"], scopes = ["repo.read", "repo.write"], default_tools_approval_mode = "prompt", tools = { "tools.read\u007F" = { approval_mode = "auto" }, "tools.write" = { approval_mode = "approve" } } }, z-last = { url = "https://example.com/last", required = true } }`
+	if len(overrides) != 1 || overrides[0] != want {
+		t.Fatalf("unexpected deterministic policy override:\nwant %#v\ngot  %#v", []string{want}, overrides)
+	}
+	if strings.ContainsRune(overrides[0], '\x7f') || strings.Contains(overrides[0], `approval_mode = ""`) {
+		t.Fatalf("override did not omit inherit or escape controls: %q", overrides[0])
+	}
+	var parsed map[string]any
+	if err := toml.Unmarshal([]byte(overrides[0]), &parsed); err != nil {
+		t.Fatalf("compiled policy override is not valid TOML: %v\n%s", err, overrides[0])
+	}
+}
+
 func withCodexAdminSkillRoots(t *testing.T, roots []string) {
 	t.Helper()
 	previous := codexAdminSkillRoots
@@ -448,6 +503,7 @@ func installFakeCodex(t *testing.T, exitCode int) string {
 	logPath := filepath.Join(t.TempDir(), "codex-args.bin")
 	name := "codex"
 	script := []byte("#!/bin/sh\n" +
+		"if [ \"$1\" = \"--version\" ]; then printf 'codex-cli 0.139.0\\n'; exit 0; fi\n" +
 		"printf '%s' \"$PWD\" > '" + logPath + ".pwd'\n" +
 		"printf '%s' \"$HOME\" > '" + logPath + ".home'\n" +
 		"printf '%s' \"$CODEX_HOME\" > '" + logPath + ".codexhome'\n" +
@@ -464,7 +520,7 @@ func installFakeCodex(t *testing.T, exitCode int) string {
 		"exit " + strconv.Itoa(exitCode) + "\n")
 	if runtime.GOOS == "windows" {
 		name = "codex.bat"
-		script = []byte("@echo off\r\nexit /b " + strconv.Itoa(exitCode) + "\r\n")
+		script = []byte("@echo off\r\nif \"%1\"==\"--version\" (\r\n  echo codex-cli 0.139.0\r\n  exit /b 0\r\n)\r\nexit /b " + strconv.Itoa(exitCode) + "\r\n")
 	}
 	codexPath := filepath.Join(binDir, name)
 	if err := os.WriteFile(codexPath, script, 0o755); err != nil {

--- a/cmd/madari/run_codex_version.go
+++ b/cmd/madari/run_codex_version.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const minimumCodexPolicyRunVersion = "0.139.0"
+
+var codexSemanticVersionPattern = regexp.MustCompile(`([0-9]+)\.([0-9]+)\.([0-9]+)(-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?`)
+
+type codexSemanticVersion struct {
+	major      int
+	minor      int
+	patch      int
+	prerelease string
+}
+
+func validateCodexPolicyRunCompatibility() error {
+	return validateCodexPolicyRunVersion()
+}
+
+func validateCodexPolicyRunVersion() error {
+	path, err := exec.LookPath("codex")
+	if err != nil {
+		return fmt.Errorf("codex executable not found in PATH; install a stable Codex CLI 0.139.x release (minimum %s) for capability policy runs", minimumCodexPolicyRunVersion)
+	}
+	output, err := exec.Command(path, "--version").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("inspect Codex version for capability policy run: %w", err)
+	}
+	current, err := parseCodexSemanticVersion(string(output))
+	if err != nil {
+		return fmt.Errorf("cannot verify Codex capability policy support from version output %q: %w", strings.TrimSpace(string(output)), err)
+	}
+	minimum, _ := parseCodexSemanticVersion(minimumCodexPolicyRunVersion)
+	if current.lessThan(minimum) || current.major != 0 || current.minor != 139 || current.prerelease != "" {
+		return fmt.Errorf("Codex %s is outside the validated capability policy run range; install a stable Codex CLI 0.139.x release (minimum %s)", current, minimumCodexPolicyRunVersion)
+	}
+	return nil
+}
+
+func parseCodexSemanticVersion(output string) (codexSemanticVersion, error) {
+	match := codexSemanticVersionPattern.FindStringSubmatch(strings.TrimSpace(output))
+	if len(match) != 5 {
+		return codexSemanticVersion{}, fmt.Errorf("expected MAJOR.MINOR.PATCH")
+	}
+	parts := [3]int{}
+	for i := range parts {
+		value, err := strconv.Atoi(match[i+1])
+		if err != nil {
+			return codexSemanticVersion{}, fmt.Errorf("parse version component %q: %w", match[i+1], err)
+		}
+		parts[i] = value
+	}
+	return codexSemanticVersion{major: parts[0], minor: parts[1], patch: parts[2], prerelease: match[4]}, nil
+}
+
+func (v codexSemanticVersion) lessThan(other codexSemanticVersion) bool {
+	if v.major != other.major {
+		return v.major < other.major
+	}
+	if v.minor != other.minor {
+		return v.minor < other.minor
+	}
+	if v.patch != other.patch {
+		return v.patch < other.patch
+	}
+	return v.prerelease != "" && other.prerelease == ""
+}
+
+func (v codexSemanticVersion) String() string {
+	return fmt.Sprintf("%d.%d.%d%s", v.major, v.minor, v.patch, v.prerelease)
+}

--- a/cmd/madari/run_codex_version_test.go
+++ b/cmd/madari/run_codex_version_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestParseCodexSemanticVersion(t *testing.T) {
+	cases := []struct {
+		output string
+		want   string
+	}{
+		{"codex-cli 0.139.0", "0.139.0"},
+		{"codex-cli 0.140.1-beta.2", "0.140.1-beta.2"},
+		{"1.0.0", "1.0.0"},
+	}
+	for _, tc := range cases {
+		got, err := parseCodexSemanticVersion(tc.output)
+		if err != nil {
+			t.Fatalf("parse %q: %v", tc.output, err)
+		}
+		if got.String() != tc.want {
+			t.Fatalf("parse %q: got %s want %s", tc.output, got, tc.want)
+		}
+	}
+	if _, err := parseCodexSemanticVersion("codex development build"); err == nil {
+		t.Fatalf("expected unversioned build to fail closed")
+	}
+	minimum, _ := parseCodexSemanticVersion("0.139.0")
+	boundaries := []struct {
+		version string
+		older   bool
+	}{
+		{"0.138.9", true},
+		{"0.139.0-beta.1", true},
+		{"0.139.0", false},
+		{"0.140.0-beta.1", false},
+	}
+	for _, boundary := range boundaries {
+		version, err := parseCodexSemanticVersion(boundary.version)
+		if err != nil {
+			t.Fatalf("parse boundary %s: %v", boundary.version, err)
+		}
+		if got := version.lessThan(minimum); got != boundary.older {
+			t.Fatalf("boundary %s older=%t want %t", boundary.version, got, boundary.older)
+		}
+	}
+}
+
+func TestValidateCodexPolicyRunVersionRejectsOlderCLI(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-specific")
+	}
+	binDir := t.TempDir()
+	path := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nprintf 'codex-cli 0.138.9\\n'\n"), 0o755); err != nil {
+		t.Fatalf("write fake Codex: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+	err := validateCodexPolicyRunVersion()
+	if err == nil || !strings.Contains(err.Error(), "stable Codex CLI 0.139.x") {
+		t.Fatalf("expected old Codex refusal, got: %v", err)
+	}
+}
+
+func TestValidateCodexPolicyRunCompatibilityRejectsUnvalidatedNewerSeries(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-specific")
+	}
+	binDir := t.TempDir()
+	path := filepath.Join(binDir, "codex")
+	script := "#!/bin/sh\nprintf 'codex-cli 0.140.0\\n'\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake Codex: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+	err := validateCodexPolicyRunCompatibility()
+	if err == nil || !strings.Contains(err.Error(), "stable Codex CLI 0.139.x") {
+		t.Fatalf("expected unvalidated version refusal, got: %v", err)
+	}
+}

--- a/cmd/madari/run_plan.go
+++ b/cmd/madari/run_plan.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/ankitvg/madari/internal/clients"
+	"github.com/ankitvg/madari/internal/policy"
 	"github.com/ankitvg/madari/internal/registry"
 )
 
@@ -195,6 +196,9 @@ func (a cliApp) buildRunPlan(target string, ringNames []string, prompt string) (
 				continue
 			}
 			return runLaunchPlan{}, err
+		}
+		if err := preflightRequiredRingPolicy(ring, manifests, target, policy.SurfaceRun); err != nil {
+			addPlanError(err.Error())
 		}
 		for _, member := range ring.Members {
 			member = strings.TrimSpace(member)

--- a/cmd/madari/run_plan.go
+++ b/cmd/madari/run_plan.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/ankitvg/madari/internal/clients"
+	codexclient "github.com/ankitvg/madari/internal/clients/codex"
 	"github.com/ankitvg/madari/internal/policy"
 	"github.com/ankitvg/madari/internal/registry"
 )
@@ -18,18 +19,20 @@ import (
 const runDryRunOnlyMessage = "madari run execution is only implemented for codex; pass --dry-run to inspect the launch plan"
 
 type runPlanJSON struct {
-	SchemaVersion   int             `json:"schema_version"`
-	Command         string          `json:"command"`
-	Target          string          `json:"target"`
-	Rings           []string        `json:"rings"`
-	Ready           bool            `json:"ready"`
-	RunnerAvailable bool            `json:"runner_available"`
-	PromptProvided  bool            `json:"prompt_provided"`
-	Servers         []runPlanServer `json:"servers"`
-	Skills          []runPlanSkill  `json:"skills"`
-	Env             []runPlanEnv    `json:"env"`
-	Warnings        []string        `json:"warnings"`
-	Errors          []string        `json:"errors"`
+	SchemaVersion   int               `json:"schema_version"`
+	Command         string            `json:"command"`
+	Target          string            `json:"target"`
+	Rings           []string          `json:"rings"`
+	Ready           bool              `json:"ready"`
+	RunnerAvailable bool              `json:"runner_available"`
+	PromptProvided  bool              `json:"prompt_provided"`
+	PolicyRequired  bool              `json:"policy_required"`
+	PolicyControls  runPolicyControls `json:"policy_controls"`
+	Servers         []runPlanServer   `json:"servers"`
+	Skills          []runPlanSkill    `json:"skills"`
+	Env             []runPlanEnv      `json:"env"`
+	Warnings        []string          `json:"warnings"`
+	Errors          []string          `json:"errors"`
 }
 
 type runLaunchPlan struct {
@@ -38,6 +41,8 @@ type runLaunchPlan struct {
 	Ready           bool
 	RunnerAvailable bool
 	PromptProvided  bool
+	PolicyRequired  bool
+	PolicyControls  runPolicyControls
 	Servers         []runPlanServer
 	Skills          []runPlanSkill
 	Env             []runPlanEnv
@@ -46,14 +51,40 @@ type runLaunchPlan struct {
 }
 
 type runPlanServer struct {
-	Name       string   `json:"name"`
-	Transport  string   `json:"transport"`
-	Endpoint   string   `json:"endpoint"`
-	Status     string   `json:"status"`
-	Auth       string   `json:"auth,omitempty"`
-	RuntimeEnv []string `json:"runtime_env"`
-	Rings      []string `json:"rings"`
-	Issues     []string `json:"issues"`
+	Name       string              `json:"name"`
+	Transport  string              `json:"transport"`
+	Endpoint   string              `json:"endpoint"`
+	Status     string              `json:"status"`
+	Auth       string              `json:"auth,omitempty"`
+	RuntimeEnv []string            `json:"runtime_env"`
+	Rings      []string            `json:"rings"`
+	Issues     []string            `json:"issues"`
+	Policy     runPlanServerPolicy `json:"policy"`
+	Manifest   registry.Manifest   `json:"-"`
+}
+
+type runPolicyControls struct {
+	ToolFiltering string `json:"tool_filtering"`
+	OAuthScopes   string `json:"oauth_scopes"`
+	Approvals     string `json:"approvals"`
+	Instructions  string `json:"instructions"`
+}
+
+type runPlanServerPolicy struct {
+	Declared                  *accessJSON                  `json:"declared,omitempty"`
+	RingEnforcement           string                       `json:"ring_enforcement"`
+	RequiredBy                []string                     `json:"required_by"`
+	Effective                 *runPlanEffectiveCodexPolicy `json:"effective,omitempty"`
+	SupportState              string                       `json:"support_state"`
+	EnforcementClassification string                       `json:"enforcement_classification"`
+}
+
+type runPlanEffectiveCodexPolicy struct {
+	EnabledTools             []string          `json:"enabled_tools"`
+	DisabledTools            []string          `json:"disabled_tools"`
+	RequestedOAuthScopes     []string          `json:"requested_oauth_scopes"`
+	DefaultToolsApprovalMode string            `json:"default_tools_approval_mode,omitempty"`
+	ToolApprovalModes        map[string]string `json:"tool_approval_modes"`
 }
 
 type runPlanSkill struct {
@@ -146,6 +177,12 @@ func (a cliApp) buildRunPlan(target string, ringNames []string, prompt string) (
 		Rings:           nonNilStrings(normalizedRingNames(ringNames)),
 		RunnerAvailable: false,
 		PromptProvided:  strings.TrimSpace(prompt) != "",
+		PolicyControls: runPolicyControls{
+			ToolFiltering: "client-enforced",
+			OAuthScopes:   "requested/client-configured/provider-unverified",
+			Approvals:     "client-control/not-authorization",
+			Instructions:  "contracts-and-skills-advisory",
+		},
 	}
 	addPlanError := func(message string) {
 		plan.Errors = append(plan.Errors, message)
@@ -188,6 +225,8 @@ func (a cliApp) buildRunPlan(target string, ringNames []string, prompt string) (
 
 	serverRings := map[string][]string{}
 	skillRings := map[string][]string{}
+	requiredByServer := map[string][]string{}
+	policySupportByServer := map[string]string{}
 	for _, name := range plan.Rings {
 		ring, err := a.store.GetRing(name)
 		if err != nil {
@@ -197,8 +236,32 @@ func (a cliApp) buildRunPlan(target string, ringNames []string, prompt string) (
 			}
 			return runLaunchPlan{}, err
 		}
-		if err := preflightRequiredRingPolicy(ring, manifests, target, policy.SurfaceRun); err != nil {
+		validation := policy.ValidateRequiredRing(ring, manifests, target, policy.SurfaceRun)
+		if err := validation.Err(); err != nil {
 			addPlanError(err.Error())
+		}
+		if ring.RequiresPolicyEnforcement() {
+			plan.PolicyRequired = true
+			for _, member := range ring.Members {
+				member = strings.TrimSpace(member)
+				if member != "" {
+					requiredByServer[member] = appendUniqueName(requiredByServer[member], name)
+					policySupportByServer[member] = strongestPolicySupport(policySupportByServer[member], "supported")
+				}
+			}
+			for _, issue := range validation.Issues {
+				state := policySupportForIssue(issue)
+				if issue.Member != "" {
+					policySupportByServer[issue.Member] = strongestPolicySupport(policySupportByServer[issue.Member], state)
+					continue
+				}
+				for _, member := range ring.Members {
+					member = strings.TrimSpace(member)
+					if member != "" {
+						policySupportByServer[member] = strongestPolicySupport(policySupportByServer[member], state)
+					}
+				}
+			}
 		}
 		for _, member := range ring.Members {
 			member = strings.TrimSpace(member)
@@ -210,6 +273,29 @@ func (a cliApp) buildRunPlan(target string, ringNames []string, prompt string) (
 			skill = strings.TrimSpace(skill)
 			if skill != "" {
 				skillRings[skill] = appendUniqueName(skillRings[skill], name)
+			}
+		}
+	}
+	declaredAccessServers := map[string]bool{}
+	for name := range serverRings {
+		if manifest, exists := manifestByName[name]; exists && manifest.Access != nil {
+			declaredAccessServers[name] = true
+		}
+	}
+	policyRuntimeBlocked := false
+	if target == codexclient.Target && (plan.PolicyRequired || len(declaredAccessServers) > 0) {
+		if !plan.RunnerAvailable {
+			policyRuntimeBlocked = true
+		} else if err := validateCodexPolicyRunCompatibility(); err != nil {
+			policyRuntimeBlocked = true
+			addPlanError(err.Error())
+		}
+		if policyRuntimeBlocked {
+			for name := range requiredByServer {
+				policySupportByServer[name] = strongestPolicySupport(policySupportByServer[name], "unsupported")
+			}
+			for name := range declaredAccessServers {
+				policySupportByServer[name] = strongestPolicySupport(policySupportByServer[name], "unsupported")
 			}
 		}
 	}
@@ -229,10 +315,13 @@ func (a cliApp) buildRunPlan(target string, ringNames []string, prompt string) (
 		if !exists {
 			server.Status = "blocked"
 			server.Issues = append(server.Issues, "server is missing from the registry")
+			policySupportByServer[name] = strongestPolicySupport(policySupportByServer[name], "invalid")
+			server.Policy = buildRunPlanServerPolicy(nil, target, requiredByServer[name], policySupportByServer[name], true)
 			plan.Servers = append(plan.Servers, server)
 			addPlanError(fmt.Sprintf("ring member %s no longer exists in the registry", name))
 			continue
 		}
+		server.Manifest = manifest
 		server.Transport = manifest.TransportType()
 		server.Endpoint = manifestEndpoint(manifest)
 		server.Auth = runPlanAuth(manifest)
@@ -279,6 +368,13 @@ func (a cliApp) buildRunPlan(target string, ringNames []string, prompt string) (
 			for _, issue := range server.Issues {
 				addPlanError(fmt.Sprintf("server %s: %s", name, issue))
 			}
+		}
+		server.Policy = buildRunPlanServerPolicy(&manifest, target, requiredByServer[name], policySupportByServer[name], policyRuntimeBlocked || server.Status == "blocked")
+		if server.Policy.EnforcementClassification == "blocked" && server.Status != "blocked" {
+			server.Status = "blocked"
+			issue := fmt.Sprintf("capability policy enforcement is blocked: support=%s", server.Policy.SupportState)
+			server.Issues = append(server.Issues, issue)
+			addPlanError(fmt.Sprintf("server %s: %s", name, issue))
 		}
 		plan.Servers = append(plan.Servers, server)
 	}
@@ -341,6 +437,8 @@ func (p runLaunchPlan) toJSON() runPlanJSON {
 		Ready:           p.Ready,
 		RunnerAvailable: p.RunnerAvailable,
 		PromptProvided:  p.PromptProvided,
+		PolicyRequired:  p.PolicyRequired,
+		PolicyControls:  p.PolicyControls,
 		Servers:         nonNilRunPlanServers(p.Servers),
 		Skills:          nonNilRunPlanSkills(p.Skills),
 		Env:             nonNilRunPlanEnv(p.Env),
@@ -358,6 +456,96 @@ func runPlanAuth(manifest registry.Manifest) string {
 	default:
 		return ""
 	}
+}
+
+func strongestPolicySupport(current, candidate string) string {
+	rank := map[string]int{"": 0, "not-declared": 1, "supported": 2, "unsupported": 3, "invalid": 4}
+	if rank[candidate] > rank[current] {
+		return candidate
+	}
+	return current
+}
+
+func policySupportForIssue(issue policy.Issue) string {
+	switch issue.Code {
+	case policy.IssueUnsupportedCompiler, policy.IssueUnsupportedFeature,
+		policy.IssueUnsupportedTransport, policy.IssueUnsupportedServerField:
+		return "unsupported"
+	default:
+		return "invalid"
+	}
+}
+
+func buildRunPlanServerPolicy(manifest *registry.Manifest, target string, requiredBy []string, support string, blocked bool) runPlanServerPolicy {
+	requiredBy = nonNilStrings(sortedUniqueStrings(requiredBy))
+	out := runPlanServerPolicy{
+		RingEnforcement: "none",
+		RequiredBy:      requiredBy,
+		SupportState:    support,
+	}
+	if manifest != nil {
+		out.Declared = accessToJSON(manifest.Access)
+	}
+	if len(requiredBy) > 0 {
+		out.RingEnforcement = registry.PolicyEnforcementRequired
+		if out.SupportState == "" {
+			out.SupportState = "supported"
+		}
+		if blocked || out.SupportState != "supported" {
+			out.EnforcementClassification = "blocked"
+		} else {
+			out.EnforcementClassification = "exact"
+		}
+	} else if manifest != nil && manifest.Access != nil {
+		capabilities, known := policy.CapabilitiesFor(target, policy.SurfaceRun)
+		if !known || !capabilities.Compiler {
+			out.SupportState = "unsupported"
+		} else {
+			out.SupportState = strongestPolicySupport(out.SupportState, "supported")
+		}
+		if blocked && out.SupportState != "supported" {
+			out.EnforcementClassification = "blocked"
+		} else {
+			out.EnforcementClassification = "advisory"
+		}
+	} else {
+		out.EnforcementClassification = "none"
+		out.SupportState = "not-declared"
+	}
+
+	if manifest != nil && manifest.Access != nil && target == codexclient.Target {
+		capabilities, known := policy.CapabilitiesFor(target, policy.SurfaceRun)
+		if known && capabilities.Compiler {
+			compiled := codexclient.CompileAccess(manifest.Access)
+			effective := &runPlanEffectiveCodexPolicy{
+				EnabledTools:         []string{},
+				DisabledTools:        []string{},
+				RequestedOAuthScopes: []string{},
+				ToolApprovalModes:    map[string]string{},
+			}
+			if compiled.EnabledTools != nil {
+				effective.EnabledTools = append([]string(nil), (*compiled.EnabledTools)...)
+			}
+			if compiled.DisabledTools != nil {
+				effective.DisabledTools = append([]string(nil), (*compiled.DisabledTools)...)
+			}
+			if compiled.Scopes != nil {
+				effective.RequestedOAuthScopes = append([]string(nil), (*compiled.Scopes)...)
+			}
+			if compiled.DefaultApproval != nil {
+				effective.DefaultToolsApprovalMode = *compiled.DefaultApproval
+			}
+			if compiled.ToolApprovals != nil {
+				for tool, approval := range *compiled.ToolApprovals {
+					if approval != "" {
+						effective.ToolApprovalModes[tool] = approval
+					}
+				}
+			}
+			out.Effective = effective
+		}
+	}
+	return out
 }
 
 func normalizedRingNames(names []string) []string {
@@ -444,6 +632,12 @@ func printRunPlan(out io.Writer, plan runLaunchPlan) {
 	} else {
 		fmt.Fprintln(out, "runner: unavailable")
 	}
+	fmt.Fprintf(out, "policy controls: tool-filtering=%s oauth-scopes=%s approvals=%s instructions=%s\n",
+		plan.PolicyControls.ToolFiltering,
+		plan.PolicyControls.OAuthScopes,
+		plan.PolicyControls.Approvals,
+		plan.PolicyControls.Instructions,
+	)
 	fmt.Fprintln(out)
 
 	fmt.Fprintln(out, "servers:")
@@ -465,6 +659,7 @@ func printRunPlan(out io.Writer, plan runLaunchPlan) {
 			for _, issue := range server.Issues {
 				fmt.Fprintf(out, "    issue: %s\n", issue)
 			}
+			printRunPlanServerPolicy(out, server.Policy)
 		}
 	}
 
@@ -521,6 +716,90 @@ func printRunPlan(out io.Writer, plan runLaunchPlan) {
 	}
 }
 
+func printRunPlanServerPolicy(out io.Writer, policyPlan runPlanServerPolicy) {
+	fmt.Fprintf(out, "    policy: support=%s enforcement=%s ring_enforcement=%s",
+		policyPlan.SupportState,
+		policyPlan.EnforcementClassification,
+		policyPlan.RingEnforcement,
+	)
+	if len(policyPlan.RequiredBy) > 0 {
+		fmt.Fprintf(out, " required_by=%s", formatNameList(policyPlan.RequiredBy))
+	}
+	fmt.Fprintln(out)
+	if policyPlan.Declared == nil {
+		fmt.Fprintln(out, "    declared policy: none")
+	} else {
+		fmt.Fprintf(out, "    declared policy: allowed_tools=%s denied_tools=%s oauth_scopes=%s default_approval=%s tool_approvals=%s\n",
+			formatOptionalStringList(policyPlan.Declared.AllowedTools),
+			formatOptionalStringList(policyPlan.Declared.DeniedTools),
+			formatOptionalStringList(policyPlan.Declared.OAuthScopes),
+			formatOptionalString(policyPlan.Declared.DefaultApproval),
+			formatOptionalStringMap(policyPlan.Declared.ToolApprovals),
+		)
+	}
+	if policyPlan.Effective == nil {
+		fmt.Fprintln(out, "    effective policy: none")
+		return
+	}
+	fmt.Fprintf(out, "    effective policy: enabled_tools=%s disabled_tools=%s requested_oauth_scopes=%s default_tools_approval_mode=%s tool_approval_modes=%s\n",
+		formatEffectiveStringList(policyPlan.Effective.EnabledTools),
+		formatEffectiveStringList(policyPlan.Effective.DisabledTools),
+		formatEffectiveStringList(policyPlan.Effective.RequestedOAuthScopes),
+		formatOptionalEffectiveString(policyPlan.Effective.DefaultToolsApprovalMode),
+		formatStringMap(policyPlan.Effective.ToolApprovalModes),
+	)
+}
+
+func formatEffectiveStringList(values []string) string {
+	if len(values) == 0 {
+		return "target-default"
+	}
+	return strings.Join(values, ",")
+}
+
+func formatOptionalStringList(values *[]string) string {
+	if values == nil {
+		return "absent"
+	}
+	if len(*values) == 0 {
+		return "[]"
+	}
+	return "[" + strings.Join(*values, ",") + "]"
+}
+
+func formatOptionalString(value *string) string {
+	if value == nil {
+		return "absent"
+	}
+	return *value
+}
+
+func formatOptionalEffectiveString(value string) string {
+	if value == "" {
+		return "target-default"
+	}
+	return value
+}
+
+func formatOptionalStringMap(values *map[string]string) string {
+	if values == nil {
+		return "absent"
+	}
+	return formatStringMap(*values)
+}
+
+func formatStringMap(values map[string]string) string {
+	if len(values) == 0 {
+		return "{}"
+	}
+	keys := sortedMapKeys(values)
+	pairs := make([]string, 0, len(keys))
+	for _, key := range keys {
+		pairs = append(pairs, key+"="+values[key])
+	}
+	return "{" + strings.Join(pairs, ",") + "}"
+}
+
 func printRunHelp(out io.Writer) {
 	fmt.Fprintln(out, "Usage:")
 	fmt.Fprintln(out, "  madari run <client> --ring <ring> [--ring <ring> ...] [--dry-run] -- <prompt>")
@@ -540,6 +819,10 @@ func printRunHelp(out io.Writer) {
 	fmt.Fprintln(out, "  working directory and caller HOME/USERPROFILE; Codex gets temporary")
 	fmt.Fprintln(out, "  HOME/CODEX_HOME roots with auth copied in. Other clients are dry-run only")
 	fmt.Fprintln(out, "  for now.")
+	fmt.Fprintln(out, "  Access-bearing Codex runs add --strict-config; legacy no-access runs omit it.")
+	fmt.Fprintln(out, "  Codex policy runs require a validated stable CLI 0.139.x release; dry-run")
+	fmt.Fprintln(out, "  reports declared/effective policy separately from client enforcement and")
+	fmt.Fprintln(out, "  advisory instructions.")
 	fmt.Fprintln(out, "  Run never writes client config, managed state, or permanent skill files.")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Examples:")

--- a/cmd/madari/run_policy_test.go
+++ b/cmd/madari/run_policy_test.go
@@ -1,0 +1,449 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+func TestRunDryRunReportsDeclaredEffectiveAndStrongestRequiredPolicy(t *testing.T) {
+	store := newTestStore(t)
+	installFakeCodex(t, 0)
+	manifest := registry.Manifest{
+		Name: "docs.server", Transport: registry.TransportHTTP, URL: "https://example.com/mcp",
+		Enabled: true, Clients: []string{"codex"}, Access: codexPolicyRenderAccess(),
+	}
+	if err := store.Save(manifest); err != nil {
+		t.Fatalf("save policy manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{Name: "advisory", Members: []string{manifest.Name}}); err != nil {
+		t.Fatalf("save advisory ring: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{
+		Name: "required", Members: []string{manifest.Name},
+		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
+	}); err != nil {
+		t.Fatalf("save required ring: %v", err)
+	}
+
+	result := runCmd(store, "run", "codex", "--ring", "advisory", "--ring", "required", "--dry-run", "--json", "--", "inspect")
+	if result.code != 0 {
+		t.Fatalf("required policy dry-run failed: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	plan := decodeRunPlan(t, result.stdout)
+	if !plan.Ready || len(plan.Servers) != 1 {
+		t.Fatalf("unexpected plan: %#v", plan)
+	}
+	server := plan.Servers[0]
+	if server.Policy.RingEnforcement != registry.PolicyEnforcementRequired ||
+		server.Policy.SupportState != "supported" ||
+		server.Policy.EnforcementClassification != "exact" ||
+		!reflect.DeepEqual(server.Policy.RequiredBy, []string{"required"}) {
+		t.Fatalf("required ring did not win for shared server: %#v", server.Policy)
+	}
+	if server.Policy.Declared == nil || server.Policy.Declared.DefaultApproval == nil || *server.Policy.Declared.DefaultApproval != string(registry.ApprovalBehaviorAlwaysPrompt) {
+		t.Fatalf("portable declared policy missing: %#v", server.Policy.Declared)
+	}
+	effective := server.Policy.Effective
+	if effective == nil ||
+		!reflect.DeepEqual(effective.EnabledTools, []string{"tools.inherit", "tools.read", "tools.write"}) ||
+		!reflect.DeepEqual(effective.DisabledTools, []string{"tools.delete", "tools.remove"}) ||
+		!reflect.DeepEqual(effective.RequestedOAuthScopes, []string{"repo.read", "repo.write"}) ||
+		effective.DefaultToolsApprovalMode != "prompt" ||
+		effective.ToolApprovalModes["tools.read"] != "auto" ||
+		effective.ToolApprovalModes["tools.write"] != "approve" {
+		t.Fatalf("Codex effective policy mismatch: %#v", effective)
+	}
+	if plan.PolicyControls.ToolFiltering != "client-enforced" ||
+		plan.PolicyControls.OAuthScopes != "requested/client-configured/provider-unverified" ||
+		plan.PolicyControls.Approvals != "client-control/not-authorization" ||
+		plan.PolicyControls.Instructions != "contracts-and-skills-advisory" {
+		t.Fatalf("policy controls are ambiguous: %#v", plan.PolicyControls)
+	}
+
+	textResult := runCmd(store, "run", "codex", "--ring", "required", "--dry-run", "--", "inspect")
+	if textResult.code != 0 {
+		t.Fatalf("text dry-run failed: %s", textResult.stderr)
+	}
+	for _, want := range []string{
+		"policy controls: tool-filtering=client-enforced",
+		"oauth-scopes=requested/client-configured/provider-unverified",
+		"approvals=client-control/not-authorization",
+		"instructions=contracts-and-skills-advisory",
+		"policy: support=supported enforcement=exact",
+		"declared policy: allowed_tools=[tools.inherit,tools.read,tools.write]",
+		"effective policy: enabled_tools=tools.inherit,tools.read,tools.write",
+	} {
+		if !strings.Contains(textResult.stdout, want) {
+			t.Fatalf("text policy report missing %q:\n%s", want, textResult.stdout)
+		}
+	}
+}
+
+func TestRunDryRunReportsAdvisoryPolicyWithoutMandatoryClaim(t *testing.T) {
+	store := newTestStore(t)
+	installFakeCodex(t, 0)
+	allowed := []string{"read"}
+	if err := store.Save(registry.Manifest{
+		Name: "docs", Command: mustCurrentExecutable(t), Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{AllowedTools: &allowed},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{Name: "advisory", Members: []string{"docs"}}); err != nil {
+		t.Fatalf("save ring: %v", err)
+	}
+	result := runCmd(store, "run", "codex", "--ring", "advisory", "--dry-run", "--json", "--", "inspect")
+	if result.code != 0 {
+		t.Fatalf("advisory dry-run failed: %s", result.stderr)
+	}
+	policy := decodeRunPlan(t, result.stdout).Servers[0].Policy
+	if policy.SupportState != "supported" || policy.EnforcementClassification != "advisory" || policy.RingEnforcement != "none" || len(policy.RequiredBy) != 0 {
+		t.Fatalf("advisory policy made a mandatory claim: %#v", policy)
+	}
+}
+
+func TestRunAdvisoryPolicyReportsUnsupportedOldCodexTruthfully(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-specific")
+	}
+	store := newTestStore(t)
+	marker := filepath.Join(t.TempDir(), "executed")
+	installPolicyVersionCodex(t, "0.138.9", marker)
+	allowed := []string{"read"}
+	if err := store.Save(registry.Manifest{
+		Name: "docs", Command: mustCurrentExecutable(t), Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{AllowedTools: &allowed},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{Name: "advisory", Members: []string{"docs"}}); err != nil {
+		t.Fatalf("save ring: %v", err)
+	}
+	result := runCmd(store, "run", "codex", "--ring", "advisory", "--dry-run", "--json", "--", "inspect")
+	if result.code == 0 {
+		t.Fatalf("old Codex should not report a runnable advisory policy: %s", result.stdout)
+	}
+	plan := decodeRunPlan(t, result.stdout)
+	policy := plan.Servers[0].Policy
+	if plan.PolicyRequired || policy.RingEnforcement != "none" || policy.SupportState != "unsupported" || policy.EnforcementClassification != "blocked" {
+		t.Fatalf("advisory support state was not truthful: %#v", policy)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("old Codex executed advisory policy: %v", err)
+	}
+}
+
+func TestRunLegacyNoAccessRemainsCompatibleWithOlderCodex(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-specific")
+	}
+	store := newTestStore(t)
+	marker := filepath.Join(t.TempDir(), "executed")
+	installPolicyVersionCodex(t, "0.138.9", marker)
+	if err := store.Save(registry.Manifest{
+		Name: "docs", Command: mustCurrentExecutable(t), Enabled: true, Clients: []string{"codex"},
+	}); err != nil {
+		t.Fatalf("save legacy manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{Name: "legacy", Members: []string{"docs"}}); err != nil {
+		t.Fatalf("save legacy ring: %v", err)
+	}
+	result := runCmd(store, "run", "codex", "--ring", "legacy", "--", "inspect")
+	if result.code != 0 {
+		t.Fatalf("legacy run was broken by policy compatibility checks: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("legacy Codex did not execute: %v", err)
+	}
+}
+
+func TestRunDryRunPreservesDeclaredClearAndReportsTargetDefault(t *testing.T) {
+	store := newTestStore(t)
+	installFakeCodex(t, 0)
+	allowed := []string{"read"}
+	empty := []string{}
+	inherit := registry.ApprovalBehaviorInherit
+	toolApprovals := map[string]registry.ApprovalBehavior{"read": registry.ApprovalBehaviorInherit}
+	if err := store.Save(registry.Manifest{
+		Name: "docs", Command: mustCurrentExecutable(t), Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{
+			AllowedTools: &allowed, DeniedTools: &empty, OAuthScopes: &empty,
+			DefaultApproval: &inherit, ToolApprovals: &toolApprovals,
+		},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{
+		Name: "required", Members: []string{"docs"},
+		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
+	}); err != nil {
+		t.Fatalf("save ring: %v", err)
+	}
+	result := runCmd(store, "run", "codex", "--ring", "required", "--dry-run", "--json", "--", "inspect")
+	if result.code != 0 {
+		t.Fatalf("clear policy dry-run failed: %s", result.stderr)
+	}
+	policy := decodeRunPlan(t, result.stdout).Servers[0].Policy
+	if policy.Declared == nil || policy.Declared.DeniedTools == nil || len(*policy.Declared.DeniedTools) != 0 ||
+		policy.Declared.OAuthScopes == nil || len(*policy.Declared.OAuthScopes) != 0 ||
+		policy.Declared.DefaultApproval == nil || *policy.Declared.DefaultApproval != string(registry.ApprovalBehaviorInherit) ||
+		policy.Declared.ToolApprovals == nil || (*policy.Declared.ToolApprovals)["read"] != string(registry.ApprovalBehaviorInherit) {
+		t.Fatalf("declared clear presence was lost: %#v", policy.Declared)
+	}
+	if policy.Effective == nil || !reflect.DeepEqual(policy.Effective.EnabledTools, []string{"read"}) ||
+		len(policy.Effective.DisabledTools) != 0 || len(policy.Effective.RequestedOAuthScopes) != 0 ||
+		policy.Effective.DefaultToolsApprovalMode != "" || len(policy.Effective.ToolApprovalModes) != 0 {
+		t.Fatalf("effective clear did not resolve to target defaults: %#v", policy.Effective)
+	}
+	textResult := runCmd(store, "run", "codex", "--ring", "required", "--dry-run", "--", "inspect")
+	if textResult.code != 0 || !strings.Contains(textResult.stdout, "disabled_tools=target-default requested_oauth_scopes=target-default default_tools_approval_mode=target-default tool_approval_modes={}") {
+		t.Fatalf("text clear reporting is ambiguous: code=%d stdout=%s stderr=%s", textResult.code, textResult.stdout, textResult.stderr)
+	}
+}
+
+func TestRunRequiredPolicyBlocksOldCodexBeforeExecution(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-specific")
+	}
+	store := newTestStore(t)
+	projectDir := t.TempDir()
+	chdirForTest(t, projectDir)
+	marker := filepath.Join(t.TempDir(), "executed")
+	installPolicyVersionCodex(t, "0.138.9", marker)
+	allowed := []string{"read"}
+	if err := store.Save(registry.Manifest{
+		Name: "docs", Command: mustCurrentExecutable(t), Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{AllowedTools: &allowed},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	saveTestSkillPackage(t, store, "release", "Release workflow")
+	if err := store.SaveRing(registry.Ring{
+		Name: "required", Members: []string{"docs"}, Skills: []string{"release"},
+		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
+	}); err != nil {
+		t.Fatalf("save ring: %v", err)
+	}
+	result := runCmd(store, "run", "codex", "--ring", "required", "--dry-run", "--json", "--", "inspect")
+	if result.code == 0 || !strings.Contains(result.stderr, "launch plan is not ready") {
+		t.Fatalf("old Codex should block readiness: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	plan := decodeRunPlan(t, result.stdout)
+	server := plan.Servers[0]
+	if plan.Ready || server.Status != "blocked" || server.Policy.SupportState != "unsupported" || server.Policy.EnforcementClassification != "blocked" {
+		t.Fatalf("old Codex downgrade was not classified: %#v", plan)
+	}
+	if !strings.Contains(strings.Join(plan.Errors, "\n"), "stable Codex CLI 0.139.x") {
+		t.Fatalf("old Codex error is not actionable: %#v", plan.Errors)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("old Codex was executed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(projectDir, ".agents", "skills", "release", registry.SkillFileName)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("required run materialized a permanent skill before readiness: %v", err)
+	}
+	nonDry := runCmd(store, "run", "codex", "--ring", "required", "--", "inspect")
+	if nonDry.code == 0 || !strings.Contains(nonDry.stderr, "launch plan is not ready") {
+		t.Fatalf("non-dry old Codex run crossed readiness boundary: stdout=%s stderr=%s", nonDry.stdout, nonDry.stderr)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("non-dry old Codex executed: %v", err)
+	}
+}
+
+func TestRunSkillOnlyRequiredPolicyStillGatesCodexCompatibility(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-specific")
+	}
+	store := newTestStore(t)
+	projectDir := t.TempDir()
+	chdirForTest(t, projectDir)
+	marker := filepath.Join(t.TempDir(), "executed")
+	installPolicyVersionCodex(t, "0.138.9", marker)
+	saveTestSkillPackage(t, store, "release", "Release workflow")
+	if err := store.SaveRing(registry.Ring{
+		Name: "workflow", Skills: []string{"release"},
+		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
+	}); err != nil {
+		t.Fatalf("save skill-only ring: %v", err)
+	}
+	result := runCmd(store, "run", "codex", "--ring", "workflow", "--dry-run", "--json", "--", "release")
+	if result.code == 0 {
+		t.Fatalf("skill-only required policy bypassed compatibility gate: %s", result.stdout)
+	}
+	plan := decodeRunPlan(t, result.stdout)
+	if !plan.PolicyRequired || plan.Ready || !strings.Contains(strings.Join(plan.Errors, "\n"), "stable Codex CLI 0.139.x") {
+		t.Fatalf("skill-only policy gate was not reported: %#v", plan)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("old Codex was executed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(projectDir, ".agents", "skills", "release", registry.SkillFileName)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("skill-only required run materialized before compatibility: %v", err)
+	}
+}
+
+func TestRunRequiredPolicyReportsUnrepresentableTimeoutBlocked(t *testing.T) {
+	store := newTestStore(t)
+	installFakeCodex(t, 0)
+	allowed := []string{"read"}
+	if err := store.Save(registry.Manifest{
+		Name: "docs", Transport: registry.TransportHTTP, URL: "https://example.com/mcp", TimeoutMS: 1000,
+		Enabled: true, Clients: []string{"codex"}, Access: &registry.AccessProfile{AllowedTools: &allowed},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{
+		Name: "required", Members: []string{"docs"},
+		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
+	}); err != nil {
+		t.Fatalf("save ring: %v", err)
+	}
+	result := runCmd(store, "run", "codex", "--ring", "required", "--dry-run", "--json", "--", "inspect")
+	if result.code == 0 {
+		t.Fatalf("unrepresentable timeout should block: %s", result.stdout)
+	}
+	server := decodeRunPlan(t, result.stdout).Servers[0]
+	if server.Policy.SupportState != "unsupported" || server.Policy.EnforcementClassification != "blocked" || server.Status != "blocked" {
+		t.Fatalf("timeout downgrade not classified: %#v", server)
+	}
+}
+
+func TestCodexRunOverridesUsePlannedManifestSnapshot(t *testing.T) {
+	store := newTestStore(t)
+	installFakeCodex(t, 0)
+	allowed := []string{"read"}
+	manifest := registry.Manifest{
+		Name: "docs", Command: mustCurrentExecutable(t), Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{AllowedTools: &allowed},
+	}
+	if err := store.Save(manifest); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{
+		Name: "required", Members: []string{"docs"},
+		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
+	}); err != nil {
+		t.Fatalf("save ring: %v", err)
+	}
+	plan, err := (cliApp{store: store}).buildRunPlan("codex", []string{"required"}, "inspect")
+	if err != nil || !plan.Ready {
+		t.Fatalf("build plan: ready=%t err=%v errors=%v", plan.Ready, err, plan.Errors)
+	}
+	changed := []string{"write"}
+	manifest.Access.AllowedTools = &changed
+	if err := store.Save(manifest); err != nil {
+		t.Fatalf("mutate store after plan: %v", err)
+	}
+	overrides, err := codexRunConfigOverrides(store, plan, t.TempDir())
+	if err != nil {
+		t.Fatalf("compile planned overrides: %v", err)
+	}
+	if len(overrides) != 1 || !strings.Contains(overrides[0], `enabled_tools = ["read"]`) || strings.Contains(overrides[0], `enabled_tools = ["write"]`) {
+		t.Fatalf("override re-read a changed manifest instead of using the plan snapshot: %#v", overrides)
+	}
+}
+
+func TestRunRequiredPolicyExecutesWithStrictCompiledOverride(t *testing.T) {
+	store := newTestStore(t)
+	logPath := installFakeCodex(t, 0)
+	allowed := []string{"read"}
+	defaultApproval := registry.ApprovalBehaviorAlwaysPrompt
+	if err := store.Save(registry.Manifest{
+		Name: "docs.server", Command: mustCurrentExecutable(t), Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{AllowedTools: &allowed, DefaultApproval: &defaultApproval},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{
+		Name: "required", Members: []string{"docs.server"},
+		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
+	}); err != nil {
+		t.Fatalf("save ring: %v", err)
+	}
+	result := runCmd(store, "run", "codex", "--ring", "required", "--", "inspect")
+	if result.code != 0 {
+		t.Fatalf("required policy execution failed: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	args := readNULArgs(t, logPath)
+	if len(args) < 2 || args[0] != "exec" || args[1] != "--strict-config" {
+		t.Fatalf("required run did not enable strict config: %#v", args)
+	}
+	overrides := collectConfigOverrides(args)
+	if len(overrides) != 1 || !strings.Contains(overrides[0], `"docs.server"`) ||
+		!strings.Contains(overrides[0], `enabled_tools = ["read"]`) ||
+		!strings.Contains(overrides[0], `default_tools_approval_mode = "prompt"`) {
+		t.Fatalf("required run omitted compiled policy: %#v", overrides)
+	}
+}
+
+func TestRunCodexRechecksPolicyCompatibilityBeforeSkillMaterialization(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-specific")
+	}
+	store := newTestStore(t)
+	installFakeCodex(t, 0)
+	allowed := []string{"read"}
+	if err := store.Save(registry.Manifest{
+		Name: "docs", Command: mustCurrentExecutable(t), Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{AllowedTools: &allowed},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	saveTestSkillPackage(t, store, "release", "Release workflow")
+	if err := store.SaveRing(registry.Ring{
+		Name: "required", Members: []string{"docs"}, Skills: []string{"release"},
+		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
+	}); err != nil {
+		t.Fatalf("save ring: %v", err)
+	}
+	plan, err := (cliApp{store: store}).buildRunPlan("codex", []string{"required"}, "inspect")
+	if err != nil || !plan.Ready {
+		t.Fatalf("build exact plan: ready=%t err=%v errors=%v", plan.Ready, err, plan.Errors)
+	}
+	codexPath, err := exec.LookPath("codex")
+	if err != nil {
+		t.Fatalf("locate fake Codex: %v", err)
+	}
+	marker := filepath.Join(t.TempDir(), "executed")
+	replaced := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--version\" ]; then printf 'codex-cli 0.138.9\\n'; exit 0; fi\n" +
+		"printf executed > '" + marker + "'\n"
+	if err := os.WriteFile(codexPath, []byte(replaced), 0o755); err != nil {
+		t.Fatalf("replace Codex after plan: %v", err)
+	}
+	if err := store.RemoveSkill("release"); err != nil {
+		t.Fatalf("remove planned skill to detect materialization: %v", err)
+	}
+	err = runCodex(cliApp{store: store}, plan, "inspect")
+	if err == nil || !strings.Contains(err.Error(), "stable Codex CLI 0.139.x") {
+		t.Fatalf("executor did not recheck compatibility first: %v", err)
+	}
+	if strings.Contains(err.Error(), "skill") {
+		t.Fatalf("skill materialization happened before compatibility check: %v", err)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("replaced Codex executed: %v", err)
+	}
+}
+
+func installPolicyVersionCodex(t *testing.T, version, executionMarker string) {
+	t.Helper()
+	binDir := t.TempDir()
+	path := filepath.Join(binDir, "codex")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--version\" ]; then printf 'codex-cli " + version + "\\n'; exit 0; fi\n" +
+		"printf executed > '" + executionMarker + "'\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write versioned Codex fixture: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -2742,6 +2742,7 @@ func TestRunWithStoreSyncDryRunJSON(t *testing.T) {
     "stewreads"
   ],
   "updated": [],
+  "policy_updated": [],
   "removed": [],
   "unchanged": [],
   "skipped": [],
@@ -2794,6 +2795,7 @@ func TestRunWithStoreSyncReportsUnsupportedRemote(t *testing.T) {
   "dry_run": true,
   "added": [],
   "updated": [],
+  "policy_updated": [],
   "removed": [],
   "unchanged": [],
   "skipped": [],
@@ -2852,6 +2854,7 @@ func TestRunWithStoreSyncReportsUnsupportedRemoteAuth(t *testing.T) {
   "dry_run": true,
   "added": [],
   "updated": [],
+  "policy_updated": [],
   "removed": [],
   "unchanged": [],
   "skipped": [],
@@ -3200,13 +3203,16 @@ func TestRunWithStoreStatusReportsDrift(t *testing.T) {
 		t.Fatalf("expected one drift entry, got: %v", drift)
 	}
 	entry := drift[0].(map[string]any)
-	assertJSONKeys(t, entry, "target", "scope", "config_path", "status", "stale", "missing", "orphaned", "issue")
+	assertJSONKeys(t, entry, "target", "scope", "config_path", "status", "stale", "policy_stale", "missing", "orphaned", "issue")
 	if entry["target"] != "claude-code" || entry["status"] != "warn" {
 		t.Fatalf("unexpected drift entry: %v", entry)
 	}
 	orphaned := entry["orphaned"].([]any)
 	if len(orphaned) != 1 || orphaned[0] != "driftee" {
 		t.Fatalf("expected driftee orphaned, got: %v", orphaned)
+	}
+	if policyStale := entry["policy_stale"].([]any); len(policyStale) != 0 {
+		t.Fatalf("expected no policy drift for legacy manifest, got: %v", policyStale)
 	}
 }
 

--- a/docs/adr/003-capability-policy-contract-v1.md
+++ b/docs/adr/003-capability-policy-contract-v1.md
@@ -133,8 +133,12 @@ stale attachment can always be cleaned up.
 
 Target support is declared centrally and separately for persistent sync/attach,
 render, and run. A compiler must opt into a surface; an unspecified compiler is
-unsupported. The policy-schema PR intentionally leaves every compiler disabled,
-so required operations fail closed until the corresponding compiler lands.
+unsupported. The policy-schema PR initially left every compiler disabled. The
+Codex compiler now opts into persistent sync/attach, render, and run for all
+five V1 access fields; other target surfaces remain disabled until their
+corresponding lossless compilers land. Codex run support is additionally bounded
+to stable CLI 0.139.x releases; other runtime versions fail closed until their
+complete field semantics are validated.
 
 For persistent sync, undeclared native policy fields are preserved. Declared
 fields are compiled exactly. A required operation blocks on unknown
@@ -180,5 +184,6 @@ write.
   narrow serializer.
 - Supporting another client requires an explicit compiler and fidelity tests;
   approximate mappings are not accepted for required rings.
-- Environment sanitization, TTLs, receipts, credential brokers, audit, and
-  runtime `[policy.execution]` semantics remain outside this decision.
+- Environment sanitization, TTLs, receipts, credential brokers, audit,
+  OpenCode support, production examples, and runtime `[policy.execution]`
+  semantics remain outside this decision.

--- a/docs/adr/003-capability-policy-contract-v1.md
+++ b/docs/adr/003-capability-policy-contract-v1.md
@@ -1,0 +1,181 @@
+# ADR 003: Capability Policy Contract V1
+
+- Status: Accepted
+- Date: 2026-07-10
+
+## Context
+
+Madari server manifests describe one MCP server and rings compose server and
+skill references. Ring `[contract]` metadata is intentionally advisory. None of
+those primitives currently states which server tools a client may expose or
+whether a ring must fail when a target cannot reproduce the declared access
+controls.
+
+Client-native MCP policy fields are not portable as-is. Names, supported
+features, and approval enums vary by client and client version. Copying one
+client's values into Madari's registry would make that client the canonical
+contract and would encourage other adapters to approximate unsupported
+semantics. Approximation is unsafe for a ring that requires enforcement because
+it can silently widen access.
+
+## Decision
+
+### Primitive ownership
+
+- A server manifest owns one optional MCP access profile.
+- A ring continues to compose server profiles and skills by reference.
+- `[contract]` remains advisory and is never an authorization mechanism.
+- A new ring `[policy]` section declares whether exact enforcement is required.
+- `[policy.execution]` is reserved for a later runtime-policy goal and is
+  rejected in V1.
+
+The V1 server shape is:
+
+```toml
+[access]
+allowed_tools = ["issues.get", "issues.list"]
+denied_tools = ["issues.delete"]
+oauth_scopes = ["issues:read"]
+default_approval = "always-prompt"
+
+[access.tool_approvals]
+"issues.get" = "always-allow"
+```
+
+The V1 ring enforcement shape is:
+
+```toml
+[policy]
+enforcement = "required"
+```
+
+`allowed_tools` is the exact tool allowlist. `denied_tools` is an optional
+second-stage deny list. `oauth_scopes` contains scopes Madari asks the client to
+request. `default_approval` and `tool_approvals` control client prompts; they do
+not grant server-side permission.
+
+### Portable approval vocabulary
+
+Madari V1 defines these values:
+
+| Madari value | Portable intent | Codex value |
+| --- | --- | --- |
+| `inherit` | Remove the explicit override and use the client default | field omitted |
+| `automatic` | Let the client choose from its native tool metadata and policy | `auto` |
+| `always-prompt` | Prompt for every invocation covered by the value | `prompt` |
+| `always-allow` | Do not add an approval prompt for the invocation | `approve` |
+
+Raw Codex values are not valid Madari values. In particular, V1 does not expose
+Codex's version-dependent `writes` value as a portable behavior. A later schema
+revision can add a portable write-classification behavior after its semantics
+and target support are stable enough to compile without version guessing.
+
+Approval behavior is a client-side control, not an authorization boundary. A
+server and its OAuth provider remain responsible for authorization.
+
+### Presence and explicit clear
+
+Presence is part of the contract and must survive TOML, JSON snapshots, store
+round trips, and CLI JSON output.
+
+- No `[access]` section means a legacy manifest makes no Madari access-policy
+  declaration.
+- An absent field inside `[access]` means persistent sync preserves that native
+  field on an existing managed entry. Render and ephemeral run omit it and use
+  the target default.
+- An explicitly empty `allowed_tools`, `denied_tools`, or `oauth_scopes` array
+  clears the corresponding native override. Clearing `allowed_tools` makes the
+  server unbounded from Madari's perspective.
+- An absent `[access.tool_approvals]` table preserves an existing native table.
+  A present empty table clears all native per-tool approval overrides.
+- `default_approval = "inherit"` explicitly clears the native default approval
+  override.
+
+Required enforcement therefore distinguishes an absent or empty allowlist from
+a non-empty allowlist. Both absent and explicitly cleared allowlists are
+unbounded and invalid for a required ring.
+
+### Validation and contradictions
+
+The registry rejects:
+
+- unknown access, policy, or nested tool-approval fields;
+- blank, whitespace-padded, or duplicate tool and scope values;
+- invalid portable approval values;
+- a tool present in both allow and deny lists;
+- a per-tool approval for a denied tool;
+- a per-tool approval outside a declared non-empty allowlist; and
+- a required ring whose server member lacks an explicit non-empty allowlist.
+
+Set-like arrays and per-tool keys marshal in deterministic lexical order.
+Dotted server and tool names are literal identifiers and must be quoted when a
+target's syntax would otherwise interpret dots as nesting.
+
+### Required enforcement
+
+For a selected operation, a required ring is ready only when:
+
+1. every server member exists, is enabled, and targets the selected client;
+2. every server member has an explicit non-empty allowlist;
+3. the target supports the member transport and every declared access field on
+   that operation's surface;
+4. the compiler can represent every declared value without approximation; and
+5. existing behavior-affecting native fields do not prevent a fidelity claim.
+
+Failure is a preflight error. Attach and routine sync of an already attached
+required ring fail before client config, managed state, or skill files change.
+Render fails before writing partial output. Run fails before skill
+materialization or client execution. Detach remains available so a broken or
+stale attachment can always be cleaned up.
+
+Target support is declared centrally and separately for persistent sync/attach,
+render, and run. A compiler must opt into a surface; an unspecified compiler is
+unsupported. The policy-schema PR intentionally leaves every compiler disabled,
+so required operations fail closed until the corresponding compiler lands.
+
+For persistent sync, undeclared native policy fields are preserved. Declared
+fields are compiled exactly. A required operation blocks on unknown
+behavior-affecting fields inside the selected managed server entry rather than
+deleting or guessing at them. Unmanaged entries and unrelated top-level client
+configuration retain the existing ownership and preservation guarantees.
+
+### OAuth and effective-policy reporting
+
+`oauth_scopes` means requested and client-configured. Madari can verify that the
+target config carries the requested values; it cannot prove that an OAuth
+provider granted them or that a token contains them. Diagnostics and run plans
+must use that language.
+
+Dry-run reporting distinguishes:
+
+- declared policy: the portable server profile plus ring enforcement;
+- effective policy: the values the selected target will receive;
+- support state: whether the target can represent those values; and
+- enforcement classification: none, advisory, exact, or blocked.
+
+Client-enforced tool filtering, requested OAuth scopes, approval prompting, and
+advisory contract/skill instructions are reported as separate controls.
+
+## Compatibility
+
+Manifests without `[access]` and rings without `[policy]` preserve existing
+behavior. Access profiles on non-required rings may be compiled and diagnosed
+when a target supports them, but Madari does not claim mandatory enforcement.
+
+Snapshot format V10 adds server access profiles and ring policies. V1 through
+V9 snapshots remain importable. Older snapshot versions carrying V10 fields are
+rejected so policy data cannot be silently discarded by version mismatch.
+Import validates the complete resulting server/ring graph before its first
+write.
+
+## Consequences
+
+- Madari gains a portable, client-independent access contract without turning
+  rings into duplicate server configuration.
+- Required policy is fail-closed across persistent, render, and run surfaces.
+- Legacy native restrictions survive routine sync instead of being erased by a
+  narrow serializer.
+- Supporting another client requires an explicit compiler and fidelity tests;
+  approximate mappings are not accepted for required rings.
+- Environment sanitization, TTLs, receipts, credential brokers, audit, and
+  runtime `[policy.execution]` semantics remain outside this decision.

--- a/docs/adr/003-capability-policy-contract-v1.md
+++ b/docs/adr/003-capability-policy-contract-v1.md
@@ -101,7 +101,8 @@ unbounded and invalid for a required ring.
 
 The registry rejects:
 
-- unknown access, policy, or nested tool-approval fields;
+- unknown access or policy fields, unknown nested access sections, and
+  malformed or duplicate tool-approval entries;
 - blank, whitespace-padded, or duplicate tool and scope values;
 - invalid portable approval values;
 - a tool present in both allow and deny lists;

--- a/docs/adr/003-capability-policy-contract-v1.md
+++ b/docs/adr/003-capability-policy-contract-v1.md
@@ -69,6 +69,8 @@ Raw Codex values are not valid Madari values. In particular, V1 does not expose
 Codex's version-dependent `writes` value as a portable behavior. A later schema
 revision can add a portable write-classification behavior after its semantics
 and target support are stable enough to compile without version guessing.
+The native field names and values are tracked against the current
+[Codex configuration reference](https://developers.openai.com/codex/config-reference).
 
 Approval behavior is a client-side control, not an authorization boundary. A
 server and its OAuth provider remain responsible for authorization.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,11 +10,12 @@
 
 Madari keeps four concepts separate:
 
-- Server: an executable MCP capability with command, args, env, and target
-  client metadata.
-- Ring: a named capability grouping with optional advisory contract metadata.
-  Persisted rings can contain server members and skill members by name; the
-  referenced server manifests and skill packages remain the source of truth.
+- Server: an executable MCP capability with command, args, env, target client
+  metadata, and one optional portable access profile.
+- Ring: a named capability grouping with optional required-enforcement policy
+  and optional advisory contract metadata. Persisted rings contain server and
+  skill members by name; referenced server manifests and skill packages remain
+  the source of truth.
 - Skill: procedural or domain instructions for how an agent should use
   capabilities. Skills are official Agent Skill package directories with
   `SKILL.md` metadata, bundled files, and a render surface.
@@ -33,6 +34,12 @@ config/state. Plain `skill render` emits managed `SKILL.md` only, and `skill
 attach` materializes client-native skill packages without changing MCP client
 configs.
 
+Access policy follows the same boundary: the server owns `allowed_tools`,
+`denied_tools`, `oauth_scopes`, `default_approval`, and per-tool approvals. A
+ring only selects whether exact enforcement is required; it does not duplicate
+member profiles. `[contract]` and skill content remain advisory, while
+`[policy.execution]` is reserved and rejected in V1.
+
 ## Components
 
 1. Registry
@@ -45,15 +52,21 @@ configs.
   JSON; export refuses rings that would not round-trip, import validates
   everything before writing anything and never attaches or syncs. Snapshot
   version 4 added ring skill membership, version 5 added ring contract metadata,
-  and version 6 stores full skill package files.
+  version 6 stores full skill package files, and V10 adds server access profiles
+  plus ring policy. V1 through V9 remain importable; older versions carrying V10
+  fields are rejected so policy data cannot be discarded silently.
 
 2. Client Targets and Adapters
 - The command layer keeps a single client target registry for target-level
-  capabilities: sync adapter, ring config renderer, skill roots, and scope
-  support.
+  capabilities: sync adapter, ring config renderer, skill roots, scope support,
+  and separate policy support declarations for persistent sync/attach, render,
+  and run.
 - Translate registry entries into client-specific config.
 - Current adapters: Claude Desktop, Claude Code, Gemini, Codex, and Vibe.
 - Adapters own read/merge/write behavior for their client format.
+- An unspecified policy compiler is unsupported. In the policy schema stage all
+  target/surface policy declarations are unsupported, so required operations
+  fail closed until a compiler explicitly opts in.
 
 3. Sync Engine
 - Reads registry + client config.
@@ -84,12 +97,13 @@ configs.
 5. Rings
 - Named capability sets (`rings/<name>.toml`). Server members are references by
   name only — the server manifest stays the single source of truth for command,
-  args, and env. Skill members are references by name only — managed skill
-  metadata and Markdown stay the source of truth. Optional `[contract]`
-  metadata describes when the ring is useful, what context a delegating agent
-  should provide, and what outputs to expect. Contracts are advisory only:
-  attach, detach, sync, render, status, ownership, and skill materialization do
-  not change when a contract changes.
+  args, env, and access profile. Skill members are references by name only —
+  managed skill metadata and Markdown stay the source of truth. Optional
+  `[contract]` metadata describes when the ring is useful, what context a
+  delegating agent should provide, and what outputs to expect. Contracts are
+  advisory only: attach, detach, sync, render, status, ownership, and skill
+  materialization do not change when a contract changes. Optional `[policy]`
+  metadata can set `enforcement = "required"` without embedding member policy.
 - Attachment is derived state: ring `R` is attached to a target+scope iff
   `ring:R` appears among server ownership sources or skill attachment sources
   there. Attach records the source on every server and skill member,
@@ -115,7 +129,28 @@ configs.
 - `ring delete` refuses while any target/scope still records the ring as an
   ownership source, and never edits client configs or managed state.
 
-6. Skills
+6. Capability Policy
+- `[access]` is optional. No section means a legacy server makes no Madari
+  access declaration.
+- The portable approval vocabulary is `inherit`, `automatic`, `always-prompt`,
+  and `always-allow`. Raw client-native values are not registry values.
+- Field presence is semantic. Absent fields preserve native values during
+  persistent sync, while explicit empty arrays/tables and `inherit` clear the
+  corresponding override. Required rings reject absent or empty allowlists as
+  unbounded.
+- A required operation succeeds only if every member exists, is enabled, targets
+  the selected client, has a non-empty exact allowlist, and compiles every field
+  without approximation. Unknown behavior-affecting native fields also prevent
+  an exact fidelity claim.
+- Required sync/attach fails before config, managed state, or skills change;
+  render fails before partial output; run fails before skill materialization or
+  execution. Detach remains available.
+- OAuth scopes are requested and client-configured, not proof of a provider
+  grant. Approval behavior is a client prompt control, not authorization.
+- Environment sanitization, TTLs, receipts, credential brokers, audit, and
+  `[policy.execution]` are outside V1.
+
+7. Skills
 - Standalone Agent Skill packages stored at `skills/<name>/` with `SKILL.md`
   frontmatter plus optional bundled files such as `references/`, `scripts/`,
   and `assets/`.
@@ -134,7 +169,7 @@ configs.
   ring skills by temporarily materializing them as project skills under the
   isolated run root; other run targets are dry-run only today.
 
-7. Doctor Engine
+8. Doctor Engine
 - Verifies command/binary resolution.
 - Validates required env values are present.
 - Validates client config parseability.
@@ -176,6 +211,10 @@ configs.
   and sync scope is declared explicitly, never inferred from paths.
 - Always backup before write.
 - Fail closed on parse errors.
+- Never claim required policy fidelity when any declared restriction is
+  unsupported, omitted, or approximated.
+- Keep client-enforced tool filtering, requested OAuth scopes, client approval
+  prompts, and advisory contract/skill instructions distinct in reporting.
 
 Materialized sync is the only mode: client configs always contain real
 commands and survive madari's removal. A launcher shim was considered and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,9 +64,10 @@ member profiles. `[contract]` and skill content remain advisory, while
 - Translate registry entries into client-specific config.
 - Current adapters: Claude Desktop, Claude Code, Gemini, Codex, and Vibe.
 - Adapters own read/merge/write behavior for their client format.
-- An unspecified policy compiler is unsupported. In the policy schema stage all
-  target/surface policy declarations are unsupported, so required operations
-  fail closed until a compiler explicitly opts in.
+- An unspecified policy compiler is unsupported. Codex persistent sync/attach,
+  render, and run opt into all five V1 access features; every other target
+  policy surface remains fail-closed. Access-bearing Codex runs additionally
+  require a validated stable CLI 0.139.x release.
 
 3. Sync Engine
 - Reads registry + client config.
@@ -145,10 +146,15 @@ member profiles. `[contract]` and skill content remain advisory, while
 - Required sync/attach fails before config, managed state, or skills change;
   render fails before partial output; run fails before skill materialization or
   execution. Detach remains available.
+- Codex sync patches cloned native server tables instead of serializing a narrow
+  replacement. Undeclared native policy fields survive legacy updates; declared
+  fields compile exactly, explicit clears remove only their native overrides,
+  and required operations reject unknown behavior-affecting fields.
 - OAuth scopes are requested and client-configured, not proof of a provider
   grant. Approval behavior is a client prompt control, not authorization.
-- Environment sanitization, TTLs, receipts, credential brokers, audit, and
-  `[policy.execution]` are outside V1.
+- Environment sanitization, TTLs, receipts, credential brokers, audit,
+  OpenCode support, production examples, and `[policy.execution]` are outside
+  V1.
 
 7. Skills
 - Standalone Agent Skill packages stored at `skills/<name>/` with `SKILL.md`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -26,6 +26,77 @@ runtime env key that contains a bearer token. `madari list` and `madari doctor`
 show each server's transport and endpoint so remote entries are visible where
 materialization is pending.
 
+Server manifests can also carry an optional portable `[access]` profile. The
+profile fields are `allowed_tools`, `denied_tools`, `oauth_scopes`,
+`default_approval`, and `[access.tool_approvals]`. Access profiles are stored on
+the server rather than duplicated into rings. See the manifest spec for strict
+validation and presence semantics.
+
+Both `madari add` and `madari install` can create a profile with repeatable
+`--allow-tool`, `--deny-tool`, and `--tool-approval TOOL=BEHAVIOR` flags plus
+`--default-tool-approval BEHAVIOR`. Remote-capable `madari add` also accepts
+repeatable `--oauth-scope` values. Direct TOML or snapshot editing remains the
+way to express an explicit empty list or table clear.
+
+## Capability Policy V1
+
+The portable server shape is:
+
+```toml
+[access]
+allowed_tools = ["issues.get", "issues.list"]
+denied_tools = ["issues.delete"]
+oauth_scopes = ["issues:read"]
+default_approval = "always-prompt"
+
+[access.tool_approvals]
+"issues.get" = "always-allow"
+```
+
+The supported approval values are `inherit`, `automatic`, `always-prompt`, and
+`always-allow`. Raw client-native enum values are rejected. `inherit` explicitly
+clears an approval override. Approval behavior controls client prompts and is
+not an authorization boundary.
+
+Presence is preserved across TOML, snapshots, the store, and JSON output. No
+`[access]` section means no Madari policy declaration. An absent field preserves
+the corresponding native field during persistent sync; render and run omit it.
+Explicitly empty tool/scope arrays clear that native override, a present empty
+`[access.tool_approvals]` table clears the per-tool table, and an empty or absent
+allowlist is unbounded.
+
+Rings request mandatory enforcement separately:
+
+```toml
+[policy]
+enforcement = "required"
+```
+
+`madari ring create ... --enforcement required` writes the same ring policy.
+
+A required ring must have an explicit non-empty allowlist on every server. All
+members must exist, be enabled, target the selected client, and compile exactly
+for the selected operation surface. Missing, disabled, wrong-target, unbounded,
+unsupported, and unrepresentable members are errors; Madari never substitutes
+an advisory prompt or a weaker native control.
+
+Policy support is declared independently for persistent sync/attach, render,
+and run. In the schema-and-compatibility stage every target/surface compiler is
+unsupported. Required sync or attach therefore fails before config, managed
+state, or skill mutation; required render fails before partial output; and
+required run fails before skill materialization or client execution. Detach
+remains available for cleanup. Manifests without `[access]` and rings without
+`[policy]` preserve existing behavior.
+
+Access profiles outside required rings are still stored, validated, exported,
+imported, and reported, but the schema stage makes no exact-enforcement claim
+for them and has no target compiler that materializes them.
+
+`oauth_scopes` is requested and client-configured; it does not prove that an
+OAuth provider granted the scopes or that a token contains them.
+`[policy.execution]` is reserved for a later runtime contract and is rejected in
+V1.
+
 ## Install Workflow
 
 ```bash
@@ -127,6 +198,12 @@ prints that same standalone file shape, and `ring contract clear` removes the
 contract. Contract commands do not change members, skills, attach state, sync
 behavior, or render output.
 
+Ring policy is distinct from the advisory contract. A ring file may set
+`[policy] enforcement = "required"`, but each referenced server remains the
+source of truth for its own `[access]` profile. The initial policy-contract
+release stores and reports this declaration but has no enabled target compiler,
+so required attach, render, and run operations fail during preflight.
+
 ```toml
 summary = "Collect source context and prepare a research brief."
 good_for = ["source collection", "evidence review"]
@@ -175,6 +252,10 @@ with warnings for targets, transports, or auth modes without support (codex
 SSE, bearer-token-env auth outside Codex, claude-desktop, vibe).
 Ring skill members are not embedded in MCP render output; use `ring attach`
 for native skill materialization.
+Policy-required render does not use the legacy omit-and-warn behavior: if any
+restriction cannot be represented exactly, it fails before writing partial
+stdout. In the schema-and-compatibility stage every required render is blocked
+because no render policy compiler is enabled.
 Ephemeral-session recipe:
 
 ```bash
@@ -228,6 +309,11 @@ capability.
 Codex execution also blocks when a non-empty admin/system skill root is
 present, because Madari cannot guarantee ring-only skill isolation in that
 case.
+Policy-required run adds a stricter preflight boundary: every declared member
+restriction must compile exactly before any temporary skill package is
+materialized or the client starts. No run policy compiler is enabled in the
+schema-and-compatibility stage, so required runs are currently blocked while
+legacy runs remain unchanged.
 
 ## Skills
 
@@ -289,12 +375,15 @@ madari import --file madari-snapshot.json --apply
 ```
 
 Snapshots are versioned JSON documents containing server manifests, ring
-definitions, and skill packages. Export writes the current snapshot version
-with `servers`, `rings`, and `skills`. Snapshot version 6 stores skills as
-deterministic package file entries with relative paths, base64 content, and
-file modes; older snapshots with a single skill `content` string remain
-importable and are converted to package-backed `SKILL.md`. Import is a dry-run
-by default; `--apply` adds or updates listed servers, rings, and skills, never
+definitions, and skill packages. Export writes V10 with `servers`, `rings`, and
+`skills`; V10 adds server access profiles and ring policy. V1 through V9 remain
+importable. An older snapshot version carrying V10 fields is rejected so access
+or enforcement data cannot be discarded silently. Snapshot version 6 introduced
+deterministic skill package file entries with relative paths, base64 content,
+and file modes; older snapshots with a single skill `content` string remain
+importable and are converted to package-backed `SKILL.md`. Import validates the
+complete resulting server/ring graph before its first write. It is a dry-run by
+default; `--apply` adds or updates listed servers, rings, and skills, never
 deletes entries absent from the snapshot, and never attaches or syncs imported
 rings.
 Ring membership changes converge through the normal reconciliation pass on
@@ -307,9 +396,12 @@ the next sync, attach, or detach.
 single JSON document on stdout with nothing else.
 Every payload carries the envelope fields `schema_version` (currently `1`)
 and `command`. Field additions are backward-compatible; renames or removals
-bump `schema_version`. List-valued fields are always present (empty arrays,
-never `null`) when their containing object is emitted. Optional objects such as
-ring `contract` are omitted when absent.
+bump `schema_version`. Except for presence-sensitive access-profile fields,
+list-valued fields are always present (empty arrays, never `null`) when their
+containing object is emitted. Optional objects such as server `access`, ring
+`contract`, and ring `policy` are omitted when absent. Inside `access`, absent
+fields are omitted while explicitly cleared arrays or the per-tool table are
+emitted as `[]` or `{}` so presence semantics survive the JSON round trip.
 
 ```bash
 madari list --json
@@ -343,6 +435,10 @@ the target client output unchanged.
       "transport": "stdio",
       "command": "/abs/path/stewreads-mcp",
       "clients": ["claude-desktop"],
+      "access": {
+        "allowed_tools": ["books.create"],
+        "default_approval": "always-prompt"
+      },
       "sources": ["standalone"]
     }
   ]
@@ -514,6 +610,7 @@ itself.
       "members": ["arxiv", "stewreads"],
       "skills": ["release"],
       "description": "Research helpers",
+      "policy": {"enforcement": "required"},
       "contract": {
         "summary": "Collect source context and prepare a research brief.",
         "good_for": ["source collection", "evidence review"],
@@ -538,6 +635,7 @@ itself.
     "members": ["arxiv", "stewreads"],
     "skills": ["release"],
     "description": "Research helpers",
+    "policy": {"enforcement": "required"},
     "contract": {
       "summary": "Collect source context and prepare a research brief.",
       "good_for": ["source collection", "evidence review"],

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -81,16 +81,17 @@ unsupported, and unrepresentable members are errors; Madari never substitutes
 an advisory prompt or a weaker native control.
 
 Policy support is declared independently for persistent sync/attach, render,
-and run. In the schema-and-compatibility stage every target/surface compiler is
-unsupported. Required sync or attach therefore fails before config, managed
-state, or skill mutation; required render fails before partial output; and
-required run fails before skill materialization or client execution. Detach
-remains available for cleanup. Manifests without `[access]` and rings without
-`[policy]` preserve existing behavior.
+and run. Codex compiles all five V1 fields on all three surfaces. Every policy
+surface for other targets remains unsupported.
+Required sync or attach fails before config, managed state, or skill mutation;
+required render fails before partial output; and required run fails before skill
+materialization or client execution. Detach remains available for cleanup.
+Manifests without `[access]` and rings without `[policy]` preserve existing
+behavior.
 
-Access profiles outside required rings are still stored, validated, exported,
-imported, and reported, but the schema stage makes no exact-enforcement claim
-for them and has no target compiler that materializes them.
+Access profiles outside required rings are stored, validated, exported,
+imported, reported, and compiled when the selected target surface supports
+them. They do not turn an advisory ring into a mandatory enforcement claim.
 
 `oauth_scopes` is requested and client-configured; it does not prove that an
 OAuth provider granted the scopes or that a token contains them.
@@ -152,6 +153,17 @@ as Codex `http_headers`. `sse` manifests stay pending (Codex's documented
 remote support is Streamable HTTP), and `timeout_ms` has no Codex equivalent
 and is not emitted.
 
+Codex compiles `allowed_tools`, `denied_tools`, `oauth_scopes`,
+`default_approval`, and per-tool approvals into `enabled_tools`,
+`disabled_tools`, `scopes`, `default_tools_approval_mode`, and
+`tools.<tool>.approval_mode`. Routine sync preserves undeclared native policy
+fields, including on core command or URL updates. Explicit empty declarations
+and portable `inherit` remove the corresponding native override. A required
+ring refuses unknown behavior-affecting native fields or native approval values
+that Madari cannot prove equivalent instead of rewriting them. Policy-only
+differences are reported separately by doctor/status while remaining a subset
+of ordinary stale entries.
+
 `vibe` sync targets Vibe's user config (`$VIBE_HOME/config.toml`, or
 `~/.vibe/config.toml` when `VIBE_HOME` is unset). Static `[env]` values are
 written into `[[mcp_servers]]` stdio entries. Existing unmanaged HTTP,
@@ -200,9 +212,9 @@ behavior, or render output.
 
 Ring policy is distinct from the advisory contract. A ring file may set
 `[policy] enforcement = "required"`, but each referenced server remains the
-source of truth for its own `[access]` profile. The initial policy-contract
-release stores and reports this declaration but has no enabled target compiler,
-so required attach, render, and run operations fail during preflight.
+source of truth for its own `[access]` profile. Codex required attach, render,
+and run are supported when every member compiles exactly. Unsupported target
+surfaces fail during preflight.
 
 ```toml
 summary = "Collect source context and prepare a research brief."
@@ -254,8 +266,9 @@ Ring skill members are not embedded in MCP render output; use `ring attach`
 for native skill materialization.
 Policy-required render does not use the legacy omit-and-warn behavior: if any
 restriction cannot be represented exactly, it fails before writing partial
-stdout. In the schema-and-compatibility stage every required render is blocked
-because no render policy compiler is enabled.
+stdout. Codex render emits the five native policy fields, with dotted server and
+tool names quoted as literal TOML keys. Other render targets remain unsupported
+for required policy.
 Ephemeral-session recipe:
 
 ```bash
@@ -302,6 +315,12 @@ checks runtime env keys by name, and reports the launch plan. Run never writes
 client config, creates managed state, or permanently materializes skill
 packages.
 
+When any selected server declares `[access]`, Codex execution also adds
+`--strict-config` and requires a stable Codex CLI 0.139.x release. This applies
+to advisory profiles as well as policy-required rings so Madari never drops a
+declared restriction. Legacy runs with no access declarations omit the newer
+flag and version gate, preserving their existing compatibility behavior.
+
 Unlike `ring render`, `run` is fail-closed. A disabled member, missing member,
 unsupported remote transport or auth mode, missing runtime env key, or
 unsupported skill target blocks the plan instead of silently omitting that
@@ -311,9 +330,19 @@ present, because Madari cannot guarantee ring-only skill isolation in that
 case.
 Policy-required run adds a stricter preflight boundary: every declared member
 restriction must compile exactly before any temporary skill package is
-materialized or the client starts. No run policy compiler is enabled in the
-schema-and-compatibility stage, so required runs are currently blocked while
-legacy runs remain unchanged.
+materialized or the client starts. Codex maps every V1 access field into the
+single ephemeral `mcp_servers={...}` override. The plan and executor both check
+the bounded version range Madari has validated for this complete contract.
+`--strict-config` is an additional config-parser safeguard, not proof that
+nested MCP policy fields retain their semantics outside the validated range.
+
+Dry-run text and JSON report each server's portable declared policy, the
+Codex-native effective policy, support state, and enforcement classification.
+If a server is shared, any selected required ring wins and is listed in
+`required_by`. The control labels are intentionally distinct: tool filtering is
+client-enforced; OAuth scopes are requested/client-configured and
+provider-unverified; approval modes are client controls rather than an
+authorization boundary; contracts and skills remain advisory instructions.
 
 ## Skills
 
@@ -477,6 +506,7 @@ summaries cover every sync target):
       "config_path": "/path/to/claude_desktop_config.json",
       "status": "ready",
       "stale": [],
+      "policy_stale": [],
       "missing": [],
       "orphaned": [],
       "issue": ""
@@ -486,10 +516,14 @@ summaries cover every sync target):
 ```
 
 Drift entries appear per target+scope that has managed entries: `stale`
-(materialized value differs from the manifest), `missing` (managed entry
-deleted from the client config), and `orphaned` (no longer desired; the next
-sync removes it). Drift is warning-level and never changes the exit code by
-itself.
+(materialized value differs from the manifest), `policy_stale` (the subset of
+`stale` whose declared access policy differs from the target's materialized
+policy), `missing` (managed entry deleted from the client config), and
+`orphaned` (no longer desired; the next sync removes it). Policy drift covers
+client-enforced tool filtering, requested/client-configured OAuth scopes, and
+client approval controls. It does not prove scopes were granted by the OAuth
+provider, and approval behavior is not an authorization boundary. Drift is
+warning-level and never changes the exit code by itself.
 
 `madari doctor --json`:
 
@@ -534,6 +568,7 @@ itself.
       "config_path": "/path/to/claude_desktop_config.json",
       "status": "warn",
       "stale": ["stewreads"],
+      "policy_stale": [],
       "missing": [],
       "orphaned": [],
       "issue": ""
@@ -554,6 +589,7 @@ itself.
   "dry_run": true,
   "added": ["stewreads"],
   "updated": [],
+  "policy_updated": [],
   "removed": [],
   "unchanged": [],
   "skipped": [],
@@ -566,6 +602,10 @@ itself.
 }
 ```
 
+For Codex, `policy_updated` is the sorted subset of `updated` whose declared
+access fields differ from the native configuration. Undeclared preserved fields
+do not appear as policy drift.
+
 `madari run <client> --ring <ring> --dry-run --json`:
 
 ```json
@@ -577,6 +617,13 @@ itself.
   "ready": true,
   "runner_available": true,
   "prompt_provided": true,
+  "policy_required": true,
+  "policy_controls": {
+    "tool_filtering": "client-enforced",
+    "oauth_scopes": "requested/client-configured/provider-unverified",
+    "approvals": "client-control/not-authorization",
+    "instructions": "contracts-and-skills-advisory"
+  },
   "servers": [
     {
       "name": "cloud-sql",
@@ -586,7 +633,20 @@ itself.
       "auth": "bearer_token_env_var",
       "runtime_env": ["CLOUDSQL_MCP_TOKEN"],
       "rings": ["cloudsql-readonly"],
-      "issues": []
+      "issues": [],
+      "policy": {
+        "declared": {"allowed_tools": ["query"]},
+        "ring_enforcement": "required",
+        "required_by": ["cloudsql-readonly"],
+        "effective": {
+          "enabled_tools": ["query"],
+          "disabled_tools": [],
+          "requested_oauth_scopes": [],
+          "tool_approval_modes": {}
+        },
+        "support_state": "supported",
+        "enforcement_classification": "exact"
+      }
     }
   ],
   "skills": [],

--- a/docs/manifest-spec.md
+++ b/docs/manifest-spec.md
@@ -104,7 +104,8 @@ section must declare at least one field:
 - `denied_tools` (array of strings, optional): second-stage deny list applied
   after the allowlist.
 - `oauth_scopes` (array of strings, optional): scopes Madari asks the selected
-  client to request.
+  client to request. A non-empty declaration is remote-only because stdio
+  transports have no OAuth client flow for Madari to configure.
 - `default_approval` (string, optional): portable default approval behavior.
 
 `oauth_scopes` records requested, client-configured values. Madari can verify

--- a/docs/manifest-spec.md
+++ b/docs/manifest-spec.md
@@ -253,11 +253,13 @@ wrong-target, unbounded, unsupported, or unrepresentable members block the
 operation.
 
 Policy capability support is declared separately for persistent sync/attach,
-render, and run. The schema-and-compatibility stage declares every target and
-surface unsupported, so a required operation currently fails during preflight:
-sync and attach before config, state, or skills change; render before partial
-output; and run before skill materialization or client execution. Detach remains
-available for cleanup. Rings without `[policy]` preserve legacy behavior.
+render, and run. Codex compiles every V1 access field on all three surfaces.
+Access-bearing Codex runs additionally require a validated stable CLI 0.139.x
+release. All other target policy surfaces remain unsupported. Any
+required operation that cannot compile exactly fails during preflight: sync and
+attach before config, state, or skills change; render before partial output; and
+run before skill materialization or client execution. Detach remains available
+for cleanup. Rings without `[policy]` preserve legacy behavior.
 
 `[policy.execution]` is reserved for a later runtime-policy contract and is
 rejected in V1.

--- a/docs/manifest-spec.md
+++ b/docs/manifest-spec.md
@@ -94,6 +94,68 @@ case-insensitive). Use `[secret_headers]` to mark additional headers whose
 values must stay out of committed configs. `ring render` never emits secret
 header values; the warning names the headers to provide manually.
 
+### `[access]`
+
+An optional access profile owned by this server manifest. No `[access]` section
+means a legacy manifest makes no Madari access-policy declaration. A present
+section must declare at least one field:
+
+- `allowed_tools` (array of strings, optional): exact tool allowlist.
+- `denied_tools` (array of strings, optional): second-stage deny list applied
+  after the allowlist.
+- `oauth_scopes` (array of strings, optional): scopes Madari asks the selected
+  client to request.
+- `default_approval` (string, optional): portable default approval behavior.
+
+`oauth_scopes` records requested, client-configured values. Madari can verify
+that a target config carries them, but cannot prove that an OAuth provider
+granted them or that a token contains them.
+
+Approval values use Madari's portable vocabulary only:
+
+- `inherit`: explicitly remove the target-native override and use the client
+  default.
+- `automatic`: let the client choose from its native tool metadata and policy.
+- `always-prompt`: prompt for every invocation covered by the value.
+- `always-allow`: do not add an approval prompt for the invocation.
+
+Raw client-native approval enum values are invalid Madari values. Approval
+behavior controls client prompts; it does not authorize a server-side action.
+The server and OAuth provider remain responsible for authorization.
+
+### `[access.tool_approvals]`
+
+An optional table mapping literal tool names to the same portable approval
+values. Dotted tool names are identifiers, not nested paths, and must be quoted:
+
+```toml
+[access]
+allowed_tools = ["issues.get", "issues.list"]
+denied_tools = ["issues.delete"]
+oauth_scopes = ["issues:read"]
+default_approval = "always-prompt"
+
+[access.tool_approvals]
+"issues.get" = "always-allow"
+```
+
+Presence is part of the access contract:
+
+- An absent field inside `[access]` tells persistent sync to preserve that
+  native field on an existing managed entry. Render and ephemeral run omit the
+  field and use the target default.
+- Explicitly empty `allowed_tools`, `denied_tools`, or `oauth_scopes` arrays
+  clear the corresponding native override. An empty `allowed_tools` array is
+  unbounded from Madari's perspective.
+- An absent `[access.tool_approvals]` table preserves the existing native table.
+  A present empty table clears all native per-tool overrides.
+- `default_approval = "inherit"` explicitly clears the native default approval
+  override.
+
+Required enforcement needs an explicit, non-empty `allowed_tools` declaration.
+Both an absent allowlist and an explicitly cleared allowlist are unbounded and
+invalid for a required ring.
+
 ## Example
 
 Stdio server:
@@ -138,6 +200,15 @@ description = "Official Cloud SQL remote MCP server"
   `CLOUDSQL_MCP_TOKEN`.
 - `[secret_headers]` is remote-only; names must be valid header names and
   unique (case-insensitive).
+- Unknown `[access]` fields and nested access sections are rejected.
+- Tool and scope values, including per-tool approval names, must be non-blank
+  and have no surrounding whitespace. Array values must be unique. Set-like
+  arrays and per-tool keys marshal in lexical order.
+- A tool cannot appear in both `allowed_tools` and `denied_tools`.
+- A denied tool cannot have a per-tool approval. When a non-empty allowlist is
+  declared, each per-tool approval must name an allowed tool.
+- `default_approval` and every `[access.tool_approvals]` value must be one of
+  `inherit`, `automatic`, `always-prompt`, or `always-allow`.
 
 ## Ring Files
 
@@ -154,13 +225,41 @@ document per ring at
   reference managed skill entries by name only — rings never embed Markdown
   content.
 - `description` (string, optional): friendly description.
+- `[policy]` (optional): required-enforcement metadata described below.
 
 At least one `members` or `skills` entry is required. Every referenced server
 and skill must exist in the registry when a ring is created or imported.
 Ring manifests support only the top-level fields above plus the optional
-`[contract]` section. Unknown top-level keys, unknown sections, and unknown
-`[contract]` keys are rejected. Files are written deterministically with sorted
-server and skill members; contract arrays preserve authored order.
+`[contract]` and `[policy]` sections. Unknown top-level keys, unknown sections,
+and unknown contract or policy keys are rejected. Files are written
+deterministically with sorted server and skill members; contract arrays preserve
+authored order.
+
+### `[policy]`
+
+A ring can require exact access-profile enforcement for the selected operation:
+
+```toml
+[policy]
+enforcement = "required"
+```
+
+`required` is the only V1 enforcement value. Every server member must exist, be
+enabled, target the selected client, and declare an explicit non-empty
+`allowed_tools` list. The selected target and operation surface must represent
+every declared access field without approximation. Missing, disabled,
+wrong-target, unbounded, unsupported, or unrepresentable members block the
+operation.
+
+Policy capability support is declared separately for persistent sync/attach,
+render, and run. The schema-and-compatibility stage declares every target and
+surface unsupported, so a required operation currently fails during preflight:
+sync and attach before config, state, or skills change; render before partial
+output; and run before skill materialization or client execution. Detach remains
+available for cleanup. Rings without `[policy]` preserve legacy behavior.
+
+`[policy.execution]` is reserved for a later runtime-policy contract and is
+rejected in V1.
 
 ### `[contract]`
 
@@ -200,6 +299,15 @@ required_context = ["research question"]
 optional_context = ["time window", "known source URLs"]
 expected_outputs = ["findings summary", "sources inspected", "recommended next check"]
 ```
+
+## Snapshot Compatibility
+
+Snapshot format V10 adds server access profiles and ring policies. Snapshot V1
+through V9 documents remain importable; entries from formats without those
+fields make no new access or enforcement declaration. An older snapshot version
+that carries V10 access or policy fields is rejected so version mismatch cannot
+silently discard policy data. Import validates the complete resulting
+server/ring graph before its first write.
 
 ## Skill Packages
 

--- a/internal/clients/adapter.go
+++ b/internal/clients/adapter.go
@@ -97,6 +97,10 @@ type SyncResult struct {
 	Added []string
 	// Updated are names managed by Madari whose values changed.
 	Updated []string
+	// PolicyUpdated are updated names whose declared access policy differs
+	// from the target's materialized policy. It is a sorted subset of Updated;
+	// adapters that do not compile access policy leave it empty.
+	PolicyUpdated []string
 	// Removed are previously managed names no longer desired.
 	Removed []string
 	// Unchanged are desired names already matching target config values.

--- a/internal/clients/codex/access.go
+++ b/internal/clients/codex/access.go
@@ -1,0 +1,78 @@
+package codex
+
+import (
+	"sort"
+
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+// CompiledAccess is the Codex-native representation of one portable Madari
+// access profile. Presence is part of the contract: nil fields were not
+// declared and must preserve an existing native value during persistent sync,
+// while non-nil empty slices and maps explicitly clear that native override.
+// An empty approval string is the native omission produced by portable
+// "inherit"; non-empty values are Codex's auto, prompt, or approve enums.
+type CompiledAccess struct {
+	EnabledTools    *[]string
+	DisabledTools   *[]string
+	Scopes          *[]string
+	DefaultApproval *string
+	ToolApprovals   *map[string]string
+}
+
+// CompileAccess maps Madari's portable access vocabulary into Codex-native
+// values without mutating the registry profile. Registry validation guarantees
+// the input approval values belong to the portable V1 vocabulary.
+func CompileAccess(access *registry.AccessProfile) CompiledAccess {
+	if access == nil {
+		return CompiledAccess{}
+	}
+
+	compiled := CompiledAccess{
+		EnabledTools:  sortedStringSetCopy(access.AllowedTools),
+		DisabledTools: sortedStringSetCopy(access.DeniedTools),
+		Scopes:        sortedStringSetCopy(access.OAuthScopes),
+	}
+	if access.DefaultApproval != nil {
+		value := compileApproval(*access.DefaultApproval)
+		compiled.DefaultApproval = &value
+	}
+	if access.ToolApprovals != nil {
+		values := make(map[string]string, len(*access.ToolApprovals))
+		for tool, approval := range *access.ToolApprovals {
+			values[tool] = compileApproval(approval)
+		}
+		compiled.ToolApprovals = &values
+	}
+	return compiled
+}
+
+func compileApproval(approval registry.ApprovalBehavior) string {
+	switch approval {
+	case registry.ApprovalBehaviorAutomatic:
+		return "auto"
+	case registry.ApprovalBehaviorAlwaysPrompt:
+		return "prompt"
+	case registry.ApprovalBehaviorAlwaysAllow:
+		return "approve"
+	case registry.ApprovalBehaviorInherit:
+		return ""
+	default:
+		// Invalid portable values are rejected by registry validation before a
+		// manifest reaches a client compiler. Keep unknown values fail-closed by
+		// omitting rather than forwarding a raw client-native enum.
+		return ""
+	}
+}
+
+func sortedStringSetCopy(values *[]string) *[]string {
+	if values == nil {
+		return nil
+	}
+	copyOfValues := append([]string(nil), (*values)...)
+	sort.Strings(copyOfValues)
+	if copyOfValues == nil {
+		copyOfValues = []string{}
+	}
+	return &copyOfValues
+}

--- a/internal/clients/codex/access_test.go
+++ b/internal/clients/codex/access_test.go
@@ -1,0 +1,97 @@
+package codex
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+func TestCompileAccessMapsPortableVocabularyAndSortsSets(t *testing.T) {
+	allowed := []string{"tools.write", "tools.read"}
+	denied := []string{"tools.remove", "tools.delete"}
+	scopes := []string{"repo.write", "repo.read"}
+	defaultApproval := registry.ApprovalBehaviorAlwaysPrompt
+	toolApprovals := map[string]registry.ApprovalBehavior{
+		"tools.write": registry.ApprovalBehaviorAlwaysAllow,
+		"tools.read":  registry.ApprovalBehaviorAutomatic,
+	}
+	access := &registry.AccessProfile{
+		AllowedTools:    &allowed,
+		DeniedTools:     &denied,
+		OAuthScopes:     &scopes,
+		DefaultApproval: &defaultApproval,
+		ToolApprovals:   &toolApprovals,
+	}
+
+	compiled := CompileAccess(access)
+	if got, want := *compiled.EnabledTools, []string{"tools.read", "tools.write"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("enabled tools mismatch: got %#v want %#v", got, want)
+	}
+	if got, want := *compiled.DisabledTools, []string{"tools.delete", "tools.remove"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("disabled tools mismatch: got %#v want %#v", got, want)
+	}
+	if got, want := *compiled.Scopes, []string{"repo.read", "repo.write"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("scopes mismatch: got %#v want %#v", got, want)
+	}
+	if compiled.DefaultApproval == nil || *compiled.DefaultApproval != "prompt" {
+		t.Fatalf("default approval mismatch: %#v", compiled.DefaultApproval)
+	}
+	wantApprovals := map[string]string{"tools.read": "auto", "tools.write": "approve"}
+	if compiled.ToolApprovals == nil || !reflect.DeepEqual(*compiled.ToolApprovals, wantApprovals) {
+		t.Fatalf("tool approvals mismatch: got %#v want %#v", compiled.ToolApprovals, wantApprovals)
+	}
+
+	// Compilation must not reorder or alias registry input.
+	if got, want := allowed, []string{"tools.write", "tools.read"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("compiler mutated allowed tools: got %#v want %#v", got, want)
+	}
+	(*compiled.EnabledTools)[0] = "changed"
+	if allowed[0] == "changed" || allowed[1] == "changed" {
+		t.Fatalf("compiled tools alias registry input: %#v", allowed)
+	}
+}
+
+func TestCompileAccessPreservesAbsenceAndExplicitClear(t *testing.T) {
+	if got := CompileAccess(nil); got.EnabledTools != nil || got.DisabledTools != nil || got.Scopes != nil || got.DefaultApproval != nil || got.ToolApprovals != nil {
+		t.Fatalf("nil profile must compile to undeclared fields: %#v", got)
+	}
+
+	emptyTools := []string{}
+	emptyApprovals := map[string]registry.ApprovalBehavior{}
+	inherit := registry.ApprovalBehaviorInherit
+	compiled := CompileAccess(&registry.AccessProfile{
+		AllowedTools:    &emptyTools,
+		DefaultApproval: &inherit,
+		ToolApprovals:   &emptyApprovals,
+	})
+	if compiled.EnabledTools == nil || len(*compiled.EnabledTools) != 0 {
+		t.Fatalf("explicit empty tools must remain a present clear: %#v", compiled.EnabledTools)
+	}
+	if compiled.DisabledTools != nil || compiled.Scopes != nil {
+		t.Fatalf("undeclared fields must remain absent: %#v", compiled)
+	}
+	if compiled.DefaultApproval == nil || *compiled.DefaultApproval != "" {
+		t.Fatalf("inherit must compile to a present native omission: %#v", compiled.DefaultApproval)
+	}
+	if compiled.ToolApprovals == nil || len(*compiled.ToolApprovals) != 0 {
+		t.Fatalf("explicit empty approvals must remain a present clear: %#v", compiled.ToolApprovals)
+	}
+}
+
+func TestCompileAccessMapsPerToolInheritToOmission(t *testing.T) {
+	approvals := map[string]registry.ApprovalBehavior{
+		"tools.inherit": registry.ApprovalBehaviorInherit,
+		"tools.prompt":  registry.ApprovalBehaviorAlwaysPrompt,
+	}
+	compiled := CompileAccess(&registry.AccessProfile{ToolApprovals: &approvals})
+	if compiled.ToolApprovals == nil {
+		t.Fatal("expected declared tool approval table")
+	}
+	if got := (*compiled.ToolApprovals)["tools.inherit"]; got != "" {
+		t.Fatalf("inherit should compile to native omission, got %q", got)
+	}
+	if got := (*compiled.ToolApprovals)["tools.prompt"]; got != "prompt" {
+		t.Fatalf("prompt mapping mismatch: %q", got)
+	}
+}

--- a/internal/clients/codex/native_policy.go
+++ b/internal/clients/codex/native_policy.go
@@ -1,0 +1,468 @@
+package codex
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/ankitvg/madari/internal/clients/syncshared"
+	"github.com/ankitvg/madari/internal/policy"
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+type fidelityIssueKind string
+
+const (
+	fidelityUnknown         fidelityIssueKind = "unknown"
+	fidelityDefaultApproval fidelityIssueKind = "default-approval"
+	fidelityToolApproval    fidelityIssueKind = "tool-approval"
+)
+
+type nativeFidelityIssue struct {
+	Kind fidelityIssueKind
+	Path string
+}
+
+var knownServerFields = map[string]bool{
+	"command": true, "args": true, "env": true, "env_vars": true, "cwd": true,
+	"url": true, "bearer_token_env_var": true, "http_headers": true,
+	"env_http_headers": true, "oauth_resource": true, "enabled": true,
+	"auth": true, "experimental_environment": true,
+	"required": true, "startup_timeout_ms": true, "startup_timeout_sec": true, "tool_timeout_sec": true,
+	"enabled_tools": true, "disabled_tools": true, "scopes": true,
+	"default_tools_approval_mode": true, "tools": true,
+}
+
+func parseNativeAccess(name string, table map[string]any) (CompiledAccess, []nativeFidelityIssue, error) {
+	var access CompiledAccess
+	issues := make([]nativeFidelityIssue, 0)
+
+	for _, field := range []struct {
+		key string
+		set func(*[]string)
+	}{
+		{key: "enabled_tools", set: func(value *[]string) { access.EnabledTools = value }},
+		{key: "disabled_tools", set: func(value *[]string) { access.DisabledTools = value }},
+		{key: "scopes", set: func(value *[]string) { access.Scopes = value }},
+	} {
+		values, present, err := optionalStringSlice(table, field.key)
+		if err != nil {
+			return CompiledAccess{}, nil, fmt.Errorf("parse mcp_servers.%s.%s: %w", name, field.key, err)
+		}
+		if present {
+			copyOfValues := append([]string(nil), values...)
+			field.set(&copyOfValues)
+		}
+	}
+
+	if raw, present := table["default_tools_approval_mode"]; present {
+		value, ok := raw.(string)
+		if !ok {
+			return CompiledAccess{}, nil, fmt.Errorf("parse mcp_servers.%s.default_tools_approval_mode: expected string", name)
+		}
+		access.DefaultApproval = &value
+		if !supportedNativeApproval(value) {
+			issues = append(issues, nativeFidelityIssue{
+				Kind: fidelityDefaultApproval,
+				Path: fmt.Sprintf("mcp_servers.%s.default_tools_approval_mode=%q", name, value),
+			})
+		}
+	}
+
+	if raw, present := table["tools"]; present {
+		tools, ok := raw.(map[string]any)
+		if !ok {
+			return CompiledAccess{}, nil, fmt.Errorf("parse mcp_servers.%s.tools: expected table", name)
+		}
+		approvals := make(map[string]string)
+		toolNames := sortedAnyMapKeys(tools)
+		for _, tool := range toolNames {
+			rawTool := tools[tool]
+			toolTable, ok := rawTool.(map[string]any)
+			if !ok {
+				return CompiledAccess{}, nil, fmt.Errorf("parse mcp_servers.%s.tools.%s: expected table", name, tool)
+			}
+			for _, key := range sortedAnyMapKeys(toolTable) {
+				if key != "approval_mode" {
+					issues = append(issues, nativeFidelityIssue{
+						Kind: fidelityUnknown,
+						Path: fmt.Sprintf("mcp_servers.%s.tools.%s.%s", name, tool, key),
+					})
+				}
+			}
+			if rawApproval, exists := toolTable["approval_mode"]; exists {
+				approval, ok := rawApproval.(string)
+				if !ok {
+					return CompiledAccess{}, nil, fmt.Errorf("parse mcp_servers.%s.tools.%s.approval_mode: expected string", name, tool)
+				}
+				approvals[tool] = approval
+				if !supportedNativeApproval(approval) {
+					issues = append(issues, nativeFidelityIssue{
+						Kind: fidelityToolApproval,
+						Path: fmt.Sprintf("mcp_servers.%s.tools.%s.approval_mode=%q", name, tool, approval),
+					})
+				}
+			}
+		}
+		access.ToolApprovals = &approvals
+	}
+
+	for _, key := range sortedAnyMapKeys(table) {
+		if !knownServerFields[key] {
+			issues = append(issues, nativeFidelityIssue{
+				Kind: fidelityUnknown,
+				Path: fmt.Sprintf("mcp_servers.%s.%s", name, key),
+			})
+		}
+	}
+	if err := validateKnownNativeExtras(name, table); err != nil {
+		return CompiledAccess{}, nil, err
+	}
+	return access, issues, nil
+}
+
+func validateKnownNativeExtras(name string, table map[string]any) error {
+	for key, allowed := range map[string]map[string]bool{
+		"auth": {
+			"oauth":   true,
+			"chatgpt": true,
+		},
+		"experimental_environment": {
+			"local":  true,
+			"remote": true,
+		},
+	} {
+		if raw, ok := table[key]; ok {
+			value, valid := raw.(string)
+			if !valid {
+				return fmt.Errorf("parse mcp_servers.%s.%s: expected string", name, key)
+			}
+			if !allowed[value] {
+				return fmt.Errorf("parse mcp_servers.%s.%s: unsupported value %q", name, key, value)
+			}
+		}
+	}
+	if raw, ok := table["cwd"]; ok {
+		if _, valid := raw.(string); !valid {
+			return fmt.Errorf("parse mcp_servers.%s.cwd: expected string", name)
+		}
+	}
+	if _, _, err := optionalStringMap(table, "env_http_headers"); err != nil {
+		return fmt.Errorf("parse mcp_servers.%s.env_http_headers: %w", name, err)
+	}
+	if _, _, err := optionalBool(table, "required"); err != nil {
+		return fmt.Errorf("parse mcp_servers.%s.required: %w", name, err)
+	}
+	for _, key := range []string{"startup_timeout_ms", "startup_timeout_sec", "tool_timeout_sec"} {
+		if raw, ok := table[key]; ok {
+			switch raw.(type) {
+			case int64, float64:
+			default:
+				return fmt.Errorf("parse mcp_servers.%s.%s: expected number", name, key)
+			}
+		}
+	}
+	return nil
+}
+
+func supportedNativeApproval(value string) bool {
+	switch value {
+	case "auto", "prompt", "writes", "approve":
+		return true
+	default:
+		return false
+	}
+}
+
+func equalDeclaredAccess(existing, desired CompiledAccess) bool {
+	if !equalDeclaredStringSet(existing.EnabledTools, desired.EnabledTools) ||
+		!equalDeclaredStringSet(existing.DisabledTools, desired.DisabledTools) ||
+		!equalDeclaredStringSet(existing.Scopes, desired.Scopes) {
+		return false
+	}
+	if desired.DefaultApproval != nil {
+		if *desired.DefaultApproval == "" {
+			if existing.DefaultApproval != nil {
+				return false
+			}
+		} else if existing.DefaultApproval == nil || *existing.DefaultApproval != *desired.DefaultApproval {
+			return false
+		}
+	}
+	if desired.ToolApprovals != nil {
+		wanted := effectiveToolApprovals(*desired.ToolApprovals)
+		got := map[string]string{}
+		if existing.ToolApprovals != nil {
+			got = effectiveToolApprovals(*existing.ToolApprovals)
+		}
+		if !equalStringMap(got, wanted) {
+			return false
+		}
+	}
+	return true
+}
+
+func equalDeclaredStringSet(existing, desired *[]string) bool {
+	if desired == nil {
+		return true
+	}
+	if len(*desired) == 0 {
+		return existing == nil
+	}
+	if existing == nil || len(*existing) != len(*desired) {
+		return false
+	}
+	got := append([]string(nil), (*existing)...)
+	want := append([]string(nil), (*desired)...)
+	sort.Strings(got)
+	sort.Strings(want)
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func effectiveToolApprovals(values map[string]string) map[string]string {
+	out := make(map[string]string, len(values))
+	for tool, approval := range values {
+		if approval != "" {
+			out[tool] = approval
+		}
+	}
+	return out
+}
+
+func equalStringMap(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for key, value := range a {
+		if b[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func policyUpdatedNames(updated []string, existing, desired map[string]serverConfig) []string {
+	result := make([]string, 0, len(updated))
+	for _, name := range updated {
+		current, currentOK := existing[name]
+		want, desiredOK := desired[name]
+		if currentOK && desiredOK && !equalDeclaredAccess(current.Access, want.Access) {
+			result = append(result, name)
+		}
+	}
+	sort.Strings(result)
+	return result
+}
+
+func mergeServerTable(raw any, desired serverConfig) (map[string]any, error) {
+	table := map[string]any{}
+	if raw != nil {
+		existing, ok := raw.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("expected existing table")
+		}
+		table = cloneAnyMap(existing)
+	}
+	if effectiveServerEnabled(desired.Enabled) {
+		delete(table, "enabled")
+	} else {
+		table["enabled"] = false
+	}
+
+	if desired.URL != "" {
+		deleteKeys(table, "command", "args", "env", "env_vars", "cwd")
+		table["url"] = desired.URL
+		setOrDeleteString(table, "oauth_resource", desired.OAuthResource)
+		setOrDeleteString(table, "bearer_token_env_var", desired.BearerTokenEnvVar)
+		setOrDeleteStringMap(table, "http_headers", desired.HTTPHeaders)
+	} else {
+		deleteKeys(table, "url", "oauth_resource", "bearer_token_env_var", "http_headers", "env_http_headers")
+		table["command"] = desired.Command
+		setOrDeleteStringSlice(table, "args", desired.Args)
+		setOrDeleteStringSlice(table, "env_vars", desired.EnvVars)
+		setOrDeleteStringMap(table, "env", desired.Env)
+	}
+	applyDeclaredAccess(table, desired.Access)
+	return table, nil
+}
+
+func applyDeclaredAccess(table map[string]any, access CompiledAccess) {
+	applyStringSliceField(table, "enabled_tools", access.EnabledTools)
+	applyStringSliceField(table, "disabled_tools", access.DisabledTools)
+	applyStringSliceField(table, "scopes", access.Scopes)
+	if access.DefaultApproval != nil {
+		if *access.DefaultApproval == "" {
+			delete(table, "default_tools_approval_mode")
+		} else {
+			table["default_tools_approval_mode"] = *access.DefaultApproval
+		}
+	}
+	if access.ToolApprovals == nil {
+		return
+	}
+	tools := map[string]any{}
+	if rawTools, ok := table["tools"].(map[string]any); ok {
+		tools = cloneAnyMap(rawTools)
+	}
+	for tool, rawTool := range tools {
+		toolTable, ok := rawTool.(map[string]any)
+		if !ok {
+			continue
+		}
+		copyOfTool := cloneAnyMap(toolTable)
+		delete(copyOfTool, "approval_mode")
+		if len(copyOfTool) == 0 {
+			delete(tools, tool)
+		} else {
+			tools[tool] = copyOfTool
+		}
+	}
+	for tool, approval := range *access.ToolApprovals {
+		if approval == "" {
+			continue
+		}
+		toolTable := map[string]any{}
+		if rawTool, ok := tools[tool].(map[string]any); ok {
+			toolTable = cloneAnyMap(rawTool)
+		}
+		toolTable["approval_mode"] = approval
+		tools[tool] = toolTable
+	}
+	if len(tools) == 0 {
+		delete(table, "tools")
+	} else {
+		table["tools"] = tools
+	}
+}
+
+func applyStringSliceField(table map[string]any, key string, value *[]string) {
+	if value == nil {
+		return
+	}
+	if len(*value) == 0 {
+		delete(table, key)
+		return
+	}
+	table[key] = append([]string(nil), (*value)...)
+}
+
+func preflightAttachedPolicyRings(rings []registry.Ring, manifests []registry.Manifest, state map[string][]string, existing map[string]serverConfig) error {
+	byName := make(map[string]registry.Ring, len(rings))
+	for _, ring := range rings {
+		byName[ring.Name] = ring
+	}
+	for _, name := range syncshared.AttachedRings(state) {
+		ring, ok := byName[name]
+		if !ok {
+			return fmt.Errorf("attached ring %q is missing; restore its definition or detach it before sync so policy requirements cannot be bypassed", name)
+		}
+		if err := preflightPolicyRing(ring, manifests, state, existing); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func preflightPolicyRing(ring registry.Ring, manifests []registry.Manifest, state map[string][]string, existing map[string]serverConfig) error {
+	if err := policy.ValidateRequiredRing(ring, manifests, Target, policy.SurfacePersistent).Err(); err != nil {
+		return err
+	}
+	if !ring.RequiresPolicyEnforcement() {
+		return nil
+	}
+	manifestByName := make(map[string]registry.Manifest, len(manifests))
+	for _, manifest := range manifests {
+		manifestByName[manifest.Name] = manifest
+	}
+	for _, member := range ring.Members {
+		member = strings.TrimSpace(member)
+		server, exists := existing[member]
+		if !exists {
+			continue
+		}
+		if len(state[member]) == 0 {
+			return fmt.Errorf("ring %q requires policy enforcement, but Codex entry %q is unmanaged and cannot satisfy ring ownership; remove or rename the unmanaged native entry, then retry sync or attach", ring.Name, member)
+		}
+		desired := CompileAccess(manifestByName[member].Access)
+		paths := make([]string, 0, len(server.FidelityIssues))
+		for _, issue := range server.FidelityIssues {
+			if issue.Kind == fidelityDefaultApproval && desired.DefaultApproval != nil {
+				continue
+			}
+			if issue.Kind == fidelityToolApproval && desired.ToolApprovals != nil {
+				continue
+			}
+			paths = append(paths, issue.Path)
+		}
+		if len(paths) > 0 {
+			sort.Strings(paths)
+			return fmt.Errorf("ring %q requires policy enforcement, but existing managed Codex entry %q has behavior-affecting native fields Madari cannot prove equivalent: %s; remove or migrate those fields before retrying", ring.Name, member, strings.Join(paths, ", "))
+		}
+	}
+	return nil
+}
+
+func cloneAnyMap(input map[string]any) map[string]any {
+	out := make(map[string]any, len(input))
+	for key, value := range input {
+		switch typed := value.(type) {
+		case map[string]any:
+			out[key] = cloneAnyMap(typed)
+		case []any:
+			out[key] = append([]any(nil), typed...)
+		case []string:
+			out[key] = append([]string(nil), typed...)
+		default:
+			out[key] = value
+		}
+	}
+	return out
+}
+
+func sortedAnyMapKeys(values map[string]any) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func deleteKeys(table map[string]any, keys ...string) {
+	for _, key := range keys {
+		delete(table, key)
+	}
+}
+
+func setOrDeleteString(table map[string]any, key, value string) {
+	if value == "" {
+		delete(table, key)
+	} else {
+		table[key] = value
+	}
+}
+
+func setOrDeleteStringSlice(table map[string]any, key string, values []string) {
+	if len(values) == 0 {
+		delete(table, key)
+	} else {
+		table[key] = append([]string(nil), values...)
+	}
+}
+
+func setOrDeleteStringMap(table map[string]any, key string, values map[string]string) {
+	if len(values) == 0 {
+		delete(table, key)
+		return
+	}
+	copyOfValues := make(map[string]string, len(values))
+	for mapKey, value := range values {
+		copyOfValues[mapKey] = value
+	}
+	table[key] = copyOfValues
+}

--- a/internal/clients/codex/policy_sync_test.go
+++ b/internal/clients/codex/policy_sync_test.go
@@ -1,0 +1,514 @@
+package codex
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/ankitvg/madari/internal/clients/syncshared"
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+func TestSyncCompilesAllCodexAccessFields(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state.json")
+	manifest := newCloudSQLManifest()
+	manifest.Access = fullPolicyAccess()
+
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{ConfigPath: configPath, StatePath: statePath})
+	if err != nil {
+		t.Fatalf("sync policy: %v", err)
+	}
+	if !reflect.DeepEqual(result.Added, []string{"cloud-sql"}) {
+		t.Fatalf("unexpected plan: %#v", result)
+	}
+	table := rawServerTable(t, configPath, "cloud-sql")
+	assertRawStringSlice(t, table, "enabled_tools", []string{"issues.get", "issues.inherit", "issues.list"})
+	assertRawStringSlice(t, table, "disabled_tools", []string{"issues.delete"})
+	assertRawStringSlice(t, table, "scopes", []string{"issues:read", "profile:read"})
+	if table["default_tools_approval_mode"] != "prompt" {
+		t.Fatalf("default approval not compiled: %#v", table)
+	}
+	tools := table["tools"].(map[string]any)
+	if got := tools["issues.get"].(map[string]any)["approval_mode"]; got != "approve" {
+		t.Fatalf("per-tool approval not compiled: %#v", tools)
+	}
+	if got := tools["issues.list"].(map[string]any)["approval_mode"]; got != "auto" {
+		t.Fatalf("automatic approval not compiled: %#v", tools)
+	}
+	if _, exists := tools["issues.inherit"]; exists {
+		t.Fatalf("inherit must omit the native approval override: %#v", tools)
+	}
+}
+
+func TestSyncPreservesLegacyNativeRestrictionsDuringCoreUpdate(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state.json")
+	original := `[mcp_servers.stewreads]
+command = "stewreads-mcp"
+args = ["--old"]
+enabled_tools = ["read"]
+disabled_tools = ["delete"]
+scopes = ["repo:read"]
+default_tools_approval_mode = "writes"
+startup_timeout_ms = 1500
+auth = "chatgpt"
+experimental_environment = "remote"
+future_restriction = "strict"
+
+[mcp_servers.stewreads.tools.read]
+approval_mode = "prompt"
+classification = "sensitive"
+`
+	if err := os.WriteFile(configPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := syncshared.SaveManagedState(statePath, map[string][]string{"stewreads": {syncshared.SourceStandalone}}); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	manifest := newStewreadsManifest()
+	manifest.Args = []string{"--new"}
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{ConfigPath: configPath, StatePath: statePath})
+	if err != nil {
+		t.Fatalf("sync legacy entry: %v", err)
+	}
+	if !reflect.DeepEqual(result.Updated, []string{"stewreads"}) || len(result.PolicyUpdated) != 0 {
+		t.Fatalf("unexpected plan: %#v", result)
+	}
+	table := rawServerTable(t, configPath, "stewreads")
+	assertRawStringSlice(t, table, "enabled_tools", []string{"read"})
+	assertRawStringSlice(t, table, "disabled_tools", []string{"delete"})
+	assertRawStringSlice(t, table, "scopes", []string{"repo:read"})
+	if table["default_tools_approval_mode"] != "writes" || table["future_restriction"] != "strict" {
+		t.Fatalf("legacy native fields were stripped: %#v", table)
+	}
+	if table["startup_timeout_ms"] != int64(1500) {
+		t.Fatalf("documented millisecond timeout alias was stripped: %#v", table)
+	}
+	if table["auth"] != "chatgpt" || table["experimental_environment"] != "remote" {
+		t.Fatalf("documented native fields were stripped: %#v", table)
+	}
+	tool := table["tools"].(map[string]any)["read"].(map[string]any)
+	if tool["approval_mode"] != "prompt" || tool["classification"] != "sensitive" {
+		t.Fatalf("legacy nested fields were stripped: %#v", tool)
+	}
+}
+
+func TestSyncExplicitAccessClearsRemoveNativeOverrides(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state.json")
+	original := `[mcp_servers.cloud-sql]
+url = "https://sqladmin.googleapis.com/mcp"
+oauth_resource = "https://sqladmin.googleapis.com/"
+bearer_token_env_var = "CLOUDSQL_MCP_TOKEN"
+enabled_tools = ["read"]
+disabled_tools = ["delete"]
+scopes = ["repo:read"]
+default_tools_approval_mode = "prompt"
+
+[mcp_servers.cloud-sql.tools.read]
+approval_mode = "approve"
+`
+	if err := os.WriteFile(configPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := syncshared.SaveManagedState(statePath, map[string][]string{"cloud-sql": {syncshared.SourceStandalone}}); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	empty := []string{}
+	inherit := registry.ApprovalBehaviorInherit
+	emptyTools := map[string]registry.ApprovalBehavior{}
+	manifest := newCloudSQLManifest()
+	manifest.Access = &registry.AccessProfile{
+		AllowedTools: &empty, DeniedTools: &empty, OAuthScopes: &empty,
+		DefaultApproval: &inherit, ToolApprovals: &emptyTools,
+	}
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{ConfigPath: configPath, StatePath: statePath})
+	if err != nil {
+		t.Fatalf("sync explicit clears: %v", err)
+	}
+	if !reflect.DeepEqual(result.PolicyUpdated, []string{"cloud-sql"}) {
+		t.Fatalf("expected policy drift classification: %#v", result)
+	}
+	table := rawServerTable(t, configPath, "cloud-sql")
+	for _, key := range []string{"enabled_tools", "disabled_tools", "scopes", "default_tools_approval_mode", "tools"} {
+		if _, exists := table[key]; exists {
+			t.Fatalf("explicit clear left %s behind: %#v", key, table)
+		}
+	}
+}
+
+func TestSyncDeclaredToolApprovalsPreserveUnknownNestedDataAdvisory(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state.json")
+	original := `[mcp_servers.stewreads]
+command = "stewreads-mcp"
+
+[mcp_servers.stewreads.tools.read]
+approval_mode = "prompt"
+classification = "sensitive"
+
+[mcp_servers.stewreads.tools.stale]
+approval_mode = "approve"
+`
+	if err := os.WriteFile(configPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := syncshared.SaveManagedState(statePath, map[string][]string{"stewreads": {syncshared.SourceStandalone}}); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	approval := map[string]registry.ApprovalBehavior{
+		"read": registry.ApprovalBehaviorAlwaysAllow,
+		"new":  registry.ApprovalBehaviorAlwaysPrompt,
+	}
+	manifest := newStewreadsManifest()
+	manifest.Access = &registry.AccessProfile{ToolApprovals: &approval}
+	if _, err := Sync([]registry.Manifest{manifest}, SyncOptions{ConfigPath: configPath, StatePath: statePath}); err != nil {
+		t.Fatalf("sync approvals: %v", err)
+	}
+	tools := rawServerTable(t, configPath, "stewreads")["tools"].(map[string]any)
+	read := tools["read"].(map[string]any)
+	if read["approval_mode"] != "approve" || read["classification"] != "sensitive" {
+		t.Fatalf("declared approval or unknown nested data lost: %#v", read)
+	}
+	if _, exists := tools["stale"]; exists {
+		t.Fatalf("stale approval was not cleared: %#v", tools)
+	}
+	if tools["new"].(map[string]any)["approval_mode"] != "prompt" {
+		t.Fatalf("new approval missing: %#v", tools)
+	}
+}
+
+func TestRequiredSyncUnknownNativeFieldFailsBeforeMutation(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state.json")
+	command := currentTestExecutable(t)
+	originalConfig := "[mcp_servers.docs]\ncommand = " + tomlQuoted(command) + "\nfuture_policy = \"strict\"\n"
+	if err := os.WriteFile(configPath, []byte(originalConfig), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := syncshared.SaveManagedState(statePath, map[string][]string{"docs": {syncshared.RingSource("restricted")}}); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	originalState, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	allowed := []string{"read"}
+	manifest := registry.Manifest{Name: "docs", Command: command, Enabled: true, Clients: []string{Target}, Access: &registry.AccessProfile{AllowedTools: &allowed}}
+	ring := registry.Ring{Name: "restricted", Members: []string{"docs"}, Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired}}
+	_, err = Sync([]registry.Manifest{manifest}, SyncOptions{ConfigPath: configPath, StatePath: statePath, Rings: []registry.Ring{ring}})
+	if err == nil || !strings.Contains(err.Error(), "future_policy") || !strings.Contains(err.Error(), "behavior-affecting native fields") {
+		t.Fatalf("expected native fidelity refusal, got: %v", err)
+	}
+	assertFileEquals(t, configPath, []byte(originalConfig))
+	assertFileEquals(t, statePath, originalState)
+	backups, globErr := filepath.Glob(configPath + ".bak.*")
+	if globErr != nil || len(backups) != 0 {
+		t.Fatalf("preflight created backups: %#v err=%v", backups, globErr)
+	}
+}
+
+func TestRequiredSyncRejectsNewMemberCollidingWithUnmanagedEntry(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state.json")
+	command := currentTestExecutable(t)
+	config := "[mcp_servers.docs]\ncommand = " + tomlQuoted(command) + "\nenabled_tools = [\"read\"]\n"
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := syncshared.SaveManagedState(statePath, map[string][]string{"existing": {syncshared.RingSource("restricted")}}); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	allowed := []string{"read"}
+	manifests := []registry.Manifest{
+		{Name: "existing", Command: command, Enabled: true, Clients: []string{Target}, Access: &registry.AccessProfile{AllowedTools: &allowed}},
+		{Name: "docs", Command: command, Enabled: true, Clients: []string{Target}, Access: &registry.AccessProfile{AllowedTools: &allowed}},
+	}
+	ring := registry.Ring{Name: "restricted", Members: []string{"existing", "docs"}, Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired}}
+	_, err := Sync(manifests, SyncOptions{ConfigPath: configPath, StatePath: statePath, Rings: []registry.Ring{ring}, DryRun: true})
+	if err == nil || !strings.Contains(err.Error(), "unmanaged") || !strings.Contains(err.Error(), "docs") {
+		t.Fatalf("expected unmanaged required-member refusal, got: %v", err)
+	}
+}
+
+func TestRequiredSyncBlocksUnknownNestedAndVersionSkewApproval(t *testing.T) {
+	command := currentTestExecutable(t)
+	cases := []struct {
+		name       string
+		nativeTOML string
+		want       string
+	}{
+		{
+			name: "unknown nested tool field",
+			nativeTOML: "\n[mcp_servers.docs.tools.read]\n" +
+				"approval_mode = \"prompt\"\nclassification = \"sensitive\"\n",
+			want: "classification",
+		},
+		{
+			name:       "version skew approval",
+			nativeTOML: "\ndefault_tools_approval_mode = \"future\"\n",
+			want:       "future",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			configPath := filepath.Join(tmp, "config.toml")
+			statePath := filepath.Join(tmp, "state.json")
+			payload := "[mcp_servers.docs]\ncommand = " + tomlQuoted(command) + tc.nativeTOML
+			if err := os.WriteFile(configPath, []byte(payload), 0o600); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+			if err := syncshared.SaveManagedState(statePath, map[string][]string{"docs": {syncshared.RingSource("restricted")}}); err != nil {
+				t.Fatalf("write state: %v", err)
+			}
+			allowed := []string{"read"}
+			manifest := registry.Manifest{Name: "docs", Command: command, Enabled: true, Clients: []string{Target}, Access: &registry.AccessProfile{AllowedTools: &allowed}}
+			ring := registry.Ring{Name: "restricted", Members: []string{"docs"}, Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired}}
+			_, err := Sync([]registry.Manifest{manifest}, SyncOptions{ConfigPath: configPath, StatePath: statePath, Rings: []registry.Ring{ring}, DryRun: true})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected fidelity refusal containing %q, got: %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestRequiredSyncAcceptsDocumentedNativeCompatibilityFields(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state.json")
+	command := currentTestExecutable(t)
+	payload := "[mcp_servers.docs]\ncommand = " + tomlQuoted(command) + "\nenabled = false\nenabled_tools = [\"read\"]\ndefault_tools_approval_mode = \"writes\"\nstartup_timeout_ms = 1500\nauth = \"chatgpt\"\nexperimental_environment = \"remote\"\n\n[mcp_servers.docs.tools.read]\napproval_mode = \"writes\"\n"
+	if err := os.WriteFile(configPath, []byte(payload), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := syncshared.SaveManagedState(statePath, map[string][]string{"docs": {syncshared.RingSource("restricted")}}); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	allowed := []string{"read"}
+	manifest := registry.Manifest{Name: "docs", Command: command, Enabled: true, Clients: []string{Target}, Access: &registry.AccessProfile{AllowedTools: &allowed}}
+	ring := registry.Ring{Name: "restricted", Members: []string{"docs"}, Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired}}
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{ConfigPath: configPath, StatePath: statePath, Rings: []registry.Ring{ring}})
+	if err != nil {
+		t.Fatalf("sync documented native compatibility fields: %v", err)
+	}
+	if !reflect.DeepEqual(result.Updated, []string{"docs"}) {
+		t.Fatalf("native disabled state was not reconciled: %#v", result)
+	}
+	table := rawServerTable(t, configPath, "docs")
+	if _, exists := table["enabled"]; exists {
+		t.Fatalf("native disabled state survived reconciliation: %#v", table)
+	}
+	if table["default_tools_approval_mode"] != "writes" || table["startup_timeout_ms"] != int64(1500) {
+		t.Fatalf("documented native fields were not preserved: %#v", table)
+	}
+	if table["auth"] != "chatgpt" || table["experimental_environment"] != "remote" {
+		t.Fatalf("documented native compatibility fields were not preserved: %#v", table)
+	}
+	if table["tools"].(map[string]any)["read"].(map[string]any)["approval_mode"] != "writes" {
+		t.Fatalf("documented per-tool writes approval was not preserved: %#v", table)
+	}
+}
+
+func TestSyncRejectsUnsupportedDocumentedNativeValuesWithoutMutation(t *testing.T) {
+	command := currentTestExecutable(t)
+	for _, tc := range []struct {
+		name  string
+		field string
+		value string
+	}{
+		{name: "auth", field: "auth", value: "future"},
+		{name: "experimental environment", field: "experimental_environment", value: "cloud"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			configPath := filepath.Join(tmp, "config.toml")
+			statePath := filepath.Join(tmp, "state.json")
+			original := []byte("[mcp_servers.docs]\ncommand = " + tomlQuoted(command) + "\n" + tc.field + " = " + tomlQuoted(tc.value) + "\n")
+			if err := os.WriteFile(configPath, original, 0o600); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+
+			_, err := Sync([]registry.Manifest{{Name: "docs", Command: command, Enabled: true, Clients: []string{Target}}}, SyncOptions{ConfigPath: configPath, StatePath: statePath})
+			if err == nil || !strings.Contains(err.Error(), tc.field) || !strings.Contains(err.Error(), tc.value) {
+				t.Fatalf("expected unsupported native value error, got: %v", err)
+			}
+			assertFileEquals(t, configPath, original)
+			if _, statErr := os.Stat(statePath); !errors.Is(statErr, os.ErrNotExist) {
+				t.Fatalf("parse failure wrote state: %v", statErr)
+			}
+		})
+	}
+}
+
+func TestSyncRejectsMalformedNativePolicyTypesWithoutMutation(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state.json")
+	original := []byte("[mcp_servers.stewreads]\ncommand = \"stewreads-mcp\"\nenabled_tools = [1]\n")
+	if err := os.WriteFile(configPath, original, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	_, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{ConfigPath: configPath, StatePath: statePath})
+	if err == nil || !strings.Contains(err.Error(), "enabled_tools") {
+		t.Fatalf("expected native policy parse failure, got: %v", err)
+	}
+	assertFileEquals(t, configPath, original)
+	if _, statErr := os.Stat(statePath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("parse failure wrote state: %v", statErr)
+	}
+}
+
+func TestRequiredAttachRejectsInvalidInMemoryPortableApproval(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state.json")
+	allowed := []string{"read"}
+	invalid := registry.ApprovalBehavior("prompt")
+	manifest := registry.Manifest{
+		Name: "docs", Command: currentTestExecutable(t), Enabled: true, Clients: []string{Target},
+		Access: &registry.AccessProfile{AllowedTools: &allowed, DefaultApproval: &invalid},
+	}
+	ring := registry.Ring{Name: "restricted", Members: []string{"docs"}, Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired}}
+	_, err := AttachRing(ring, []registry.Manifest{manifest}, SyncOptions{ConfigPath: configPath, StatePath: statePath, Rings: []registry.Ring{ring}})
+	if err == nil || !strings.Contains(err.Error(), "invalid default_approval") {
+		t.Fatalf("expected invalid portable approval refusal, got: %v", err)
+	}
+	for _, path := range []string{configPath, statePath} {
+		if _, statErr := os.Stat(path); !errors.Is(statErr, os.ErrNotExist) {
+			t.Fatalf("invalid approval mutated %s: %v", path, statErr)
+		}
+	}
+}
+
+func TestRequiredAttachRejectsUnsupportedSSEBeforeMutation(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state.json")
+	manifest := newCloudSQLManifest()
+	manifest.Transport = registry.TransportSSE
+	allowed := []string{"read"}
+	manifest.Access = &registry.AccessProfile{AllowedTools: &allowed}
+	ring := registry.Ring{Name: "restricted", Members: []string{manifest.Name}, Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired}}
+	_, err := AttachRing(ring, []registry.Manifest{manifest}, SyncOptions{ConfigPath: configPath, StatePath: statePath, Rings: []registry.Ring{ring}})
+	if err == nil || !strings.Contains(err.Error(), "uses sse transport") {
+		t.Fatalf("expected SSE refusal, got: %v", err)
+	}
+	for _, path := range []string{configPath, statePath} {
+		if _, statErr := os.Stat(path); !errors.Is(statErr, os.ErrNotExist) {
+			t.Fatalf("required preflight mutated %s: %v", path, statErr)
+		}
+	}
+}
+
+func TestSyncPolicyOnlyDriftIsClassifiedAndSetOrderIsSemantic(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state.json")
+	command := currentTestExecutable(t)
+	original := "[mcp_servers.docs]\ncommand = " + tomlQuoted(command) + "\nenabled_tools = [\"write\", \"read\"]\n"
+	if err := os.WriteFile(configPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := syncshared.SaveManagedState(statePath, map[string][]string{"docs": {syncshared.SourceStandalone}}); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	matching := []string{"read", "write"}
+	manifest := registry.Manifest{Name: "docs", Command: command, Enabled: true, Clients: []string{Target}, Access: &registry.AccessProfile{AllowedTools: &matching}}
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{ConfigPath: configPath, StatePath: statePath, DryRun: true})
+	if err != nil {
+		t.Fatalf("dry-run matching set: %v", err)
+	}
+	if !reflect.DeepEqual(result.Unchanged, []string{"docs"}) || len(result.PolicyUpdated) != 0 {
+		t.Fatalf("array ordering must not create drift: %#v", result)
+	}
+
+	changed := []string{"read"}
+	manifest.Access.AllowedTools = &changed
+	result, err = Sync([]registry.Manifest{manifest}, SyncOptions{ConfigPath: configPath, StatePath: statePath, DryRun: true})
+	if err != nil {
+		t.Fatalf("dry-run policy drift: %v", err)
+	}
+	if !reflect.DeepEqual(result.Updated, []string{"docs"}) || !reflect.DeepEqual(result.PolicyUpdated, []string{"docs"}) {
+		t.Fatalf("policy-only drift not classified: %#v", result)
+	}
+}
+
+func fullPolicyAccess() *registry.AccessProfile {
+	allowed := []string{"issues.list", "issues.inherit", "issues.get"}
+	denied := []string{"issues.delete"}
+	scopes := []string{"profile:read", "issues:read"}
+	defaultApproval := registry.ApprovalBehaviorAlwaysPrompt
+	toolApprovals := map[string]registry.ApprovalBehavior{
+		"issues.get":     registry.ApprovalBehaviorAlwaysAllow,
+		"issues.list":    registry.ApprovalBehaviorAutomatic,
+		"issues.inherit": registry.ApprovalBehaviorInherit,
+	}
+	return &registry.AccessProfile{
+		AllowedTools: &allowed, DeniedTools: &denied, OAuthScopes: &scopes,
+		DefaultApproval: &defaultApproval, ToolApprovals: &toolApprovals,
+	}
+}
+
+func rawServerTable(t *testing.T, path, name string) map[string]any {
+	t.Helper()
+	root := readRoot(t, path)
+	servers, ok := root["mcp_servers"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing mcp_servers table: %#v", root)
+	}
+	table, ok := servers[name].(map[string]any)
+	if !ok {
+		t.Fatalf("missing server %s: %#v", name, servers)
+	}
+	return table
+}
+
+func assertRawStringSlice(t *testing.T, table map[string]any, key string, want []string) {
+	t.Helper()
+	raw, ok := table[key].([]any)
+	if !ok {
+		t.Fatalf("%s is not an array: %#v", key, table[key])
+	}
+	got := make([]string, len(raw))
+	for i, value := range raw {
+		got[i] = value.(string)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("%s mismatch: got %#v want %#v", key, got, want)
+	}
+}
+
+func currentTestExecutable(t *testing.T) string {
+	t.Helper()
+	path, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve executable: %v", err)
+	}
+	return path
+}
+
+func tomlQuoted(value string) string {
+	return `"` + strings.ReplaceAll(strings.ReplaceAll(value, `\`, `\\`), `"`, `\"`) + `"`
+}
+
+func assertFileEquals(t *testing.T, path string, want []byte) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("file %s changed\nwant:\n%s\ngot:\n%s", path, want, got)
+	}
+}

--- a/internal/clients/codex/sync.go
+++ b/internal/clients/codex/sync.go
@@ -31,6 +31,9 @@ type SyncResult = clients.SyncResult
 // config file. Codex's native `codex mcp add` command writes global MCP
 // servers to $CODEX_HOME/config.toml, defaulting to ~/.codex/config.toml.
 func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
+	if err := validateInputManifests(manifests); err != nil {
+		return SyncResult{}, err
+	}
 	if err := validateScope(opts.Scope); err != nil {
 		return SyncResult{}, err
 	}
@@ -51,11 +54,15 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 	if err != nil {
 		return SyncResult{}, err
 	}
+	if err := preflightAttachedPolicyRings(opts.Rings, manifests, managedState, existingServers); err != nil {
+		return SyncResult{}, err
+	}
 
 	result, nextState, writeSet, err := syncshared.PlanSync(existingServers, managedState, entriesForTarget(manifests), opts.Rings, equalServer, ErrConflict)
 	if err != nil {
 		return SyncResult{}, err
 	}
+	result.PolicyUpdated = policyUpdatedNames(result.Updated, existingServers, writeSet)
 	result.ConfigPath = configPath
 	result.DryRun = opts.DryRun
 
@@ -73,6 +80,9 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 // eligible ones into Codex config. Attaching onto any pre-existing unmanaged
 // entry, equal values included, refuses with ErrConflict.
 func AttachRing(ring registry.Ring, manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
+	if err := validateInputManifests(manifests); err != nil {
+		return SyncResult{}, err
+	}
 	if err := validateScope(opts.Scope); err != nil {
 		return SyncResult{}, err
 	}
@@ -93,11 +103,15 @@ func AttachRing(ring registry.Ring, manifests []registry.Manifest, opts SyncOpti
 	if err != nil {
 		return SyncResult{}, err
 	}
+	if err := preflightPolicyRing(ring, manifests, managedState, existingServers); err != nil {
+		return SyncResult{}, err
+	}
 
 	result, nextState, writeSet, err := syncshared.PlanAttach(existingServers, managedState, ring.Name, ring.Members, entriesForTarget(manifests), opts.Rings, equalServer, ErrConflict)
 	if err != nil {
 		return SyncResult{}, err
 	}
+	result.PolicyUpdated = policyUpdatedNames(result.Updated, existingServers, writeSet)
 	result.ConfigPath = configPath
 	result.DryRun = opts.DryRun
 
@@ -165,7 +179,11 @@ func applyPlan(
 		delete(mutated, name)
 	}
 	for name, server := range writeSet {
-		mutated[name] = server
+		merged, err := mergeServerTable(rawServers[name], server)
+		if err != nil {
+			return fmt.Errorf("merge Codex server %q: %w", name, err)
+		}
+		mutated[name] = merged
 	}
 
 	updatedRoot := make(map[string]any, len(root)+1)
@@ -234,6 +252,18 @@ func validateScope(scope string) error {
 	}
 }
 
+func validateInputManifests(manifests []registry.Manifest) error {
+	for _, manifest := range manifests {
+		if !manifest.HasClient(Target) {
+			continue
+		}
+		if err := manifest.Validate(); err != nil {
+			return fmt.Errorf("validate manifest %q before Codex policy compilation: %w", manifest.Name, err)
+		}
+	}
+	return nil
+}
+
 func entriesForTarget(manifests []registry.Manifest) map[string]syncshared.Entry[serverConfig] {
 	entries := map[string]syncshared.Entry[serverConfig]{}
 	for _, manifest := range manifests {
@@ -268,6 +298,7 @@ func materializeServer(manifest registry.Manifest) serverConfig {
 			URL:               manifest.URL,
 			OAuthResource:     manifest.OAuthResource,
 			BearerTokenEnvVar: manifest.BearerTokenEnvVar,
+			Access:            CompileAccess(manifest.Access),
 		}
 		if len(manifest.Headers) > 0 {
 			entry.HTTPHeaders = make(map[string]string, len(manifest.Headers))
@@ -280,6 +311,7 @@ func materializeServer(manifest registry.Manifest) serverConfig {
 
 	entry := serverConfig{
 		Command: manifest.Command,
+		Access:  CompileAccess(manifest.Access),
 		EnvVars: runtimeEnvKeys(
 			manifest.RequiredEnv.Keys,
 			manifest.SecretEnv.Keys,
@@ -325,6 +357,9 @@ func runtimeEnvKeys(keyGroups ...[]string) []string {
 }
 
 func equalServer(a, b serverConfig) bool {
+	if effectiveServerEnabled(a.Enabled) != effectiveServerEnabled(b.Enabled) {
+		return false
+	}
 	if a.Command != b.Command {
 		return false
 	}
@@ -345,9 +380,6 @@ func equalServer(a, b serverConfig) bool {
 			return false
 		}
 	}
-	if effectiveEnabled(a) != effectiveEnabled(b) {
-		return false
-	}
 	if !equalStringSlices(a.Args, b.Args) {
 		return false
 	}
@@ -359,11 +391,14 @@ func equalServer(a, b serverConfig) bool {
 			return false
 		}
 	}
-	return equalStringSlices(a.EnvVars, b.EnvVars)
+	if !equalStringSlices(a.EnvVars, b.EnvVars) {
+		return false
+	}
+	return equalDeclaredAccess(a.Access, b.Access)
 }
 
-func effectiveEnabled(server serverConfig) bool {
-	return server.Enabled == nil || *server.Enabled
+func effectiveServerEnabled(enabled *bool) bool {
+	return enabled == nil || *enabled
 }
 
 func equalStringSlices(a, b []string) bool {
@@ -487,6 +522,12 @@ func parseServer(name string, raw any) (serverConfig, error) {
 	} else if ok {
 		entry.EnvVars = envVars
 	}
+	access, fidelityIssues, err := parseNativeAccess(name, table)
+	if err != nil {
+		return serverConfig{}, err
+	}
+	entry.Access = access
+	entry.FidelityIssues = fidelityIssues
 	return entry, nil
 }
 
@@ -553,13 +594,15 @@ func optionalStringMap(table map[string]any, key string) (map[string]string, boo
 }
 
 type serverConfig struct {
-	Command           string            `toml:"command,omitempty"`
-	URL               string            `toml:"url,omitempty"`
-	OAuthResource     string            `toml:"oauth_resource,omitempty"`
-	BearerTokenEnvVar string            `toml:"bearer_token_env_var,omitempty"`
-	Enabled           *bool             `toml:"enabled,omitempty"`
-	Args              []string          `toml:"args,omitempty"`
-	EnvVars           []string          `toml:"env_vars,omitempty"`
-	Env               map[string]string `toml:"env,omitempty"`
-	HTTPHeaders       map[string]string `toml:"http_headers,omitempty"`
+	Command           string                `toml:"command,omitempty"`
+	URL               string                `toml:"url,omitempty"`
+	OAuthResource     string                `toml:"oauth_resource,omitempty"`
+	BearerTokenEnvVar string                `toml:"bearer_token_env_var,omitempty"`
+	Enabled           *bool                 `toml:"enabled,omitempty"`
+	Args              []string              `toml:"args,omitempty"`
+	EnvVars           []string              `toml:"env_vars,omitempty"`
+	Env               map[string]string     `toml:"env,omitempty"`
+	HTTPHeaders       map[string]string     `toml:"http_headers,omitempty"`
+	Access            CompiledAccess        `toml:"-"`
+	FidelityIssues    []nativeFidelityIssue `toml:"-"`
 }

--- a/internal/clients/codex/sync_test.go
+++ b/internal/clients/codex/sync_test.go
@@ -211,7 +211,7 @@ STEWREADS_CONFIG_PATH = "~/.config/stewreads/config.toml"
 	}
 }
 
-func TestSyncConflictsOnDisabledUnmanagedEntry(t *testing.T) {
+func TestSyncRefusesDisabledUnmanagedEntry(t *testing.T) {
 	tmp := t.TempDir()
 	configPath := filepath.Join(tmp, "config.toml")
 	statePath := filepath.Join(tmp, "state", "codex-managed.json")
@@ -231,12 +231,15 @@ STEWREADS_CONFIG_PATH = "~/.config/stewreads/config.toml"
 		StatePath:  statePath,
 		DryRun:     true,
 	})
-	if !errors.Is(err, clients.ErrConflict) {
-		t.Fatalf("expected disabled unmanaged entry to conflict, got: %v", err)
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected disabled unmanaged entry conflict, got: %v", err)
+	}
+	if _, statErr := os.Stat(statePath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("unmanaged conflict wrote state: %v", statErr)
 	}
 }
 
-func TestSyncUpdatesOwnedDisabledEntry(t *testing.T) {
+func TestSyncReenablesOwnedDisabledEntry(t *testing.T) {
 	tmp := t.TempDir()
 	configPath := filepath.Join(tmp, "config.toml")
 	statePath := filepath.Join(tmp, "state", "codex-managed.json")
@@ -259,13 +262,15 @@ STEWREADS_CONFIG_PATH = "~/.config/stewreads/config.toml"
 	result, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
 		ConfigPath: configPath,
 		StatePath:  statePath,
-		DryRun:     true,
 	})
 	if err != nil {
 		t.Fatalf("sync dry-run failed: %v", err)
 	}
 	if !reflect.DeepEqual(result.Updated, []string{"stewreads"}) {
-		t.Fatalf("expected owned disabled entry to be reported updated, got: %+v", result)
+		t.Fatalf("expected registry-enabled server to reconcile native enabled=false, got: %+v", result)
+	}
+	if enabled := readServers(t, configPath)["stewreads"].Enabled; enabled != nil {
+		t.Fatalf("reconciled entry should use Codex's enabled-by-default state: %#v", enabled)
 	}
 }
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -47,6 +47,7 @@ type ServerReport struct {
 	URL               string
 	OAuthResource     string
 	BearerTokenEnvVar string
+	Access            *registry.AccessProfile
 	Status            Status
 	Issues            []Issue
 }
@@ -385,6 +386,7 @@ func inspectServer(manifest registry.Manifest, envLookup func(string) string, ta
 		URL:               manifest.URL,
 		OAuthResource:     manifest.OAuthResource,
 		BearerTokenEnvVar: manifest.BearerTokenEnvVar,
+		Access:            manifest.Access,
 		Status:            StatusSkipped,
 		Issues:            []Issue{},
 	}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -117,6 +117,9 @@ type DriftReport struct {
 	// Stale are managed entries whose materialized values differ from the
 	// manifest.
 	Stale []string
+	// PolicyStale is the subset of Stale whose declared access policy differs
+	// from the target's materialized policy.
+	PolicyStale []string
 	// Missing are managed entries absent from the client config.
 	Missing []string
 	// Orphaned are managed entries no longer desired; the next sync removes
@@ -315,13 +318,14 @@ func checkDrift(manifests []registry.Manifest, targets []DriftTarget, rings []re
 
 		dr.ConfigPath = plan.ConfigPath
 		dr.Stale = append([]string(nil), plan.Updated...)
+		dr.PolicyStale = append([]string(nil), plan.PolicyUpdated...)
 		for _, name := range plan.Added {
 			if _, managed := state[name]; managed {
 				dr.Missing = append(dr.Missing, name)
 			}
 		}
 		dr.Orphaned = append([]string(nil), plan.Removed...)
-		if len(dr.Stale)+len(dr.Missing)+len(dr.Orphaned) > 0 {
+		if len(dr.Stale)+len(dr.PolicyStale)+len(dr.Missing)+len(dr.Orphaned) > 0 {
 			dr.Status = StatusWarning
 		}
 		reports = append(reports, dr)

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ankitvg/madari/internal/clients"
 	"github.com/ankitvg/madari/internal/clients/codex"
 	"github.com/ankitvg/madari/internal/clients/syncshared"
+	"github.com/ankitvg/madari/internal/policy"
 	"github.com/ankitvg/madari/internal/registry"
 	"github.com/pelletier/go-toml/v2"
 )
@@ -283,6 +284,18 @@ func checkDrift(manifests []registry.Manifest, targets []DriftTarget, rings []re
 			continue
 		}
 		if len(state) == 0 {
+			continue
+		}
+		if err := policy.ValidateAttachedRequiredRings(
+			rings,
+			syncshared.AttachedRings(state),
+			manifests,
+			target.Adapter.Target(),
+			policy.SurfacePersistent,
+		); err != nil {
+			dr.Status = StatusError
+			dr.Issue = fmt.Sprintf("policy preflight: %v", err)
+			reports = append(reports, dr)
 			continue
 		}
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -106,6 +106,10 @@ type DriftTarget struct {
 	StatePath string
 	// ConfigPath overrides the adapter's default config path when non-empty.
 	ConfigPath string
+	// SkillAttachedRings carries ring ownership found in the target's skill
+	// attachment state. A skill-only attachment must participate in policy
+	// preflight even when the server managed state is empty.
+	SkillAttachedRings []string
 }
 
 // DriftReport diffs materialized client entries against current manifests
@@ -286,12 +290,13 @@ func checkDrift(manifests []registry.Manifest, targets []DriftTarget, rings []re
 			reports = append(reports, dr)
 			continue
 		}
-		if len(state) == 0 {
+		attachedRings := append(syncshared.AttachedRings(state), target.SkillAttachedRings...)
+		if len(state) == 0 && len(attachedRings) == 0 {
 			continue
 		}
 		if err := policy.ValidateAttachedRequiredRings(
 			rings,
-			syncshared.AttachedRings(state),
+			attachedRings,
 			manifests,
 			target.Adapter.Target(),
 			policy.SurfacePersistent,
@@ -299,6 +304,9 @@ func checkDrift(manifests []registry.Manifest, targets []DriftTarget, rings []re
 			dr.Status = StatusError
 			dr.Issue = fmt.Sprintf("policy preflight: %v", err)
 			reports = append(reports, dr)
+			continue
+		}
+		if len(state) == 0 {
 			continue
 		}
 

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -777,6 +777,37 @@ func TestRunDriftReportsPolicyStaleAsSubset(t *testing.T) {
 	}
 }
 
+func TestRunDriftPreflightsSkillAttachedRingWithoutServerState(t *testing.T) {
+	tmp := t.TempDir()
+	store := registry.NewStore(filepath.Join(tmp, "servers"))
+	commandPath := writeTestExecutable(t, tmp, "policy-mcp")
+	if err := store.Save(registry.Manifest{
+		Name: "docs", Command: commandPath, Enabled: true, Clients: []string{"codex"},
+	}); err != nil {
+		t.Fatalf("save unbounded policy manifest: %v", err)
+	}
+	ring := registry.Ring{
+		Name: "workflow", Members: []string{"docs"}, Skills: []string{"release"},
+		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
+	}
+	adapter := testAdapter{target: "codex"}
+	report, err := Run(store, Options{
+		Rings: []registry.Ring{ring},
+		DriftTargets: []DriftTarget{{
+			Adapter: adapter, StatePath: filepath.Join(tmp, "missing-server-state.json"),
+			SkillAttachedRings: []string{"workflow"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("doctor run failed: %v", err)
+	}
+	if len(report.Drift) != 1 || report.Drift[0].Status != StatusError ||
+		!strings.Contains(report.Drift[0].Issue, "policy preflight") ||
+		!strings.Contains(report.Drift[0].Issue, "non-empty [access].allowed_tools allowlist") {
+		t.Fatalf("skill-only policy attachment bypassed drift preflight: %#v", report.Drift)
+	}
+}
+
 func TestRunDriftUsesCodexDeclaredPolicyComparator(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("unix fixture mode bits are used in this test")

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -3,13 +3,16 @@ package doctor
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/ankitvg/madari/internal/clients"
 	"github.com/ankitvg/madari/internal/clients/claudecode"
+	"github.com/ankitvg/madari/internal/clients/codex"
 	"github.com/ankitvg/madari/internal/clients/gemini"
+	"github.com/ankitvg/madari/internal/clients/syncshared"
 	"github.com/ankitvg/madari/internal/registry"
 )
 
@@ -18,13 +21,14 @@ type testAdapter struct {
 	target         string
 	configPath     string
 	supportsRemote bool
+	syncResult     clients.SyncResult
 }
 
 func (a testAdapter) Target() string                     { return a.target }
 func (a testAdapter) DefaultConfigPath() (string, error) { return a.configPath, nil }
 func (a testAdapter) SupportsRemote(string) bool         { return a.supportsRemote }
 func (a testAdapter) Sync(_ []registry.Manifest, _ clients.SyncOptions) (clients.SyncResult, error) {
-	return clients.SyncResult{}, nil
+	return a.syncResult, nil
 }
 func (a testAdapter) AttachRing(_ registry.Ring, _ []registry.Manifest, _ clients.SyncOptions) (clients.SyncResult, error) {
 	return clients.SyncResult{}, nil
@@ -720,6 +724,92 @@ func TestRunDriftDetection(t *testing.T) {
 	}
 	if report.Summary.Warning < 1 {
 		t.Fatalf("expected drift to count as warning, got summary: %#v", report.Summary)
+	}
+}
+
+func TestRunDriftReportsPolicyStaleAsSubset(t *testing.T) {
+	tmp := t.TempDir()
+	store := registry.NewStore(filepath.Join(tmp, "servers"))
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "codex-managed.json")
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
+		t.Fatalf("create state dir: %v", err)
+	}
+	state := `{"version":2,"managed_servers":{"core-drift":["standalone"],"policy-drift":["standalone"]}}`
+	if err := os.WriteFile(statePath, []byte(state), 0o644); err != nil {
+		t.Fatalf("write state fixture: %v", err)
+	}
+
+	adapter := testAdapter{
+		target:     "codex",
+		configPath: configPath,
+		syncResult: clients.SyncResult{
+			ConfigPath:    configPath,
+			Updated:       []string{"core-drift", "policy-drift"},
+			PolicyUpdated: []string{"policy-drift"},
+		},
+	}
+	report, err := Run(store, Options{
+		DriftTargets: []DriftTarget{{
+			Adapter:    adapter,
+			StatePath:  statePath,
+			ConfigPath: configPath,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("doctor run failed: %v", err)
+	}
+	if len(report.Drift) != 1 {
+		t.Fatalf("expected one drift report, got: %#v", report.Drift)
+	}
+	dr := report.Drift[0]
+	if dr.Status != StatusWarning {
+		t.Fatalf("expected policy drift warning, got: %#v", dr)
+	}
+	if len(dr.Stale) != 2 || dr.Stale[0] != "core-drift" || dr.Stale[1] != "policy-drift" {
+		t.Fatalf("unexpected stale entries: %#v", dr.Stale)
+	}
+	if len(dr.PolicyStale) != 1 || dr.PolicyStale[0] != "policy-drift" {
+		t.Fatalf("expected policy-drift as policy stale subset, got: %#v", dr.PolicyStale)
+	}
+	if report.Summary.Warning != 1 {
+		t.Fatalf("expected one drift warning without double counting policy subset, got: %#v", report.Summary)
+	}
+}
+
+func TestRunDriftUsesCodexDeclaredPolicyComparator(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix fixture mode bits are used in this test")
+	}
+	tmp := t.TempDir()
+	store := registry.NewStore(filepath.Join(tmp, "servers"))
+	commandPath := writeTestExecutable(t, tmp, "policy-mcp")
+	allowed := []string{"read"}
+	if err := store.Save(registry.Manifest{
+		Name: "docs", Command: commandPath, Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{AllowedTools: &allowed},
+	}); err != nil {
+		t.Fatalf("save policy manifest: %v", err)
+	}
+	configPath := filepath.Join(tmp, "config.toml")
+	config := "[mcp_servers.docs]\ncommand = \"" + commandPath + "\"\nenabled_tools = [\"write\"]\n"
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatalf("write Codex config: %v", err)
+	}
+	statePath := filepath.Join(tmp, "state", "codex-managed.json")
+	if err := syncshared.SaveManagedState(statePath, map[string][]string{"docs": {syncshared.SourceStandalone}}); err != nil {
+		t.Fatalf("write managed state: %v", err)
+	}
+
+	adapter := codex.Adapter{}
+	report, err := Run(store, Options{DriftTargets: []DriftTarget{{
+		Adapter: adapter, StatePath: statePath, ConfigPath: configPath,
+	}}})
+	if err != nil {
+		t.Fatalf("doctor run: %v", err)
+	}
+	if len(report.Drift) != 1 || !reflect.DeepEqual(report.Drift[0].Stale, []string{"docs"}) || !reflect.DeepEqual(report.Drift[0].PolicyStale, []string{"docs"}) {
+		t.Fatalf("Codex policy drift was not propagated: %#v", report.Drift)
 	}
 }
 

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -1,0 +1,351 @@
+// Package policy centralizes target capability declarations and validates
+// policy-required rings before an operation can mutate or execute anything.
+package policy
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+// Surface identifies the operation shape for which a target must compile a
+// server access profile. Support can differ between persistent config, render,
+// and ephemeral run paths even for the same target.
+type Surface string
+
+const (
+	SurfacePersistent Surface = "persistent"
+	SurfaceRender     Surface = "render"
+	SurfaceRun        Surface = "run"
+)
+
+// Feature is one independently representable part of an access profile.
+type Feature string
+
+const (
+	FeatureToolAllowlist   Feature = "tool-allowlist"
+	FeatureToolDenylist    Feature = "tool-denylist"
+	FeatureOAuthScopes     Feature = "oauth-scopes"
+	FeatureDefaultApproval Feature = "default-approval"
+	FeatureToolApprovals   Feature = "tool-approvals"
+)
+
+// Capabilities declares which access-profile features one target surface can
+// represent without semantic loss.
+type Capabilities struct {
+	Compiler        bool `json:"compiler"`
+	ToolAllowlist   bool `json:"tool_allowlist"`
+	ToolDenylist    bool `json:"tool_denylist"`
+	OAuthScopes     bool `json:"oauth_scopes"`
+	DefaultApproval bool `json:"default_approval"`
+	ToolApprovals   bool `json:"tool_approvals"`
+}
+
+// Supports reports whether the feature can be compiled on this surface.
+func (c Capabilities) Supports(feature Feature) bool {
+	switch feature {
+	case FeatureToolAllowlist:
+		return c.ToolAllowlist
+	case FeatureToolDenylist:
+		return c.ToolDenylist
+	case FeatureOAuthScopes:
+		return c.OAuthScopes
+	case FeatureDefaultApproval:
+		return c.DefaultApproval
+	case FeatureToolApprovals:
+		return c.ToolApprovals
+	default:
+		return false
+	}
+}
+
+// TargetCapabilities is the central declaration for one supported Madari
+// target. PR 1A intentionally declares every policy feature unsupported; a
+// later compiler enables only the surface it implements losslessly.
+type TargetCapabilities struct {
+	Target     string       `json:"target"`
+	Persistent Capabilities `json:"persistent"`
+	Render     Capabilities `json:"render"`
+	Run        Capabilities `json:"run"`
+}
+
+// ForSurface returns the capability declaration for surface.
+func (c TargetCapabilities) ForSurface(surface Surface) (Capabilities, bool) {
+	switch surface {
+	case SurfacePersistent:
+		return c.Persistent, true
+	case SurfaceRender:
+		return c.Render, true
+	case SurfaceRun:
+		return c.Run, true
+	default:
+		return Capabilities{}, false
+	}
+}
+
+var targetCapabilities = map[string]TargetCapabilities{
+	"claude-desktop": {Target: "claude-desktop"},
+	"claude-code":    {Target: "claude-code"},
+	"codex":          {Target: "codex"},
+	"gemini":         {Target: "gemini"},
+	"vibe":           {Target: "vibe"},
+}
+
+// Targets returns all centrally declared targets in deterministic order.
+func Targets() []string {
+	targets := make([]string, 0, len(targetCapabilities))
+	for target := range targetCapabilities {
+		targets = append(targets, target)
+	}
+	sort.Strings(targets)
+	return targets
+}
+
+// Surfaces returns every policy-compilation surface in deterministic order.
+func Surfaces() []Surface {
+	return []Surface{SurfacePersistent, SurfaceRender, SurfaceRun}
+}
+
+// CapabilitiesFor returns the declaration for target and surface.
+func CapabilitiesFor(target string, surface Surface) (Capabilities, bool) {
+	declaration, ok := targetCapabilities[strings.TrimSpace(target)]
+	if !ok {
+		return Capabilities{}, false
+	}
+	return declaration.ForSurface(surface)
+}
+
+// SupportClassification summarizes whether a ring can make an enforcement
+// claim for a selected target surface.
+type SupportClassification string
+
+const (
+	SupportNotRequired SupportClassification = "not-required"
+	SupportSupported   SupportClassification = "supported"
+	SupportUnsupported SupportClassification = "unsupported"
+	SupportInvalid     SupportClassification = "invalid"
+)
+
+// IssueCode identifies one deterministic fail-closed reason.
+type IssueCode string
+
+const (
+	IssueUnknownTarget       IssueCode = "unknown-target"
+	IssueUnknownSurface      IssueCode = "unknown-surface"
+	IssueMissingMember       IssueCode = "missing-member"
+	IssueDisabledMember      IssueCode = "disabled-member"
+	IssueWrongTarget         IssueCode = "wrong-target"
+	IssueUnboundedMember     IssueCode = "unbounded-member"
+	IssueUnsupportedCompiler IssueCode = "unsupported-compiler"
+	IssueUnsupportedFeature  IssueCode = "unsupported-feature"
+)
+
+// Issue is one actionable policy-preflight failure.
+type Issue struct {
+	Code    IssueCode `json:"code"`
+	Member  string    `json:"member,omitempty"`
+	Feature Feature   `json:"feature,omitempty"`
+	Message string    `json:"message"`
+}
+
+// ValidationResult is the reusable support and error classification for one
+// ring/target/surface selection.
+type ValidationResult struct {
+	Ring           string                `json:"ring"`
+	Target         string                `json:"target"`
+	Surface        Surface               `json:"surface"`
+	Required       bool                  `json:"required"`
+	Classification SupportClassification `json:"classification"`
+	Issues         []Issue               `json:"issues"`
+}
+
+// Ready reports whether the operation may claim policy fidelity.
+func (r ValidationResult) Ready() bool {
+	return len(r.Issues) == 0
+}
+
+// Err returns an inspectable validation error when policy compilation is
+// blocked.
+func (r ValidationResult) Err() error {
+	if r.Ready() {
+		return nil
+	}
+	return &ValidationError{Result: r}
+}
+
+// ValidationError preserves the structured result while providing an
+// actionable CLI error.
+type ValidationError struct {
+	Result ValidationResult
+}
+
+func (e *ValidationError) Error() string {
+	details := make([]string, 0, len(e.Result.Issues))
+	for _, issue := range e.Result.Issues {
+		details = append(details, issue.Message)
+	}
+	message := fmt.Sprintf(
+		"ring %q requires policy enforcement, but %s %s policy support is %s: %s",
+		e.Result.Ring,
+		e.Result.Target,
+		e.Result.Surface,
+		e.Result.Classification,
+		strings.Join(details, "; "),
+	)
+	if e.Result.Classification == SupportUnsupported {
+		message += `; choose a target surface with exact policy support or remove enforcement = "required" until a compiler is available`
+	}
+	return message
+}
+
+// ValidateRequiredRing determines whether every declared access restriction
+// for a policy-required ring can be compiled exactly for target and surface.
+// Rings without required enforcement remain backward compatible.
+func ValidateRequiredRing(ring registry.Ring, manifests []registry.Manifest, target string, surface Surface) ValidationResult {
+	target = strings.TrimSpace(target)
+	result := ValidationResult{
+		Ring:           ring.Name,
+		Target:         target,
+		Surface:        surface,
+		Required:       ring.RequiresPolicyEnforcement(),
+		Classification: SupportNotRequired,
+		Issues:         []Issue{},
+	}
+	if !result.Required {
+		return result
+	}
+
+	capabilities, targetKnown := CapabilitiesFor(target, surface)
+	if !targetKnown {
+		if _, knownTarget := targetCapabilities[target]; !knownTarget {
+			result.Issues = append(result.Issues, Issue{
+				Code:    IssueUnknownTarget,
+				Message: fmt.Sprintf("target %q has no policy capability declaration; choose a supported target", target),
+			})
+		} else {
+			result.Issues = append(result.Issues, Issue{
+				Code:    IssueUnknownSurface,
+				Message: fmt.Sprintf("surface %q has no policy capability declaration for target %q", surface, target),
+			})
+		}
+		result.Classification = SupportInvalid
+		return result
+	}
+	if !capabilities.Compiler {
+		result.Issues = append(result.Issues, Issue{
+			Code:    IssueUnsupportedCompiler,
+			Message: fmt.Sprintf("%s %s has no lossless policy compiler yet", target, surface),
+		})
+	}
+
+	manifestByName := make(map[string]registry.Manifest, len(manifests))
+	for _, manifest := range manifests {
+		manifestByName[manifest.Name] = manifest
+	}
+
+	members := append([]string(nil), ring.Members...)
+	sort.Strings(members)
+	for _, rawMember := range members {
+		member := strings.TrimSpace(rawMember)
+		manifest, exists := manifestByName[member]
+		if !exists {
+			result.Issues = append(result.Issues, Issue{
+				Code:    IssueMissingMember,
+				Member:  member,
+				Message: fmt.Sprintf("member %q is missing from the registry; restore its manifest or remove it from the ring", member),
+			})
+			continue
+		}
+		if !manifest.Enabled {
+			result.Issues = append(result.Issues, Issue{
+				Code:    IssueDisabledMember,
+				Member:  member,
+				Message: fmt.Sprintf("member %q is disabled; enable it before using this policy-required ring", member),
+			})
+		}
+		if !manifest.HasClient(target) {
+			result.Issues = append(result.Issues, Issue{
+				Code:    IssueWrongTarget,
+				Member:  member,
+				Message: fmt.Sprintf("member %q does not target %q; add that client target or remove the member from the ring", member, target),
+			})
+		}
+		if !manifest.HasExplicitToolAllowlist() {
+			result.Issues = append(result.Issues, Issue{
+				Code:    IssueUnboundedMember,
+				Member:  member,
+				Feature: FeatureToolAllowlist,
+				Message: fmt.Sprintf("member %q is unbounded; declare a non-empty [access].allowed_tools allowlist", member),
+			})
+		}
+
+		for _, feature := range declaredFeatures(manifest.Access) {
+			if capabilities.Supports(feature) {
+				continue
+			}
+			result.Issues = append(result.Issues, Issue{
+				Code:    IssueUnsupportedFeature,
+				Member:  member,
+				Feature: feature,
+				Message: fmt.Sprintf("member %q declares %s, which %s %s cannot compile yet", member, featureField(feature), target, surface),
+			})
+		}
+	}
+
+	result.Classification = classify(result.Issues)
+	return result
+}
+
+func declaredFeatures(access *registry.AccessProfile) []Feature {
+	if access == nil {
+		return nil
+	}
+	features := make([]Feature, 0, 5)
+	if access.AllowedTools != nil {
+		features = append(features, FeatureToolAllowlist)
+	}
+	if access.DeniedTools != nil {
+		features = append(features, FeatureToolDenylist)
+	}
+	if access.OAuthScopes != nil {
+		features = append(features, FeatureOAuthScopes)
+	}
+	if access.DefaultApproval != nil {
+		features = append(features, FeatureDefaultApproval)
+	}
+	if access.ToolApprovals != nil {
+		features = append(features, FeatureToolApprovals)
+	}
+	return features
+}
+
+func featureField(feature Feature) string {
+	switch feature {
+	case FeatureToolAllowlist:
+		return "[access].allowed_tools"
+	case FeatureToolDenylist:
+		return "[access].denied_tools"
+	case FeatureOAuthScopes:
+		return "[access].oauth_scopes"
+	case FeatureDefaultApproval:
+		return "[access].default_approval"
+	case FeatureToolApprovals:
+		return "[access].tool_approvals"
+	default:
+		return string(feature)
+	}
+}
+
+func classify(issues []Issue) SupportClassification {
+	if len(issues) == 0 {
+		return SupportSupported
+	}
+	for _, issue := range issues {
+		if issue.Code != IssueUnsupportedCompiler && issue.Code != IssueUnsupportedFeature {
+			return SupportInvalid
+		}
+	}
+	return SupportUnsupported
+}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/ankitvg/madari/internal/clients"
 	"github.com/ankitvg/madari/internal/registry"
 )
 
@@ -62,8 +63,8 @@ func (c Capabilities) Supports(feature Feature) bool {
 }
 
 // TargetCapabilities is the central declaration for one supported Madari
-// target. PR 1A intentionally declares every policy feature unsupported; a
-// later compiler enables only the surface it implements losslessly.
+// target. A compiler enables only the surface and features it implements
+// losslessly; every unspecified surface remains unsupported.
 type TargetCapabilities struct {
 	Target     string       `json:"target"`
 	Persistent Capabilities `json:"persistent"`
@@ -88,9 +89,23 @@ func (c TargetCapabilities) ForSurface(surface Surface) (Capabilities, bool) {
 var targetCapabilities = map[string]TargetCapabilities{
 	"claude-desktop": {Target: "claude-desktop"},
 	"claude-code":    {Target: "claude-code"},
-	"codex":          {Target: "codex"},
-	"gemini":         {Target: "gemini"},
-	"vibe":           {Target: "vibe"},
+	"codex": {
+		Target: "codex",
+		Persistent: Capabilities{
+			Compiler: true, ToolAllowlist: true, ToolDenylist: true,
+			OAuthScopes: true, DefaultApproval: true, ToolApprovals: true,
+		},
+		Render: Capabilities{
+			Compiler: true, ToolAllowlist: true, ToolDenylist: true,
+			OAuthScopes: true, DefaultApproval: true, ToolApprovals: true,
+		},
+		Run: Capabilities{
+			Compiler: true, ToolAllowlist: true, ToolDenylist: true,
+			OAuthScopes: true, DefaultApproval: true, ToolApprovals: true,
+		},
+	},
+	"gemini": {Target: "gemini"},
+	"vibe":   {Target: "vibe"},
 }
 
 // Targets returns all centrally declared targets in deterministic order.
@@ -132,14 +147,17 @@ const (
 type IssueCode string
 
 const (
-	IssueUnknownTarget       IssueCode = "unknown-target"
-	IssueUnknownSurface      IssueCode = "unknown-surface"
-	IssueMissingMember       IssueCode = "missing-member"
-	IssueDisabledMember      IssueCode = "disabled-member"
-	IssueWrongTarget         IssueCode = "wrong-target"
-	IssueUnboundedMember     IssueCode = "unbounded-member"
-	IssueUnsupportedCompiler IssueCode = "unsupported-compiler"
-	IssueUnsupportedFeature  IssueCode = "unsupported-feature"
+	IssueUnknownTarget          IssueCode = "unknown-target"
+	IssueUnknownSurface         IssueCode = "unknown-surface"
+	IssueMissingMember          IssueCode = "missing-member"
+	IssueDisabledMember         IssueCode = "disabled-member"
+	IssueWrongTarget            IssueCode = "wrong-target"
+	IssueUnboundedMember        IssueCode = "unbounded-member"
+	IssueUnsupportedCompiler    IssueCode = "unsupported-compiler"
+	IssueUnsupportedFeature     IssueCode = "unsupported-feature"
+	IssueUnsupportedTransport   IssueCode = "unsupported-transport"
+	IssueUnsupportedServerField IssueCode = "unsupported-server-field"
+	IssueInvalidCommand         IssueCode = "invalid-command"
 )
 
 // Issue is one actionable policy-preflight failure.
@@ -272,6 +290,7 @@ func ValidateRequiredRing(ring registry.Ring, manifests []registry.Manifest, tar
 				Message: fmt.Sprintf("member %q does not target %q; add that client target or remove the member from the ring", member, target),
 			})
 		}
+		result.Issues = append(result.Issues, targetRepresentationIssues(manifest, target, surface)...)
 		if !manifest.HasExplicitToolAllowlist() {
 			result.Issues = append(result.Issues, Issue{
 				Code:    IssueUnboundedMember,
@@ -296,6 +315,39 @@ func ValidateRequiredRing(ring registry.Ring, manifests []registry.Manifest, tar
 
 	result.Classification = classify(result.Issues)
 	return result
+}
+
+func targetRepresentationIssues(manifest registry.Manifest, target string, surface Surface) []Issue {
+	if target != "codex" {
+		return nil
+	}
+	issues := []Issue{}
+	if manifest.IsRemote() {
+		if manifest.TransportType() != registry.TransportHTTP {
+			issues = append(issues, Issue{
+				Code: IssueUnsupportedTransport, Member: manifest.Name,
+				Message: fmt.Sprintf("member %q uses %s transport, which Codex %s cannot represent", manifest.Name, manifest.TransportType(), surface),
+			})
+		}
+	} else if commandErr := clients.ValidateCommandPath(manifest.Command); commandErr != nil {
+		issues = append(issues, Issue{
+			Code: IssueInvalidCommand, Member: manifest.Name,
+			Message: fmt.Sprintf("member %q cannot execute on Codex: %s", manifest.Name, commandErr.Message),
+		})
+	}
+	if manifest.TimeoutMS > 0 {
+		issues = append(issues, Issue{
+			Code: IssueUnsupportedServerField, Member: manifest.Name,
+			Message: fmt.Sprintf("member %q declares timeout_ms, which Codex %s cannot represent exactly", manifest.Name, surface),
+		})
+	}
+	if surface == SurfaceRender && len(manifest.SecretHeaderNames()) > 0 {
+		issues = append(issues, Issue{
+			Code: IssueUnsupportedServerField, Member: manifest.Name,
+			Message: fmt.Sprintf("member %q declares secret_headers whose values Codex render intentionally omits", manifest.Name),
+		})
+	}
+	return issues
 }
 
 // ValidateAttachedRequiredRings applies required-ring policy validation only
@@ -380,7 +432,8 @@ func classify(issues []Issue) SupportClassification {
 		return SupportSupported
 	}
 	for _, issue := range issues {
-		if issue.Code != IssueUnsupportedCompiler && issue.Code != IssueUnsupportedFeature {
+		if issue.Code != IssueUnsupportedCompiler && issue.Code != IssueUnsupportedFeature &&
+			issue.Code != IssueUnsupportedTransport && issue.Code != IssueUnsupportedServerField {
 			return SupportInvalid
 		}
 	}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -298,6 +298,43 @@ func ValidateRequiredRing(ring registry.Ring, manifests []registry.Manifest, tar
 	return result
 }
 
+// ValidateAttachedRequiredRings applies required-ring policy validation only
+// to ring ownership sources recorded for one target. Diagnostics and sync use
+// this shared gate so a dry-run drift plan cannot claim readiness when the
+// corresponding sync operation must fail closed.
+func ValidateAttachedRequiredRings(rings []registry.Ring, attached []string, manifests []registry.Manifest, target string, surface Surface) error {
+	byName := make(map[string]registry.Ring, len(rings))
+	for _, ring := range rings {
+		byName[ring.Name] = ring
+	}
+
+	seen := make(map[string]struct{}, len(attached))
+	names := make([]string, 0, len(attached))
+	for _, rawName := range attached {
+		name := strings.TrimSpace(rawName)
+		if name == "" {
+			continue
+		}
+		if _, exists := seen[name]; exists {
+			continue
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		ring, exists := byName[name]
+		if !exists {
+			return fmt.Errorf("attached ring %q is missing; restore its definition or detach it before sync so policy requirements cannot be bypassed", name)
+		}
+		if err := ValidateRequiredRing(ring, manifests, target, surface).Err(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func declaredFeatures(access *registry.AccessProfile) []Feature {
 	if access == nil {
 		return nil

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -198,6 +198,30 @@ func TestValidateRequiredRingRejectsUnknownTargetAndSurface(t *testing.T) {
 	}
 }
 
+func TestValidateAttachedRequiredRingsChecksOnlyRecordedSources(t *testing.T) {
+	allowed := []string{"read"}
+	manifest := registry.Manifest{
+		Name:    "docs",
+		Enabled: true,
+		Clients: []string{"codex"},
+		Access:  &registry.AccessProfile{AllowedTools: &allowed},
+	}
+	rings := []registry.Ring{
+		{Name: "advisory", Members: []string{"docs"}},
+		requiredRing("required", "docs"),
+	}
+
+	if err := ValidateAttachedRequiredRings(rings, []string{"advisory"}, []registry.Manifest{manifest}, "codex", SurfacePersistent); err != nil {
+		t.Fatalf("advisory attached ring should remain compatible: %v", err)
+	}
+	if err := ValidateAttachedRequiredRings(rings, []string{"required", "required"}, []registry.Manifest{manifest}, "codex", SurfacePersistent); err == nil || !strings.Contains(err.Error(), "codex persistent policy support is unsupported") {
+		t.Fatalf("required attached ring should fail closed: %v", err)
+	}
+	if err := ValidateAttachedRequiredRings(rings, []string{"missing"}, []registry.Manifest{manifest}, "codex", SurfacePersistent); err == nil || !strings.Contains(err.Error(), `attached ring "missing" is missing`) {
+		t.Fatalf("missing attached ring should fail closed: %v", err)
+	}
+}
+
 func requiredRing(name string, members ...string) registry.Ring {
 	return registry.Ring{
 		Name:    name,

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -2,6 +2,7 @@ package policy
 
 import (
 	"errors"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -28,12 +29,13 @@ func TestCapabilitiesDeclareEveryTargetSurfaceFailClosed(t *testing.T) {
 			if !ok {
 				t.Fatalf("missing declaration for %s %s", target, surface)
 			}
-			if capabilities.Compiler {
-				t.Fatalf("PR 1A must not enable the %s %s policy compiler", target, surface)
+			expectCodexCompiler := target == "codex"
+			if capabilities.Compiler != expectCodexCompiler {
+				t.Fatalf("unexpected compiler declaration for %s %s: %#v", target, surface, capabilities)
 			}
 			for _, feature := range features {
-				if capabilities.Supports(feature) {
-					t.Fatalf("PR 1A must fail closed, but %s %s supports %s", target, surface, feature)
+				if capabilities.Supports(feature) != expectCodexCompiler {
+					t.Fatalf("unexpected %s support for %s %s: %#v", feature, target, surface, capabilities)
 				}
 			}
 		}
@@ -61,7 +63,7 @@ func TestValidateRequiredRingClassifiesUnsupportedDeclaredFeatures(t *testing.T)
 	manifest := registry.Manifest{
 		Name:    "docs",
 		Enabled: true,
-		Clients: []string{"codex"},
+		Clients: []string{"gemini"},
 		Access: &registry.AccessProfile{
 			AllowedTools:    &allowed,
 			DeniedTools:     &denied,
@@ -71,7 +73,7 @@ func TestValidateRequiredRingClassifiesUnsupportedDeclaredFeatures(t *testing.T)
 		},
 	}
 
-	result := ValidateRequiredRing(requiredRing("research", "docs"), []registry.Manifest{manifest}, "codex", SurfacePersistent)
+	result := ValidateRequiredRing(requiredRing("research", "docs"), []registry.Manifest{manifest}, "gemini", SurfacePersistent)
 	if result.Classification != SupportUnsupported || result.Ready() {
 		t.Fatalf("expected unsupported result, got: %#v", result)
 	}
@@ -100,7 +102,7 @@ func TestValidateRequiredRingClassifiesUnsupportedDeclaredFeatures(t *testing.T)
 	if !errors.As(result.Err(), &validationErr) {
 		t.Fatalf("expected structured validation error, got: %v", result.Err())
 	}
-	if validationErr.Result.Classification != SupportUnsupported || !strings.Contains(validationErr.Error(), "codex persistent policy support is unsupported") {
+	if validationErr.Result.Classification != SupportUnsupported || !strings.Contains(validationErr.Error(), "gemini persistent policy support is unsupported") {
 		t.Fatalf("unexpected actionable error: %v", validationErr)
 	}
 }
@@ -109,12 +111,12 @@ func TestValidateRequiredRingReportsMemberProblemsDeterministically(t *testing.T
 	allowed := []string{"read"}
 	ring := requiredRing("research", "wrong", "missing", "disabled", "unbounded")
 	manifests := []registry.Manifest{
-		{Name: "wrong", Enabled: true, Clients: []string{"gemini"}, Access: &registry.AccessProfile{AllowedTools: &allowed}},
-		{Name: "disabled", Enabled: false, Clients: []string{"codex"}},
-		{Name: "unbounded", Enabled: true, Clients: []string{"codex"}},
+		{Name: "wrong", Enabled: true, Clients: []string{"codex"}, Access: &registry.AccessProfile{AllowedTools: &allowed}},
+		{Name: "disabled", Enabled: false, Clients: []string{"gemini"}},
+		{Name: "unbounded", Enabled: true, Clients: []string{"gemini"}},
 	}
 
-	result := ValidateRequiredRing(ring, manifests, "codex", SurfaceRender)
+	result := ValidateRequiredRing(ring, manifests, "gemini", SurfaceRender)
 	if result.Classification != SupportInvalid || result.Ready() {
 		t.Fatalf("expected invalid member result, got: %#v", result)
 	}
@@ -144,7 +146,7 @@ func TestValidateRequiredRingReportsMemberProblemsDeterministically(t *testing.T
 		`member "disabled" is disabled`,
 		`member "missing" is missing from the registry`,
 		`member "unbounded" is unbounded`,
-		`member "wrong" does not target "codex"`,
+		`member "wrong" does not target "gemini"`,
 	} {
 		if !strings.Contains(message, fragment) {
 			t.Fatalf("error missing actionable detail %q: %s", fragment, message)
@@ -156,31 +158,77 @@ func TestValidateRequiredRingTreatsExplicitEmptyAllowlistAsUnbounded(t *testing.
 	empty := []string{}
 	manifest := registry.Manifest{
 		Name:    "docs",
+		Command: currentExecutable(t),
 		Enabled: true,
 		Clients: []string{"codex"},
 		Access:  &registry.AccessProfile{AllowedTools: &empty},
 	}
 	result := ValidateRequiredRing(requiredRing("research", "docs"), []registry.Manifest{manifest}, "codex", SurfaceRun)
-	if result.Classification != SupportInvalid || len(result.Issues) != 3 {
-		t.Fatalf("expected unbounded plus unsupported explicit-clear issues, got: %#v", result)
+	if result.Classification != SupportInvalid || len(result.Issues) != 1 {
+		t.Fatalf("expected explicit-clear allowlist to remain unbounded, got: %#v", result)
 	}
-	if result.Issues[0].Code != IssueUnsupportedCompiler || result.Issues[1].Code != IssueUnboundedMember || result.Issues[2].Code != IssueUnsupportedFeature {
+	if result.Issues[0].Code != IssueUnboundedMember {
 		t.Fatalf("unexpected explicit-clear issue order: %#v", result.Issues)
 	}
 }
 
-func TestValidateRequiredRingBlocksSkillOnlyWithoutCompiler(t *testing.T) {
+func currentExecutable(t *testing.T) string {
+	t.Helper()
+	path, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve test executable: %v", err)
+	}
+	return path
+}
+
+func TestValidateRequiredRingAllowsSkillOnlyWithCompiler(t *testing.T) {
 	ring := registry.Ring{
 		Name:   "workflow",
 		Skills: []string{"release"},
 		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
 	}
 	result := ValidateRequiredRing(ring, nil, "codex", SurfaceRun)
-	if result.Classification != SupportUnsupported || result.Ready() || len(result.Issues) != 1 {
-		t.Fatalf("skill-only required ring must still require a compiler: %#v", result)
+	if result.Classification != SupportSupported || !result.Ready() || len(result.Issues) != 0 {
+		t.Fatalf("skill-only required ring should use the Codex run compiler: %#v", result)
 	}
-	if result.Issues[0].Code != IssueUnsupportedCompiler {
-		t.Fatalf("unexpected skill-only issue: %#v", result.Issues)
+}
+
+func TestValidateRequiredCodexRingBlocksUnrepresentableServerFields(t *testing.T) {
+	allowed := []string{"read"}
+	base := registry.Manifest{
+		Name: "docs", Transport: registry.TransportHTTP, URL: "https://example.com/mcp",
+		Enabled: true, Clients: []string{"codex"}, Access: &registry.AccessProfile{AllowedTools: &allowed},
+	}
+	cases := []struct {
+		name     string
+		surface  Surface
+		mutate   func(*registry.Manifest)
+		fragment string
+	}{
+		{
+			name: "timeout persistent", surface: SurfacePersistent, fragment: "timeout_ms",
+			mutate: func(manifest *registry.Manifest) { manifest.TimeoutMS = 5000 },
+		},
+		{
+			name: "secret header render", surface: SurfaceRender, fragment: "secret_headers",
+			mutate: func(manifest *registry.Manifest) {
+				manifest.Headers = map[string]string{"x-private-token": "secret"}
+				manifest.SecretHeaders = registry.SecretHeaders{Keys: []string{"x-private-token"}}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			manifest := base
+			tc.mutate(&manifest)
+			result := ValidateRequiredRing(requiredRing("restricted", "docs"), []registry.Manifest{manifest}, "codex", tc.surface)
+			if result.Ready() || result.Classification != SupportUnsupported || len(result.Issues) != 1 || result.Issues[0].Code != IssueUnsupportedServerField {
+				t.Fatalf("expected unsupported server field: %#v", result)
+			}
+			if !strings.Contains(result.Issues[0].Message, tc.fragment) {
+				t.Fatalf("issue missing %q: %#v", tc.fragment, result.Issues[0])
+			}
+		})
 	}
 }
 
@@ -202,6 +250,7 @@ func TestValidateAttachedRequiredRingsChecksOnlyRecordedSources(t *testing.T) {
 	allowed := []string{"read"}
 	manifest := registry.Manifest{
 		Name:    "docs",
+		Command: currentExecutable(t),
 		Enabled: true,
 		Clients: []string{"codex"},
 		Access:  &registry.AccessProfile{AllowedTools: &allowed},
@@ -214,8 +263,8 @@ func TestValidateAttachedRequiredRingsChecksOnlyRecordedSources(t *testing.T) {
 	if err := ValidateAttachedRequiredRings(rings, []string{"advisory"}, []registry.Manifest{manifest}, "codex", SurfacePersistent); err != nil {
 		t.Fatalf("advisory attached ring should remain compatible: %v", err)
 	}
-	if err := ValidateAttachedRequiredRings(rings, []string{"required", "required"}, []registry.Manifest{manifest}, "codex", SurfacePersistent); err == nil || !strings.Contains(err.Error(), "codex persistent policy support is unsupported") {
-		t.Fatalf("required attached ring should fail closed: %v", err)
+	if err := ValidateAttachedRequiredRings(rings, []string{"required", "required"}, []registry.Manifest{manifest}, "codex", SurfacePersistent); err != nil {
+		t.Fatalf("supported required attached ring should compile: %v", err)
 	}
 	if err := ValidateAttachedRequiredRings(rings, []string{"missing"}, []registry.Manifest{manifest}, "codex", SurfacePersistent); err == nil || !strings.Contains(err.Error(), `attached ring "missing" is missing`) {
 		t.Fatalf("missing attached ring should fail closed: %v", err)

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -1,0 +1,209 @@
+package policy
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+func TestCapabilitiesDeclareEveryTargetSurfaceFailClosed(t *testing.T) {
+	wantTargets := []string{"claude-code", "claude-desktop", "codex", "gemini", "vibe"}
+	if got := Targets(); !reflect.DeepEqual(got, wantTargets) {
+		t.Fatalf("unexpected policy targets: got %#v want %#v", got, wantTargets)
+	}
+
+	features := []Feature{
+		FeatureToolAllowlist,
+		FeatureToolDenylist,
+		FeatureOAuthScopes,
+		FeatureDefaultApproval,
+		FeatureToolApprovals,
+	}
+	for _, target := range wantTargets {
+		for _, surface := range Surfaces() {
+			capabilities, ok := CapabilitiesFor(target, surface)
+			if !ok {
+				t.Fatalf("missing declaration for %s %s", target, surface)
+			}
+			if capabilities.Compiler {
+				t.Fatalf("PR 1A must not enable the %s %s policy compiler", target, surface)
+			}
+			for _, feature := range features {
+				if capabilities.Supports(feature) {
+					t.Fatalf("PR 1A must fail closed, but %s %s supports %s", target, surface, feature)
+				}
+			}
+		}
+	}
+}
+
+func TestValidateRequiredRingLeavesAdvisoryRingBackwardCompatible(t *testing.T) {
+	result := ValidateRequiredRing(
+		registry.Ring{Name: "legacy", Members: []string{"missing"}},
+		nil,
+		"codex",
+		SurfacePersistent,
+	)
+	if result.Required || result.Classification != SupportNotRequired || !result.Ready() || result.Err() != nil {
+		t.Fatalf("advisory ring should bypass enforcement preflight: %#v", result)
+	}
+}
+
+func TestValidateRequiredRingClassifiesUnsupportedDeclaredFeatures(t *testing.T) {
+	allowed := []string{"read"}
+	denied := []string{"delete"}
+	scopes := []string{"documents.read"}
+	defaultApproval := registry.ApprovalBehaviorAlwaysPrompt
+	toolApprovals := map[string]registry.ApprovalBehavior{"read": registry.ApprovalBehaviorAlwaysAllow}
+	manifest := registry.Manifest{
+		Name:    "docs",
+		Enabled: true,
+		Clients: []string{"codex"},
+		Access: &registry.AccessProfile{
+			AllowedTools:    &allowed,
+			DeniedTools:     &denied,
+			OAuthScopes:     &scopes,
+			DefaultApproval: &defaultApproval,
+			ToolApprovals:   &toolApprovals,
+		},
+	}
+
+	result := ValidateRequiredRing(requiredRing("research", "docs"), []registry.Manifest{manifest}, "codex", SurfacePersistent)
+	if result.Classification != SupportUnsupported || result.Ready() {
+		t.Fatalf("expected unsupported result, got: %#v", result)
+	}
+	wantFeatures := []Feature{
+		FeatureToolAllowlist,
+		FeatureToolDenylist,
+		FeatureOAuthScopes,
+		FeatureDefaultApproval,
+		FeatureToolApprovals,
+	}
+	gotFeatures := make([]Feature, 0, len(result.Issues))
+	if len(result.Issues) == 0 || result.Issues[0].Code != IssueUnsupportedCompiler {
+		t.Fatalf("expected compiler support issue first, got: %#v", result.Issues)
+	}
+	for _, issue := range result.Issues[1:] {
+		if issue.Code != IssueUnsupportedFeature {
+			t.Fatalf("expected remaining unsupported-feature issues, got: %#v", result.Issues)
+		}
+		gotFeatures = append(gotFeatures, issue.Feature)
+	}
+	if !reflect.DeepEqual(gotFeatures, wantFeatures) {
+		t.Fatalf("feature issue order drift: got %#v want %#v", gotFeatures, wantFeatures)
+	}
+
+	var validationErr *ValidationError
+	if !errors.As(result.Err(), &validationErr) {
+		t.Fatalf("expected structured validation error, got: %v", result.Err())
+	}
+	if validationErr.Result.Classification != SupportUnsupported || !strings.Contains(validationErr.Error(), "codex persistent policy support is unsupported") {
+		t.Fatalf("unexpected actionable error: %v", validationErr)
+	}
+}
+
+func TestValidateRequiredRingReportsMemberProblemsDeterministically(t *testing.T) {
+	allowed := []string{"read"}
+	ring := requiredRing("research", "wrong", "missing", "disabled", "unbounded")
+	manifests := []registry.Manifest{
+		{Name: "wrong", Enabled: true, Clients: []string{"gemini"}, Access: &registry.AccessProfile{AllowedTools: &allowed}},
+		{Name: "disabled", Enabled: false, Clients: []string{"codex"}},
+		{Name: "unbounded", Enabled: true, Clients: []string{"codex"}},
+	}
+
+	result := ValidateRequiredRing(ring, manifests, "codex", SurfaceRender)
+	if result.Classification != SupportInvalid || result.Ready() {
+		t.Fatalf("expected invalid member result, got: %#v", result)
+	}
+	want := []struct {
+		code   IssueCode
+		member string
+	}{
+		{IssueUnsupportedCompiler, ""},
+		{IssueDisabledMember, "disabled"},
+		{IssueUnboundedMember, "disabled"},
+		{IssueMissingMember, "missing"},
+		{IssueUnboundedMember, "unbounded"},
+		{IssueWrongTarget, "wrong"},
+		{IssueUnsupportedFeature, "wrong"},
+	}
+	if len(result.Issues) != len(want) {
+		t.Fatalf("unexpected issues: %#v", result.Issues)
+	}
+	for i, expected := range want {
+		if result.Issues[i].Code != expected.code || result.Issues[i].Member != expected.member {
+			t.Fatalf("issue %d drift: got %#v want code=%s member=%s", i, result.Issues[i], expected.code, expected.member)
+		}
+	}
+
+	message := result.Err().Error()
+	for _, fragment := range []string{
+		`member "disabled" is disabled`,
+		`member "missing" is missing from the registry`,
+		`member "unbounded" is unbounded`,
+		`member "wrong" does not target "codex"`,
+	} {
+		if !strings.Contains(message, fragment) {
+			t.Fatalf("error missing actionable detail %q: %s", fragment, message)
+		}
+	}
+}
+
+func TestValidateRequiredRingTreatsExplicitEmptyAllowlistAsUnbounded(t *testing.T) {
+	empty := []string{}
+	manifest := registry.Manifest{
+		Name:    "docs",
+		Enabled: true,
+		Clients: []string{"codex"},
+		Access:  &registry.AccessProfile{AllowedTools: &empty},
+	}
+	result := ValidateRequiredRing(requiredRing("research", "docs"), []registry.Manifest{manifest}, "codex", SurfaceRun)
+	if result.Classification != SupportInvalid || len(result.Issues) != 3 {
+		t.Fatalf("expected unbounded plus unsupported explicit-clear issues, got: %#v", result)
+	}
+	if result.Issues[0].Code != IssueUnsupportedCompiler || result.Issues[1].Code != IssueUnboundedMember || result.Issues[2].Code != IssueUnsupportedFeature {
+		t.Fatalf("unexpected explicit-clear issue order: %#v", result.Issues)
+	}
+}
+
+func TestValidateRequiredRingBlocksSkillOnlyWithoutCompiler(t *testing.T) {
+	ring := registry.Ring{
+		Name:   "workflow",
+		Skills: []string{"release"},
+		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
+	}
+	result := ValidateRequiredRing(ring, nil, "codex", SurfaceRun)
+	if result.Classification != SupportUnsupported || result.Ready() || len(result.Issues) != 1 {
+		t.Fatalf("skill-only required ring must still require a compiler: %#v", result)
+	}
+	if result.Issues[0].Code != IssueUnsupportedCompiler {
+		t.Fatalf("unexpected skill-only issue: %#v", result.Issues)
+	}
+}
+
+func TestValidateRequiredRingRejectsUnknownTargetAndSurface(t *testing.T) {
+	ring := requiredRing("research")
+
+	unknownTarget := ValidateRequiredRing(ring, nil, "future-client", SurfacePersistent)
+	if unknownTarget.Classification != SupportInvalid || len(unknownTarget.Issues) != 1 || unknownTarget.Issues[0].Code != IssueUnknownTarget {
+		t.Fatalf("unexpected unknown target result: %#v", unknownTarget)
+	}
+
+	unknownSurface := ValidateRequiredRing(ring, nil, "codex", Surface("future"))
+	if unknownSurface.Classification != SupportInvalid || len(unknownSurface.Issues) != 1 || unknownSurface.Issues[0].Code != IssueUnknownSurface {
+		t.Fatalf("unexpected unknown surface result: %#v", unknownSurface)
+	}
+}
+
+func requiredRing(name string, members ...string) registry.Ring {
+	return registry.Ring{
+		Name:    name,
+		Members: members,
+		Policy: &registry.RingPolicy{
+			Enforcement: registry.PolicyEnforcementRequired,
+		},
+	}
+}

--- a/internal/registry/manifest.go
+++ b/internal/registry/manifest.go
@@ -19,6 +19,30 @@ const (
 	TransportSSE   = "sse"
 )
 
+// ApprovalBehavior is Madari's portable vocabulary for client-side MCP tool
+// approval behavior. Client adapters map these values to their native enums;
+// the native values are deliberately not part of the registry contract.
+type ApprovalBehavior string
+
+const (
+	ApprovalBehaviorInherit      ApprovalBehavior = "inherit"
+	ApprovalBehaviorAutomatic    ApprovalBehavior = "automatic"
+	ApprovalBehaviorAlwaysPrompt ApprovalBehavior = "always-prompt"
+	ApprovalBehaviorAlwaysAllow  ApprovalBehavior = "always-allow"
+)
+
+// AccessProfile describes the access restrictions Madari should compile for
+// one MCP server. Pointer fields preserve the distinction between an absent
+// declaration (leave the target-native value untouched) and an explicit empty
+// declaration (clear the target-native override).
+type AccessProfile struct {
+	AllowedTools    *[]string                    `toml:"allowed_tools,omitempty" json:"allowed_tools,omitempty"`
+	DeniedTools     *[]string                    `toml:"denied_tools,omitempty" json:"denied_tools,omitempty"`
+	OAuthScopes     *[]string                    `toml:"oauth_scopes,omitempty" json:"oauth_scopes,omitempty"`
+	DefaultApproval *ApprovalBehavior            `toml:"default_approval,omitempty" json:"default_approval,omitempty"`
+	ToolApprovals   *map[string]ApprovalBehavior `toml:"tool_approvals,omitempty" json:"tool_approvals,omitempty"`
+}
+
 // Manifest is the canonical configuration for one local MCP server.
 type Manifest struct {
 	Name              string            `toml:"name" json:"name"`
@@ -37,6 +61,7 @@ type Manifest struct {
 	RequiredEnv       RequiredEnv       `toml:"required_env,omitempty" json:"required_env,omitempty"`
 	SecretEnv         SecretEnv         `toml:"secret_env,omitempty" json:"secret_env,omitempty"`
 	SecretHeaders     SecretHeaders     `toml:"secret_headers,omitempty" json:"secret_headers,omitempty"`
+	Access            *AccessProfile    `toml:"access,omitempty" json:"access,omitempty"`
 }
 
 // RequiredEnv describes environment variables that must be present at runtime.
@@ -172,6 +197,113 @@ func (m Manifest) RequiresBearerTokenEnv() bool {
 	return strings.TrimSpace(m.BearerTokenEnvVar) != ""
 }
 
+// HasExplicitToolAllowlist reports whether the manifest declares a non-empty
+// exact tool allowlist. Policy-required rings use this as their bounded-access
+// prerequisite; an explicitly empty allowlist clears a native override and is
+// therefore unbounded.
+func (m Manifest) HasExplicitToolAllowlist() bool {
+	return m.Access != nil && m.Access.AllowedTools != nil && len(*m.Access.AllowedTools) > 0
+}
+
+func (a *AccessProfile) Validate() error {
+	if a == nil {
+		return nil
+	}
+	if a.AllowedTools == nil && a.DeniedTools == nil && a.OAuthScopes == nil && a.DefaultApproval == nil && a.ToolApprovals == nil {
+		return fmt.Errorf("access must declare at least one field")
+	}
+
+	var errs []string
+	allowed, allowedErrs := validateAccessStringSet("allowed_tools", a.AllowedTools)
+	errs = append(errs, allowedErrs...)
+	denied, deniedErrs := validateAccessStringSet("denied_tools", a.DeniedTools)
+	errs = append(errs, deniedErrs...)
+	_, scopeErrs := validateAccessStringSet("oauth_scopes", a.OAuthScopes)
+	errs = append(errs, scopeErrs...)
+
+	if a.DefaultApproval != nil && !validApprovalBehavior(*a.DefaultApproval) {
+		errs = append(errs, fmt.Sprintf("invalid default_approval %q (supported: %s)", *a.DefaultApproval, supportedApprovalBehaviors()))
+	}
+
+	for tool := range allowed {
+		if _, exists := denied[tool]; exists {
+			errs = append(errs, fmt.Sprintf("tool %q cannot appear in both allowed_tools and denied_tools", tool))
+		}
+	}
+
+	if a.ToolApprovals != nil {
+		tools := make([]string, 0, len(*a.ToolApprovals))
+		for tool := range *a.ToolApprovals {
+			tools = append(tools, tool)
+		}
+		sort.Strings(tools)
+		for _, tool := range tools {
+			approval := (*a.ToolApprovals)[tool]
+			trimmed := strings.TrimSpace(tool)
+			switch {
+			case trimmed == "":
+				errs = append(errs, "tool_approvals names must be non-empty")
+			case tool != trimmed:
+				errs = append(errs, fmt.Sprintf("tool_approvals name %q must not have leading or trailing whitespace", tool))
+			}
+			if !validApprovalBehavior(approval) {
+				errs = append(errs, fmt.Sprintf("invalid approval %q for tool %q (supported: %s)", approval, tool, supportedApprovalBehaviors()))
+			}
+			if _, exists := denied[tool]; exists {
+				errs = append(errs, fmt.Sprintf("tool_approvals cannot configure denied tool %q", tool))
+			}
+			if a.AllowedTools != nil && len(*a.AllowedTools) > 0 {
+				if _, exists := allowed[tool]; !exists {
+					errs = append(errs, fmt.Sprintf("tool_approvals tool %q is not in allowed_tools", tool))
+				}
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("invalid access profile: %s", strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+func validateAccessStringSet(field string, values *[]string) (map[string]struct{}, []string) {
+	seen := map[string]struct{}{}
+	if values == nil {
+		return seen, nil
+	}
+	var errs []string
+	for _, value := range *values {
+		trimmed := strings.TrimSpace(value)
+		switch {
+		case trimmed == "":
+			errs = append(errs, fmt.Sprintf("%s values must be non-empty", field))
+			continue
+		case value != trimmed:
+			errs = append(errs, fmt.Sprintf("%s value %q must not have leading or trailing whitespace", field, value))
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			errs = append(errs, fmt.Sprintf("duplicate %s value %q", field, value))
+			continue
+		}
+		seen[value] = struct{}{}
+	}
+	return seen, errs
+}
+
+func validApprovalBehavior(value ApprovalBehavior) bool {
+	switch value {
+	case ApprovalBehaviorInherit, ApprovalBehaviorAutomatic, ApprovalBehaviorAlwaysPrompt, ApprovalBehaviorAlwaysAllow:
+		return true
+	default:
+		return false
+	}
+}
+
+func supportedApprovalBehaviors() string {
+	return fmt.Sprintf("%q, %q, %q, or %q", ApprovalBehaviorInherit, ApprovalBehaviorAutomatic, ApprovalBehaviorAlwaysPrompt, ApprovalBehaviorAlwaysAllow)
+}
+
 // Validate enforces manifest-level invariants.
 func (m Manifest) Validate() error {
 	var errs []string
@@ -241,6 +373,13 @@ func (m Manifest) Validate() error {
 		} else if !envKeyPattern.MatchString(key) {
 			errs = append(errs, fmt.Sprintf("invalid bearer_token_env_var key %q", key))
 		}
+	}
+
+	if err := m.Access.Validate(); err != nil {
+		errs = append(errs, err.Error())
+	}
+	if !m.IsRemote() && m.Access != nil && m.Access.OAuthScopes != nil && len(*m.Access.OAuthScopes) > 0 {
+		errs = append(errs, "oauth_scopes requires a remote transport with an OAuth client flow")
 	}
 
 	for key := range m.Headers {

--- a/internal/registry/manifest_test.go
+++ b/internal/registry/manifest_test.go
@@ -19,6 +19,23 @@ func baseManifest() Manifest {
 	}
 }
 
+func stringListPointer(values ...string) *[]string {
+	copy := append([]string(nil), values...)
+	return &copy
+}
+
+func approvalPointer(value ApprovalBehavior) *ApprovalBehavior {
+	return &value
+}
+
+func approvalMapPointer(values map[string]ApprovalBehavior) *map[string]ApprovalBehavior {
+	copy := make(map[string]ApprovalBehavior, len(values))
+	for key, value := range values {
+		copy[key] = value
+	}
+	return &copy
+}
+
 func TestManifestValidateOK(t *testing.T) {
 	m := baseManifest()
 	if err := m.Validate(); err != nil {
@@ -31,6 +48,157 @@ func TestManifestValidateAllowsDotsInName(t *testing.T) {
 	m.Name = "awslabs.core-mcp-server"
 	if err := m.Validate(); err != nil {
 		t.Fatalf("expected dotted name to validate, got error: %v", err)
+	}
+}
+
+func TestManifestValidateAccessProfile(t *testing.T) {
+	m := baseManifest()
+	m.Access = &AccessProfile{
+		AllowedTools:    stringListPointer("issues.read", "repos.search"),
+		DeniedTools:     stringListPointer("issues.delete"),
+		DefaultApproval: approvalPointer(ApprovalBehaviorAlwaysPrompt),
+		ToolApprovals: approvalMapPointer(map[string]ApprovalBehavior{
+			"issues.read": ApprovalBehaviorAlwaysAllow,
+		}),
+	}
+	if err := m.Validate(); err != nil {
+		t.Fatalf("expected access profile to validate, got: %v", err)
+	}
+	if !m.HasExplicitToolAllowlist() {
+		t.Fatalf("expected non-empty allowed_tools to bound the manifest")
+	}
+
+	m.Access.AllowedTools = stringListPointer()
+	m.Access.DeniedTools = stringListPointer()
+	m.Access.ToolApprovals = approvalMapPointer(map[string]ApprovalBehavior{})
+	if err := m.Validate(); err != nil {
+		t.Fatalf("expected explicit empty clear declarations to validate, got: %v", err)
+	}
+	if m.HasExplicitToolAllowlist() {
+		t.Fatalf("explicit empty allowed_tools must be treated as unbounded clear")
+	}
+}
+
+func TestManifestValidateRemoteOAuthScopes(t *testing.T) {
+	m := Manifest{
+		Name:      "cloud-sql",
+		Transport: TransportHTTP,
+		URL:       "https://example.com/mcp",
+		Enabled:   true,
+		Clients:   []string{"codex"},
+		Access: &AccessProfile{
+			OAuthScopes: stringListPointer("database.read", "openid"),
+		},
+	}
+	if err := m.Validate(); err != nil {
+		t.Fatalf("expected remote oauth scopes to validate, got: %v", err)
+	}
+
+	stdio := baseManifest()
+	stdio.Access = &AccessProfile{OAuthScopes: stringListPointer("database.read")}
+	if err := stdio.Validate(); err == nil || !strings.Contains(err.Error(), "oauth_scopes requires a remote transport") {
+		t.Fatalf("expected non-empty stdio oauth_scopes rejection, got: %v", err)
+	}
+	stdio.Access.OAuthScopes = stringListPointer()
+	if err := stdio.Validate(); err != nil {
+		t.Fatalf("expected explicit empty stdio oauth_scopes clear to validate, got: %v", err)
+	}
+}
+
+func TestManifestValidateAccessProfileErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		access  *AccessProfile
+		expects string
+	}{
+		{name: "empty access", access: &AccessProfile{}, expects: "access must declare at least one field"},
+		{name: "blank allowed tool", access: &AccessProfile{AllowedTools: stringListPointer("")}, expects: "allowed_tools values must be non-empty"},
+		{name: "padded allowed tool", access: &AccessProfile{AllowedTools: stringListPointer(" read ")}, expects: "allowed_tools value"},
+		{name: "duplicate allowed tool", access: &AccessProfile{AllowedTools: stringListPointer("read", "read")}, expects: "duplicate allowed_tools"},
+		{name: "duplicate denied tool", access: &AccessProfile{DeniedTools: stringListPointer("delete", "delete")}, expects: "duplicate denied_tools"},
+		{name: "blank oauth scope", access: &AccessProfile{OAuthScopes: stringListPointer("")}, expects: "oauth_scopes values must be non-empty"},
+		{name: "padded oauth scope", access: &AccessProfile{OAuthScopes: stringListPointer(" repo.read ")}, expects: "oauth_scopes value"},
+		{name: "duplicate oauth scope", access: &AccessProfile{OAuthScopes: stringListPointer("repo.read", "repo.read")}, expects: "duplicate oauth_scopes"},
+		{name: "invalid default approval", access: &AccessProfile{DefaultApproval: approvalPointer("prompt-on-write")}, expects: "invalid default_approval"},
+		{
+			name: "allow deny overlap",
+			access: &AccessProfile{
+				AllowedTools: stringListPointer("read"),
+				DeniedTools:  stringListPointer("read"),
+			},
+			expects: "cannot appear in both",
+		},
+		{
+			name: "approval for denied tool",
+			access: &AccessProfile{
+				DeniedTools:   stringListPointer("delete"),
+				ToolApprovals: approvalMapPointer(map[string]ApprovalBehavior{"delete": ApprovalBehaviorAlwaysPrompt}),
+			},
+			expects: "cannot configure denied tool",
+		},
+		{
+			name: "approval outside non-empty allowlist",
+			access: &AccessProfile{
+				AllowedTools:  stringListPointer("read"),
+				ToolApprovals: approvalMapPointer(map[string]ApprovalBehavior{"write": ApprovalBehaviorAlwaysPrompt}),
+			},
+			expects: "is not in allowed_tools",
+		},
+		{
+			name: "invalid tool approval",
+			access: &AccessProfile{
+				ToolApprovals: approvalMapPointer(map[string]ApprovalBehavior{"read": "approve"}),
+			},
+			expects: "invalid approval",
+		},
+		{
+			name: "blank approval tool",
+			access: &AccessProfile{
+				ToolApprovals: approvalMapPointer(map[string]ApprovalBehavior{"": ApprovalBehaviorAutomatic}),
+			},
+			expects: "tool_approvals names must be non-empty",
+		},
+		{
+			name: "padded approval tool",
+			access: &AccessProfile{
+				ToolApprovals: approvalMapPointer(map[string]ApprovalBehavior{" read ": ApprovalBehaviorAutomatic}),
+			},
+			expects: "must not have leading or trailing whitespace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := baseManifest()
+			m.Access = tt.access
+			err := m.Validate()
+			if err == nil || !strings.Contains(err.Error(), tt.expects) {
+				t.Fatalf("expected error containing %q, got: %v", tt.expects, err)
+			}
+		})
+	}
+}
+
+func TestApprovalBehaviorVocabulary(t *testing.T) {
+	valid := []ApprovalBehavior{
+		ApprovalBehaviorInherit,
+		ApprovalBehaviorAutomatic,
+		ApprovalBehaviorAlwaysPrompt,
+		ApprovalBehaviorAlwaysAllow,
+	}
+	for _, value := range valid {
+		m := baseManifest()
+		m.Access = &AccessProfile{DefaultApproval: approvalPointer(value)}
+		if err := m.Validate(); err != nil {
+			t.Fatalf("expected approval %q to validate: %v", value, err)
+		}
+	}
+	for _, value := range []ApprovalBehavior{"", "auto", "prompt", "approve", "prompt-on-write"} {
+		m := baseManifest()
+		m.Access = &AccessProfile{DefaultApproval: approvalPointer(value)}
+		if err := m.Validate(); err == nil {
+			t.Fatalf("expected non-portable approval %q to be rejected", value)
+		}
 	}
 }
 

--- a/internal/registry/parser.go
+++ b/internal/registry/parser.go
@@ -15,6 +15,8 @@ const (
 	sectionRequiredEnv = "required_env"
 	sectionSecretEnv   = "secret_env"
 	sectionSecretHdrs  = "secret_headers"
+	sectionAccess      = "access"
+	sectionAccessTools = "access.tool_approvals"
 )
 
 // ParseManifest parses a constrained TOML manifest format and rejects unknown fields.
@@ -27,6 +29,8 @@ func ParseManifest(data []byte) (Manifest, error) {
 	}
 
 	section := sectionTop
+	accessSectionSeen := false
+	accessToolsSectionSeen := false
 	scanner := bufio.NewScanner(strings.NewReader(string(data)))
 	lineNo := 0
 
@@ -50,6 +54,26 @@ func ParseManifest(data []byte) (Manifest, error) {
 			switch name {
 			case sectionEnv, sectionHeaders, sectionRequiredEnv, sectionSecretEnv, sectionSecretHdrs:
 				section = name
+			case sectionAccess:
+				if accessSectionSeen {
+					return Manifest{}, fmt.Errorf("line %d: duplicate section %q", lineNo, name)
+				}
+				accessSectionSeen = true
+				section = name
+				if m.Access == nil {
+					m.Access = &AccessProfile{}
+				}
+			case sectionAccessTools:
+				if accessToolsSectionSeen {
+					return Manifest{}, fmt.Errorf("line %d: duplicate section %q", lineNo, name)
+				}
+				accessToolsSectionSeen = true
+				section = name
+				if m.Access == nil {
+					m.Access = &AccessProfile{}
+				}
+				approvals := map[string]ApprovalBehavior{}
+				m.Access.ToolApprovals = &approvals
 			default:
 				return Manifest{}, fmt.Errorf("line %d: unknown section %q", lineNo, name)
 			}
@@ -108,6 +132,23 @@ func ParseManifest(data []byte) (Manifest, error) {
 				return Manifest{}, fmt.Errorf("line %d: invalid secret_headers keys: %w", lineNo, err)
 			}
 			m.SecretHeaders.Keys = arr
+		case sectionAccess:
+			if err := parseAccessKey(m.Access, key, value); err != nil {
+				return Manifest{}, fmt.Errorf("line %d: %w", lineNo, err)
+			}
+		case sectionAccessTools:
+			tool, err := parseDynamicTableKey(key)
+			if err != nil {
+				return Manifest{}, fmt.Errorf("line %d: invalid tool_approvals tool name: %w", lineNo, err)
+			}
+			approval, err := parseString(value)
+			if err != nil {
+				return Manifest{}, fmt.Errorf("line %d: invalid approval for tool %q: %w", lineNo, tool, err)
+			}
+			if _, exists := (*m.Access.ToolApprovals)[tool]; exists {
+				return Manifest{}, fmt.Errorf("line %d: duplicate tool_approvals tool %q", lineNo, tool)
+			}
+			(*m.Access.ToolApprovals)[tool] = ApprovalBehavior(approval)
 		default:
 			return Manifest{}, fmt.Errorf("line %d: unknown parse section", lineNo)
 		}
@@ -199,7 +240,99 @@ func MarshalManifest(m Manifest) ([]byte, error) {
 		fmt.Fprintf(&b, "keys = %s\n", formatStringArray(keys))
 	}
 
+	if m.Access != nil {
+		b.WriteString("\n[access]\n")
+		if m.Access.AllowedTools != nil {
+			values := append([]string(nil), (*m.Access.AllowedTools)...)
+			sort.Strings(values)
+			fmt.Fprintf(&b, "allowed_tools = %s\n", formatStringArray(values))
+		}
+		if m.Access.DeniedTools != nil {
+			values := append([]string(nil), (*m.Access.DeniedTools)...)
+			sort.Strings(values)
+			fmt.Fprintf(&b, "denied_tools = %s\n", formatStringArray(values))
+		}
+		if m.Access.OAuthScopes != nil {
+			values := append([]string(nil), (*m.Access.OAuthScopes)...)
+			sort.Strings(values)
+			fmt.Fprintf(&b, "oauth_scopes = %s\n", formatStringArray(values))
+		}
+		if m.Access.DefaultApproval != nil {
+			fmt.Fprintf(&b, "default_approval = %s\n", strconv.Quote(string(*m.Access.DefaultApproval)))
+		}
+		if m.Access.ToolApprovals != nil {
+			b.WriteString("\n[access.tool_approvals]\n")
+			tools := make([]string, 0, len(*m.Access.ToolApprovals))
+			for tool := range *m.Access.ToolApprovals {
+				tools = append(tools, tool)
+			}
+			sort.Strings(tools)
+			for _, tool := range tools {
+				fmt.Fprintf(&b, "%s = %s\n", strconv.Quote(tool), strconv.Quote(string((*m.Access.ToolApprovals)[tool])))
+			}
+		}
+	}
+
 	return []byte(b.String()), nil
+}
+
+func parseAccessKey(access *AccessProfile, key, value string) error {
+	if access == nil {
+		return fmt.Errorf("access profile is required")
+	}
+	switch key {
+	case "allowed_tools":
+		if access.AllowedTools != nil {
+			return fmt.Errorf("duplicate key %q in [access]", key)
+		}
+		values, err := parseStringArray(value)
+		if err != nil {
+			return fmt.Errorf("invalid access allowed_tools: %w", err)
+		}
+		access.AllowedTools = &values
+	case "denied_tools":
+		if access.DeniedTools != nil {
+			return fmt.Errorf("duplicate key %q in [access]", key)
+		}
+		values, err := parseStringArray(value)
+		if err != nil {
+			return fmt.Errorf("invalid access denied_tools: %w", err)
+		}
+		access.DeniedTools = &values
+	case "oauth_scopes":
+		if access.OAuthScopes != nil {
+			return fmt.Errorf("duplicate key %q in [access]", key)
+		}
+		values, err := parseStringArray(value)
+		if err != nil {
+			return fmt.Errorf("invalid access oauth_scopes: %w", err)
+		}
+		access.OAuthScopes = &values
+	case "default_approval":
+		if access.DefaultApproval != nil {
+			return fmt.Errorf("duplicate key %q in [access]", key)
+		}
+		parsed, err := parseString(value)
+		if err != nil {
+			return fmt.Errorf("invalid access default_approval: %w", err)
+		}
+		approval := ApprovalBehavior(parsed)
+		access.DefaultApproval = &approval
+	default:
+		return fmt.Errorf("unknown key %q in [access]", key)
+	}
+	return nil
+}
+
+func parseDynamicTableKey(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if strings.HasPrefix(raw, "\"") || strings.HasSuffix(raw, "\"") {
+		return parseString(raw)
+	}
+	if raw == "" {
+		return "", fmt.Errorf("empty key")
+	}
+	return raw, nil
 }
 
 func parseTopLevel(m *Manifest, key, value string) error {

--- a/internal/registry/parser_test.go
+++ b/internal/registry/parser_test.go
@@ -123,6 +123,137 @@ func TestParseAndMarshalRemoteManifestRoundTrip(t *testing.T) {
 	}
 }
 
+func TestParseAndMarshalAccessProfileRoundTrip(t *testing.T) {
+	payload := `name = "remote-tools"
+transport = "http"
+url = "https://example.com/mcp"
+enabled = true
+clients = ["codex"]
+
+[access]
+allowed_tools = ["repos.search", "issues.read"]
+denied_tools = ["issues.delete"]
+oauth_scopes = ["repo.read", "openid"]
+default_approval = "always-prompt"
+
+[access.tool_approvals]
+"repos.search" = "automatic"
+"issues.read" = "always-allow"
+`
+
+	manifest, err := ParseManifest([]byte(payload))
+	if err != nil {
+		t.Fatalf("parse access profile: %v", err)
+	}
+	if manifest.Access == nil || manifest.Access.AllowedTools == nil || manifest.Access.ToolApprovals == nil {
+		t.Fatalf("expected access profile presence to survive parse: %#v", manifest.Access)
+	}
+	if got := (*manifest.Access.ToolApprovals)["issues.read"]; got != ApprovalBehaviorAlwaysAllow {
+		t.Fatalf("unexpected dotted-tool approval: %q", got)
+	}
+
+	encoded, err := MarshalManifest(manifest)
+	if err != nil {
+		t.Fatalf("marshal access profile: %v", err)
+	}
+	wantAccess := `[access]
+allowed_tools = ["issues.read", "repos.search"]
+denied_tools = ["issues.delete"]
+oauth_scopes = ["openid", "repo.read"]
+default_approval = "always-prompt"
+
+[access.tool_approvals]
+"issues.read" = "always-allow"
+"repos.search" = "automatic"
+`
+	if !strings.Contains(string(encoded), wantAccess) {
+		t.Fatalf("expected deterministic access profile:\n%s\ngot:\n%s", wantAccess, encoded)
+	}
+
+	roundTripped, err := ParseManifest(encoded)
+	if err != nil {
+		t.Fatalf("parse marshaled access profile: %v", err)
+	}
+	if !accessProfilesEqual(manifest.Access, roundTripped.Access) {
+		t.Fatalf("access profile roundtrip mismatch: %#v vs %#v", manifest.Access, roundTripped.Access)
+	}
+}
+
+func TestParseAndMarshalAccessExplicitClears(t *testing.T) {
+	payload := `name = "tools"
+command = "/usr/bin/env"
+args = []
+enabled = true
+clients = ["codex"]
+
+[access]
+allowed_tools = []
+denied_tools = []
+oauth_scopes = []
+
+[access.tool_approvals]
+`
+	manifest, err := ParseManifest([]byte(payload))
+	if err != nil {
+		t.Fatalf("parse explicit access clears: %v", err)
+	}
+	if manifest.Access == nil || manifest.Access.AllowedTools == nil || manifest.Access.DeniedTools == nil || manifest.Access.OAuthScopes == nil || manifest.Access.ToolApprovals == nil {
+		t.Fatalf("expected every explicit clear to remain present: %#v", manifest.Access)
+	}
+	if manifest.HasExplicitToolAllowlist() {
+		t.Fatalf("empty allowed_tools is a clear, not a bounded allowlist")
+	}
+
+	encoded, err := MarshalManifest(manifest)
+	if err != nil {
+		t.Fatalf("marshal explicit access clears: %v", err)
+	}
+	for _, want := range []string{"allowed_tools = []", "denied_tools = []", "oauth_scopes = []", "[access.tool_approvals]"} {
+		if !strings.Contains(string(encoded), want) {
+			t.Fatalf("expected %q in marshaled clears:\n%s", want, encoded)
+		}
+	}
+	roundTripped, err := ParseManifest(encoded)
+	if err != nil {
+		t.Fatalf("parse marshaled clears: %v", err)
+	}
+	if !accessProfilesEqual(manifest.Access, roundTripped.Access) {
+		t.Fatalf("explicit clear presence changed after roundtrip")
+	}
+}
+
+func TestParseManifestRejectsInvalidAccessSyntax(t *testing.T) {
+	base := `name = "tools"
+command = "/usr/bin/env"
+args = []
+enabled = true
+clients = ["codex"]
+`
+	tests := []struct {
+		name    string
+		extra   string
+		expects string
+	}{
+		{name: "empty access", extra: "\n[access]\n", expects: "access must declare at least one field"},
+		{name: "unknown access key", extra: "\n[access]\nunknown = []\n", expects: `unknown key "unknown" in [access]`},
+		{name: "unknown nested section", extra: "\n[access.unknown]\nvalue = \"x\"\n", expects: "unknown section"},
+		{name: "duplicate access key", extra: "\n[access]\nallowed_tools = [\"read\"]\nallowed_tools = [\"search\"]\n", expects: `duplicate key "allowed_tools"`},
+		{name: "duplicate access section", extra: "\n[access]\nallowed_tools = [\"read\"]\n[access]\ndenied_tools = []\n", expects: "duplicate section"},
+		{name: "duplicate approvals section", extra: "\n[access.tool_approvals]\n\"read\" = \"automatic\"\n[access.tool_approvals]\n", expects: "duplicate section"},
+		{name: "duplicate approval tool", extra: "\n[access.tool_approvals]\n\"read\" = \"automatic\"\n\"read\" = \"always-prompt\"\n", expects: `duplicate tool_approvals tool "read"`},
+		{name: "malformed quoted tool", extra: "\n[access.tool_approvals]\n\"read = \"automatic\"\n", expects: "invalid tool_approvals tool name"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseManifest([]byte(base + tt.extra))
+			if err == nil || !strings.Contains(err.Error(), tt.expects) {
+				t.Fatalf("expected error containing %q, got: %v", tt.expects, err)
+			}
+		})
+	}
+}
+
 func TestParseManifestRejectsUnknownSection(t *testing.T) {
 	manifest := `
 name = "stewreads"

--- a/internal/registry/ring.go
+++ b/internal/registry/ring.go
@@ -18,6 +18,34 @@ type Ring struct {
 	Skills      []string      `toml:"skills,omitempty" json:"skills,omitempty"`
 	Description string        `toml:"description,omitempty" json:"description,omitempty"`
 	Contract    *RingContract `toml:"contract,omitempty" json:"contract,omitempty"`
+	Policy      *RingPolicy   `toml:"policy,omitempty" json:"policy,omitempty"`
+}
+
+const PolicyEnforcementRequired = "required"
+
+// RingPolicy declares whether access-profile compilation is mandatory for
+// operations that select this ring. Runtime execution policy is intentionally
+// reserved for a later contract version.
+type RingPolicy struct {
+	Enforcement string `toml:"enforcement" json:"enforcement"`
+}
+
+func (p *RingPolicy) Required() bool {
+	return p != nil && p.Enforcement == PolicyEnforcementRequired
+}
+
+func (p *RingPolicy) Validate() error {
+	if p == nil {
+		return nil
+	}
+	if p.Enforcement != PolicyEnforcementRequired {
+		return fmt.Errorf("policy enforcement must be %q", PolicyEnforcementRequired)
+	}
+	return nil
+}
+
+func (r Ring) RequiresPolicyEnforcement() bool {
+	return r.Policy.Required()
 }
 
 // RingContract is advisory metadata that helps an orchestrating agent decide
@@ -79,6 +107,9 @@ func (r Ring) Validate() error {
 			continue
 		}
 		seenSkills[skill] = struct{}{}
+	}
+	if err := r.Policy.Validate(); err != nil {
+		errs = append(errs, err.Error())
 	}
 
 	if len(errs) > 0 {
@@ -171,6 +202,8 @@ func ParseRing(data []byte) (Ring, error) {
 	ring := Ring{Members: []string{}, Skills: []string{}}
 
 	section := sectionTop
+	policySectionSeen := false
+	policyEnforcementSeen := false
 	scanner := bufio.NewScanner(strings.NewReader(string(data)))
 	lineNo := 0
 	for scanner.Scan() {
@@ -196,6 +229,15 @@ func ParseRing(data []byte) (Ring, error) {
 				if ring.Contract == nil {
 					ring.Contract = &RingContract{}
 				}
+			case "policy":
+				if policySectionSeen {
+					return Ring{}, fmt.Errorf("line %d: duplicate section %q", lineNo, name)
+				}
+				policySectionSeen = true
+				section = name
+				ring.Policy = &RingPolicy{}
+			case "policy.execution":
+				return Ring{}, fmt.Errorf("line %d: section %q is reserved for a future runtime policy contract and is not supported in policy V1", lineNo, name)
 			default:
 				return Ring{}, fmt.Errorf("line %d: unknown section %q", lineNo, name)
 			}
@@ -219,6 +261,19 @@ func ParseRing(data []byte) (Ring, error) {
 			if err := parseRingContract(ring.Contract, key, value); err != nil {
 				return Ring{}, fmt.Errorf("line %d: %w", lineNo, err)
 			}
+		case "policy":
+			if key != "enforcement" {
+				return Ring{}, fmt.Errorf("line %d: unknown key %q in [policy]", lineNo, key)
+			}
+			if policyEnforcementSeen {
+				return Ring{}, fmt.Errorf("line %d: duplicate key %q in [policy]", lineNo, key)
+			}
+			parsed, err := parseString(value)
+			if err != nil {
+				return Ring{}, fmt.Errorf("line %d: invalid policy enforcement: %w", lineNo, err)
+			}
+			policyEnforcementSeen = true
+			ring.Policy.Enforcement = parsed
 		default:
 			return Ring{}, fmt.Errorf("line %d: unknown parse section", lineNo)
 		}
@@ -337,6 +392,10 @@ func MarshalRing(ring Ring) ([]byte, error) {
 	if !ring.Contract.Empty() {
 		b.WriteString("\n[contract]\n")
 		writeRingContractFields(&b, ring.Contract)
+	}
+	if ring.Policy != nil {
+		b.WriteString("\n[policy]\n")
+		fmt.Fprintf(&b, "enforcement = %s\n", strconv.Quote(ring.Policy.Enforcement))
 	}
 	return []byte(b.String()), nil
 }

--- a/internal/registry/ring_store.go
+++ b/internal/registry/ring_store.go
@@ -31,6 +31,9 @@ func (s *Store) AddRing(ring Ring) error {
 	if err := s.ValidateRingMembers(ring); err != nil {
 		return err
 	}
+	if err := s.ValidateRingPolicy(ring); err != nil {
+		return err
+	}
 	return s.SaveRing(ring)
 }
 
@@ -158,6 +161,71 @@ func (s *Store) ValidateRingMembers(ring Ring) error {
 		return fmt.Errorf("ring %q references unknown skills: %s", ring.Name, strings.Join(missingSkills, ", "))
 	}
 	return nil
+}
+
+// ValidateRingPolicy checks the registry-level prerequisites for a
+// policy-required ring. Target-specific eligibility and compiler support are
+// operation-level checks; the store only requires every referenced server to
+// carry an explicit non-empty exact allowlist.
+func (s *Store) ValidateRingPolicy(ring Ring) error {
+	if !ring.RequiresPolicyEnforcement() {
+		return nil
+	}
+	manifests := make([]Manifest, 0, len(ring.Members))
+	for _, member := range ring.Members {
+		manifest, err := s.Get(strings.TrimSpace(member))
+		if err != nil {
+			if errors.Is(err, ErrNotFound) {
+				return fmt.Errorf("ring %q policy requires unknown server %q", ring.Name, strings.TrimSpace(member))
+			}
+			return err
+		}
+		manifests = append(manifests, manifest)
+	}
+	return ValidateRequiredRingAccess(ring, manifests)
+}
+
+// ValidateRequiredRingAccess validates the registry-level bounded-access
+// invariant against a manifest set. It is shared by store and snapshot paths
+// so both reject an invalid required ring before writing anything.
+func ValidateRequiredRingAccess(ring Ring, manifests []Manifest) error {
+	byName := make(map[string]Manifest, len(manifests))
+	for _, manifest := range manifests {
+		byName[manifest.Name] = manifest
+	}
+	return validateRequiredRingAccessAgainst(ring, byName)
+}
+
+func validateRequiredRingAccessAgainst(ring Ring, manifests map[string]Manifest) error {
+	if !ring.RequiresPolicyEnforcement() {
+		return nil
+	}
+	var missing []string
+	var unbounded []string
+	for _, member := range ring.Members {
+		name := strings.TrimSpace(member)
+		manifest, exists := manifests[name]
+		if !exists {
+			missing = append(missing, name)
+			continue
+		}
+		if !manifest.HasExplicitToolAllowlist() {
+			unbounded = append(unbounded, name)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(unbounded)
+	var errs []string
+	if len(missing) > 0 {
+		errs = append(errs, fmt.Sprintf("unknown servers: %s", strings.Join(missing, ", ")))
+	}
+	if len(unbounded) > 0 {
+		errs = append(errs, fmt.Sprintf("servers without an explicit non-empty allowed_tools allowlist: %s", strings.Join(unbounded, ", ")))
+	}
+	if len(errs) == 0 {
+		return nil
+	}
+	return fmt.Errorf("ring %q requires policy enforcement but has %s", ring.Name, strings.Join(errs, "; "))
 }
 
 func (s *Store) pathForRing(name string) (string, error) {

--- a/internal/registry/ring_store_test.go
+++ b/internal/registry/ring_store_test.go
@@ -109,6 +109,71 @@ func TestAddRingRejectsUnknownSkills(t *testing.T) {
 	}
 }
 
+func TestAddRequiredRingRejectsUnboundedMembers(t *testing.T) {
+	store := newRingTestStore(t)
+	ring := Ring{
+		Name:    "bounded",
+		Members: []string{"stewreads", "arxiv"},
+		Policy:  &RingPolicy{Enforcement: PolicyEnforcementRequired},
+	}
+	err := store.AddRing(ring)
+	if err == nil || !strings.Contains(err.Error(), "servers without an explicit non-empty allowed_tools allowlist: arxiv, stewreads") {
+		t.Fatalf("expected sorted unbounded-member rejection, got: %v", err)
+	}
+	if _, getErr := store.GetRing("bounded"); !errors.Is(getErr, ErrRingNotFound) {
+		t.Fatalf("required ring validation failure must write nothing, got: %v", getErr)
+	}
+}
+
+func TestAddRequiredRingAcceptsBoundedMembers(t *testing.T) {
+	store := newRingTestStore(t)
+	for _, name := range []string{"stewreads", "arxiv"} {
+		manifest, err := store.Get(name)
+		if err != nil {
+			t.Fatalf("get manifest %s: %v", name, err)
+		}
+		manifest.Access = &AccessProfile{AllowedTools: stringListPointer("read")}
+		if err := store.Save(manifest); err != nil {
+			t.Fatalf("save bounded manifest %s: %v", name, err)
+		}
+	}
+	ring := Ring{
+		Name:    "bounded",
+		Members: []string{"stewreads", "arxiv"},
+		Policy:  &RingPolicy{Enforcement: PolicyEnforcementRequired},
+	}
+	if err := store.AddRing(ring); err != nil {
+		t.Fatalf("add bounded required ring: %v", err)
+	}
+	got, err := store.GetRing("bounded")
+	if err != nil {
+		t.Fatalf("get bounded required ring: %v", err)
+	}
+	if !got.RequiresPolicyEnforcement() {
+		t.Fatalf("expected required policy to persist: %#v", got.Policy)
+	}
+}
+
+func TestAddRequiredRingRejectsExplicitEmptyAllowlist(t *testing.T) {
+	store := newRingTestStore(t)
+	manifest, err := store.Get("stewreads")
+	if err != nil {
+		t.Fatalf("get manifest: %v", err)
+	}
+	manifest.Access = &AccessProfile{AllowedTools: stringListPointer()}
+	if err := store.Save(manifest); err != nil {
+		t.Fatalf("save explicit allowlist clear: %v", err)
+	}
+	err = store.AddRing(Ring{
+		Name:    "bounded",
+		Members: []string{"stewreads"},
+		Policy:  &RingPolicy{Enforcement: PolicyEnforcementRequired},
+	})
+	if err == nil || !strings.Contains(err.Error(), "without an explicit non-empty allowed_tools") {
+		t.Fatalf("expected explicit empty allowlist rejection, got: %v", err)
+	}
+}
+
 func TestListRingsEmptyWithoutDirectory(t *testing.T) {
 	store := NewStore(filepath.Join(t.TempDir(), "servers"))
 	rings, err := store.ListRings()

--- a/internal/registry/ring_test.go
+++ b/internal/registry/ring_test.go
@@ -20,6 +20,7 @@ func TestParseAndMarshalRingRoundTrip(t *testing.T) {
 			OptionalContext: []string{"artifact id", "request id"},
 			ExpectedOutputs: []string{"findings summary", "recommended next check"},
 		},
+		Policy: &RingPolicy{Enforcement: PolicyEnforcementRequired},
 	}
 
 	encoded, err := MarshalRing(in)
@@ -42,6 +43,9 @@ func TestParseAndMarshalRingRoundTrip(t *testing.T) {
 	}
 	if !ringContractsEqual(out.Contract, in.Contract) {
 		t.Fatalf("expected contract to survive roundtrip, got: %#v", out.Contract)
+	}
+	if !ringPoliciesEqual(out.Policy, in.Policy) {
+		t.Fatalf("expected policy to survive roundtrip, got: %#v", out.Policy)
 	}
 }
 
@@ -95,6 +99,79 @@ expected_outputs = ["findings", "evidence", "next check"]
 `
 	if string(encoded) != expected {
 		t.Fatalf("expected contract order to be preserved:\n%s\ngot:\n%s", expected, encoded)
+	}
+}
+
+func TestParseAndMarshalRequiredRingPolicy(t *testing.T) {
+	payload := `name = "bounded"
+members = ["tools"]
+
+[policy]
+enforcement = "required"
+`
+	ring, err := ParseRing([]byte(payload))
+	if err != nil {
+		t.Fatalf("parse policy ring: %v", err)
+	}
+	if !ring.RequiresPolicyEnforcement() || ring.Policy == nil || !ring.Policy.Required() {
+		t.Fatalf("expected required policy, got: %#v", ring.Policy)
+	}
+	encoded, err := MarshalRing(ring)
+	if err != nil {
+		t.Fatalf("marshal policy ring: %v", err)
+	}
+	if string(encoded) != payload {
+		t.Fatalf("policy ring output drift:\nwant:\n%s\ngot:\n%s", payload, encoded)
+	}
+}
+
+func TestMarshalRingOrdersContractBeforePolicy(t *testing.T) {
+	ring := Ring{
+		Name:     "bounded",
+		Members:  []string{"tools"},
+		Contract: &RingContract{Summary: "Use bounded tools"},
+		Policy:   &RingPolicy{Enforcement: PolicyEnforcementRequired},
+	}
+	encoded, err := MarshalRing(ring)
+	if err != nil {
+		t.Fatalf("marshal contract and policy: %v", err)
+	}
+	want := `name = "bounded"
+members = ["tools"]
+
+[contract]
+summary = "Use bounded tools"
+
+[policy]
+enforcement = "required"
+`
+	if string(encoded) != want {
+		t.Fatalf("contract/policy order drift:\nwant:\n%s\ngot:\n%s", want, encoded)
+	}
+}
+
+func TestParseRingRejectsInvalidPolicy(t *testing.T) {
+	base := "name = \"bounded\"\nmembers = [\"tools\"]\n"
+	tests := []struct {
+		name    string
+		extra   string
+		expects string
+	}{
+		{name: "missing enforcement", extra: "\n[policy]\n", expects: `policy enforcement must be "required"`},
+		{name: "invalid enforcement", extra: "\n[policy]\nenforcement = \"best-effort\"\n", expects: `policy enforcement must be "required"`},
+		{name: "padded enforcement", extra: "\n[policy]\nenforcement = \" required \"\n", expects: `policy enforcement must be "required"`},
+		{name: "unknown key", extra: "\n[policy]\nunknown = \"value\"\n", expects: `unknown key "unknown" in [policy]`},
+		{name: "duplicate key", extra: "\n[policy]\nenforcement = \"required\"\nenforcement = \"required\"\n", expects: `duplicate key "enforcement"`},
+		{name: "duplicate section", extra: "\n[policy]\nenforcement = \"required\"\n[policy]\n", expects: `duplicate section "policy"`},
+		{name: "reserved execution", extra: "\n[policy.execution]\nmode = \"sandbox\"\n", expects: `section "policy.execution" is reserved`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseRing([]byte(base + tt.extra))
+			if err == nil || !strings.Contains(err.Error(), tt.expects) {
+				t.Fatalf("expected error containing %q, got: %v", tt.expects, err)
+			}
+		})
 	}
 }
 
@@ -251,6 +328,11 @@ func TestRingValidate(t *testing.T) {
 			name:    "invalid skill name",
 			mutate:  func(r *Ring) { r.Members = nil; r.Skills = []string{"Not Valid"} },
 			expects: "invalid skill",
+		},
+		{
+			name:    "invalid policy enforcement",
+			mutate:  func(r *Ring) { r.Policy = &RingPolicy{Enforcement: "best-effort"} },
+			expects: "policy enforcement must be",
 		},
 	}
 

--- a/internal/registry/snapshot.go
+++ b/internal/registry/snapshot.go
@@ -1,9 +1,11 @@
 package registry
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"slices"
 	"sort"
@@ -26,7 +28,11 @@ const (
 	snapshotVersionV8 = 8
 	// SnapshotVersion 9 adds bearer_token_env_var; older importers reject by
 	// version instead of silently dropping the runtime auth env reference.
-	SnapshotVersion = 9
+	snapshotVersionV9 = 9
+	// SnapshotVersion 10 adds server access profiles and required ring policy;
+	// older importers reject v10 rather than silently widening access by
+	// dropping policy declarations.
+	SnapshotVersion = 10
 )
 
 type Snapshot struct {
@@ -86,8 +92,10 @@ func ExportSnapshot(store *Store) (Snapshot, error) {
 	// in the exported primitive sets, or the fresh import of this backup would
 	// be refused. Fail loudly instead of writing a broken artifact.
 	exportableServers := make(map[string]struct{}, len(servers))
+	exportableManifests := make(map[string]Manifest, len(servers))
 	for _, server := range servers {
 		exportableServers[server.Name] = struct{}{}
+		exportableManifests[server.Name] = server
 	}
 	exportableSkills := make(map[string]struct{}, len(skills))
 	for _, skill := range skills {
@@ -96,6 +104,9 @@ func ExportSnapshot(store *Store) (Snapshot, error) {
 	for _, ring := range rings {
 		if err := validateRingReferencesAgainst(ring, exportableServers, exportableSkills); err != nil {
 			return Snapshot{}, fmt.Errorf("%w; update or delete the ring before exporting", err)
+		}
+		if err := validateRequiredRingAccessAgainst(ring, exportableManifests); err != nil {
+			return Snapshot{}, fmt.Errorf("%w; update the ring or its server access profiles before exporting", err)
 		}
 	}
 
@@ -136,7 +147,19 @@ func ParseSnapshotJSON(payload []byte) (Snapshot, error) {
 		return Snapshot{}, fmt.Errorf("snapshot payload is empty")
 	}
 	var snapshot Snapshot
-	if err := json.Unmarshal(payload, &snapshot); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&snapshot); err != nil {
+		return Snapshot{}, fmt.Errorf("parse snapshot json: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return Snapshot{}, fmt.Errorf("parse snapshot json: trailing data after snapshot document")
+		}
+		return Snapshot{}, fmt.Errorf("parse snapshot json: trailing data: %w", err)
+	}
+	if err := validateSnapshotPolicyPresence(payload); err != nil {
 		return Snapshot{}, fmt.Errorf("parse snapshot json: %w", err)
 	}
 	if snapshot.Version == 0 {
@@ -155,6 +178,68 @@ func ParseSnapshotJSON(payload []byte) (Snapshot, error) {
 		return Snapshot{}, err
 	}
 	return snapshot, nil
+}
+
+// validateSnapshotPolicyPresence rejects explicit JSON null values on V10
+// fields whose presence has policy meaning. The ordinary encoding/json pointer
+// decoder maps both an omitted field and an explicit null to nil; accepting
+// null would therefore turn an explicit declaration into legacy absence.
+func validateSnapshotPolicyPresence(payload []byte) error {
+	var raw struct {
+		Servers []json.RawMessage `json:"servers"`
+		Rings   []json.RawMessage `json:"rings"`
+	}
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		return err
+	}
+	for i, serverRaw := range raw.Servers {
+		server, err := rawJSONObject(serverRaw)
+		if err != nil {
+			return fmt.Errorf("servers[%d]: %w", i, err)
+		}
+		accessRaw, exists := server["access"]
+		if !exists {
+			continue
+		}
+		if rawJSONNull(accessRaw) {
+			return fmt.Errorf("servers[%d].access must not be null; omit it for legacy absence", i)
+		}
+		access, err := rawJSONObject(accessRaw)
+		if err != nil {
+			return fmt.Errorf("servers[%d].access: %w", i, err)
+		}
+		for _, field := range []string{"allowed_tools", "denied_tools", "oauth_scopes", "default_approval", "tool_approvals"} {
+			value, exists := access[field]
+			if exists && rawJSONNull(value) {
+				return fmt.Errorf("servers[%d].access.%s must not be null; omit it for absence or use an explicit clear value", i, field)
+			}
+		}
+	}
+	for i, ringRaw := range raw.Rings {
+		ring, err := rawJSONObject(ringRaw)
+		if err != nil {
+			return fmt.Errorf("rings[%d]: %w", i, err)
+		}
+		if policyRaw, exists := ring["policy"]; exists && rawJSONNull(policyRaw) {
+			return fmt.Errorf("rings[%d].policy must not be null; omit it for advisory behavior", i)
+		}
+	}
+	return nil
+}
+
+func rawJSONObject(raw json.RawMessage) (map[string]json.RawMessage, error) {
+	value := map[string]json.RawMessage{}
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("expected object: %w", err)
+	}
+	if value == nil {
+		return nil, fmt.Errorf("expected object")
+	}
+	return value, nil
+}
+
+func rawJSONNull(raw json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(raw), []byte("null"))
 }
 
 func ImportSnapshot(store *Store, snapshot Snapshot, apply bool) (ImportResult, error) {
@@ -211,6 +296,35 @@ func ImportSnapshot(store *Store, snapshot Snapshot, apply bool) (ImportResult, 
 	}
 	for _, ring := range snapshot.Rings {
 		if err := validateRingReferencesAgainst(ring, allowedMembers, allowedSkills); err != nil {
+			return ImportResult{}, err
+		}
+	}
+
+	// Validate policy against the final registry state before any write. An
+	// incoming manifest may replace the access profile used by an existing
+	// required ring, and an incoming ring may reference a manifest that remains
+	// local rather than appearing in the snapshot.
+	finalManifests := make(map[string]Manifest, len(existingByName)+len(snapshot.Servers))
+	for name, manifest := range existingByName {
+		finalManifests[name] = manifest
+	}
+	for _, manifest := range snapshot.Servers {
+		finalManifests[manifest.Name] = manifest
+	}
+	finalRings := make(map[string]Ring, len(existingRingsByName)+len(snapshot.Rings))
+	for name, ring := range existingRingsByName {
+		finalRings[name] = ring
+	}
+	for _, ring := range snapshot.Rings {
+		finalRings[ring.Name] = ring
+	}
+	finalRingNames := make([]string, 0, len(finalRings))
+	for name := range finalRings {
+		finalRingNames = append(finalRingNames, name)
+	}
+	sort.Strings(finalRingNames)
+	for _, name := range finalRingNames {
+		if err := validateRequiredRingAccessAgainst(finalRings[name], finalManifests); err != nil {
 			return ImportResult{}, err
 		}
 	}
@@ -320,7 +434,7 @@ func ImportSnapshot(store *Store, snapshot Snapshot, apply bool) (ImportResult, 
 }
 
 func (s Snapshot) Validate() error {
-	if s.Version != snapshotVersionV1 && s.Version != snapshotVersionV2 && s.Version != snapshotVersionV3 && s.Version != snapshotVersionV4 && s.Version != snapshotVersionV5 && s.Version != snapshotVersionV6 && s.Version != snapshotVersionV7 && s.Version != snapshotVersionV8 && s.Version != SnapshotVersion {
+	if s.Version != snapshotVersionV1 && s.Version != snapshotVersionV2 && s.Version != snapshotVersionV3 && s.Version != snapshotVersionV4 && s.Version != snapshotVersionV5 && s.Version != snapshotVersionV6 && s.Version != snapshotVersionV7 && s.Version != snapshotVersionV8 && s.Version != snapshotVersionV9 && s.Version != SnapshotVersion {
 		return fmt.Errorf("unsupported snapshot version %d (supported: %d)", s.Version, SnapshotVersion)
 	}
 	if s.Version == snapshotVersionV1 && len(s.Rings) > 0 {
@@ -341,8 +455,14 @@ func (s Snapshot) Validate() error {
 	if s.Version < snapshotVersionV8 && snapshotHasSecretHeaders(s) {
 		return fmt.Errorf("snapshot version %d does not support secret_headers", s.Version)
 	}
-	if s.Version < SnapshotVersion && snapshotHasBearerTokenEnv(s) {
+	if s.Version < snapshotVersionV9 && snapshotHasBearerTokenEnv(s) {
 		return fmt.Errorf("snapshot version %d does not support bearer_token_env_var", s.Version)
+	}
+	if s.Version < SnapshotVersion && snapshotHasAccessProfiles(s) {
+		return fmt.Errorf("snapshot version %d does not support server access profiles", s.Version)
+	}
+	if s.Version < SnapshotVersion && snapshotHasRingPolicies(s) {
+		return fmt.Errorf("snapshot version %d does not support ring policies", s.Version)
 	}
 
 	seen := map[string]struct{}{}
@@ -474,7 +594,7 @@ func manifestsEqual(a, b Manifest) bool {
 	bSecretHeaders := append([]string(nil), b.SecretHeaders.Keys...)
 	sort.Strings(aSecretHeaders)
 	sort.Strings(bSecretHeaders)
-	return slices.Equal(aSecretHeaders, bSecretHeaders)
+	return slices.Equal(aSecretHeaders, bSecretHeaders) && accessProfilesEqual(a.Access, b.Access)
 }
 
 func ringsEqual(a, b Ring) bool {
@@ -488,7 +608,55 @@ func ringsEqual(a, b Ring) bool {
 	}
 	aSkills := normalizedRingSkills(a)
 	bSkills := normalizedRingSkills(b)
-	return slices.Equal(aSkills, bSkills) && ringContractsEqual(a.Contract, b.Contract)
+	return slices.Equal(aSkills, bSkills) && ringContractsEqual(a.Contract, b.Contract) && ringPoliciesEqual(a.Policy, b.Policy)
+}
+
+func accessProfilesEqual(a, b *AccessProfile) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	if !optionalStringSetsEqual(a.AllowedTools, b.AllowedTools) ||
+		!optionalStringSetsEqual(a.DeniedTools, b.DeniedTools) ||
+		!optionalStringSetsEqual(a.OAuthScopes, b.OAuthScopes) {
+		return false
+	}
+	if a.DefaultApproval == nil || b.DefaultApproval == nil {
+		if a.DefaultApproval != nil || b.DefaultApproval != nil {
+			return false
+		}
+	} else if *a.DefaultApproval != *b.DefaultApproval {
+		return false
+	}
+	if a.ToolApprovals == nil || b.ToolApprovals == nil {
+		return a.ToolApprovals == nil && b.ToolApprovals == nil
+	}
+	if len(*a.ToolApprovals) != len(*b.ToolApprovals) {
+		return false
+	}
+	for tool, approval := range *a.ToolApprovals {
+		if other, exists := (*b.ToolApprovals)[tool]; !exists || other != approval {
+			return false
+		}
+	}
+	return true
+}
+
+func optionalStringSetsEqual(a, b *[]string) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	aValues := append([]string(nil), (*a)...)
+	bValues := append([]string(nil), (*b)...)
+	sort.Strings(aValues)
+	sort.Strings(bValues)
+	return slices.Equal(aValues, bValues)
+}
+
+func ringPoliciesEqual(a, b *RingPolicy) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.Enforcement == b.Enforcement
 }
 
 func ringContractsEqual(a, b *RingContract) bool {
@@ -648,6 +816,24 @@ func snapshotHasSecretHeaders(snapshot Snapshot) bool {
 func snapshotHasBearerTokenEnv(snapshot Snapshot) bool {
 	for _, server := range snapshot.Servers {
 		if strings.TrimSpace(server.BearerTokenEnvVar) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func snapshotHasAccessProfiles(snapshot Snapshot) bool {
+	for _, server := range snapshot.Servers {
+		if server.Access != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func snapshotHasRingPolicies(snapshot Snapshot) bool {
+	for _, ring := range snapshot.Rings {
+		if ring.Policy != nil {
 			return true
 		}
 	}

--- a/internal/registry/snapshot_test.go
+++ b/internal/registry/snapshot_test.go
@@ -16,6 +16,9 @@ func TestSnapshotExportParseRoundTrip(t *testing.T) {
 		Command: "/usr/bin/env",
 		Enabled: true,
 		Clients: []string{"claude-desktop"},
+		Access: &AccessProfile{
+			AllowedTools: stringListPointer("read", "search"),
+		},
 	}); err != nil {
 		t.Fatalf("save alpha manifest: %v", err)
 	}
@@ -24,6 +27,9 @@ func TestSnapshotExportParseRoundTrip(t *testing.T) {
 		Command: "/usr/bin/env",
 		Enabled: false,
 		Clients: []string{"claude-desktop"},
+		Access: &AccessProfile{
+			AllowedTools: stringListPointer("inspect"),
+		},
 	}); err != nil {
 		t.Fatalf("save beta manifest: %v", err)
 	}
@@ -38,6 +44,7 @@ func TestSnapshotExportParseRoundTrip(t *testing.T) {
 			RequiredContext: []string{"research question"},
 			ExpectedOutputs: []string{"findings summary"},
 		},
+		Policy: &RingPolicy{Enforcement: PolicyEnforcementRequired},
 	}); err != nil {
 		t.Fatalf("save ring: %v", err)
 	}
@@ -83,6 +90,12 @@ func TestSnapshotExportParseRoundTrip(t *testing.T) {
 	if parsed.Rings[0].Contract == nil || parsed.Rings[0].Contract.Summary != "Collect research evidence" {
 		t.Fatalf("expected ring contract in parsed snapshot, got: %#v", parsed.Rings[0].Contract)
 	}
+	if !parsed.Rings[0].RequiresPolicyEnforcement() {
+		t.Fatalf("expected required ring policy in parsed snapshot, got: %#v", parsed.Rings[0].Policy)
+	}
+	if parsed.Servers[0].Access == nil && parsed.Servers[1].Access == nil {
+		t.Fatalf("expected server access profiles in parsed snapshot: %#v", parsed.Servers)
+	}
 	if len(parsed.Skills) != 1 || parsed.Skills[0].Name != "release" {
 		t.Fatalf("expected release skill in parsed snapshot, got: %#v", parsed.Skills)
 	}
@@ -111,6 +124,14 @@ func TestMarshalSnapshotUsesSnakeCaseKeys(t *testing.T) {
 				RequiredEnv: RequiredEnv{
 					Keys: []string{"SMTP_PASSWORD"},
 				},
+				Access: &AccessProfile{
+					AllowedTools:    stringListPointer("read"),
+					DeniedTools:     stringListPointer("delete"),
+					DefaultApproval: approvalPointer(ApprovalBehaviorAlwaysPrompt),
+					ToolApprovals: approvalMapPointer(map[string]ApprovalBehavior{
+						"read": ApprovalBehaviorAlwaysAllow,
+					}),
+				},
 			},
 		},
 		Rings: []Ring{
@@ -127,6 +148,7 @@ func TestMarshalSnapshotUsesSnakeCaseKeys(t *testing.T) {
 					OptionalContext: []string{"time window"},
 					ExpectedOutputs: []string{"findings summary"},
 				},
+				Policy: &RingPolicy{Enforcement: PolicyEnforcementRequired},
 			},
 		},
 		Skills: []SnapshotSkill{
@@ -145,7 +167,7 @@ func TestMarshalSnapshotUsesSnakeCaseKeys(t *testing.T) {
 		t.Fatalf("marshal snapshot failed: %v", err)
 	}
 	text := string(payload)
-	for _, key := range []string{`"name"`, `"command"`, `"args"`, `"enabled"`, `"clients"`, `"required_env"`, `"keys"`, `"rings"`, `"members"`, `"skills"`, `"files"`, `"path"`, `"content"`, `"mode"`, `"description"`, `"contract"`, `"summary"`, `"good_for"`, `"not_for"`, `"required_context"`, `"optional_context"`, `"expected_outputs"`} {
+	for _, key := range []string{`"name"`, `"command"`, `"args"`, `"enabled"`, `"clients"`, `"required_env"`, `"keys"`, `"access"`, `"allowed_tools"`, `"denied_tools"`, `"default_approval"`, `"tool_approvals"`, `"rings"`, `"members"`, `"policy"`, `"enforcement"`, `"skills"`, `"files"`, `"path"`, `"content"`, `"mode"`, `"description"`, `"contract"`, `"summary"`, `"good_for"`, `"not_for"`, `"required_context"`, `"optional_context"`, `"expected_outputs"`} {
 		if !strings.Contains(text, key) {
 			t.Fatalf("expected payload to contain key %s, payload=%s", key, text)
 		}
@@ -250,6 +272,43 @@ func TestParseSnapshotV9AcceptsBearerTokenEnv(t *testing.T) {
 	}
 	if len(snapshot.Servers) != 1 || snapshot.Servers[0].BearerTokenEnvVar != "CLOUDSQL_MCP_TOKEN" {
 		t.Fatalf("expected bearer_token_env_var to parse, got: %#v", snapshot.Servers)
+	}
+}
+
+func TestParseSnapshotV9RejectsAccessProfilesAndRingPolicies(t *testing.T) {
+	accessPayload := []byte(`{"version":9,"servers":[{"name":"alpha","command":"/usr/bin/env","enabled":true,"clients":["codex"],"access":{"allowed_tools":["read"]}}]}`)
+	if _, err := ParseSnapshotJSON(accessPayload); err == nil || !strings.Contains(err.Error(), "does not support server access profiles") {
+		t.Fatalf("expected v9 access-profile rejection, got: %v", err)
+	}
+
+	policyPayload := []byte(`{"version":9,"servers":[],"rings":[{"name":"bounded","skills":["release"],"policy":{"enforcement":"required"}}],"skills":[{"name":"release","content":"# Release\n"}]}`)
+	if _, err := ParseSnapshotJSON(policyPayload); err == nil || !strings.Contains(err.Error(), "does not support ring policies") {
+		t.Fatalf("expected v9 ring-policy rejection, got: %v", err)
+	}
+}
+
+func TestParseSnapshotV10AcceptsAccessProfilesAndRingPolicies(t *testing.T) {
+	payload := []byte(`{"version":10,"servers":[{"name":"alpha","command":"/usr/bin/env","enabled":true,"clients":["codex"],"access":{"allowed_tools":["read"],"denied_tools":[],"oauth_scopes":[],"default_approval":"always-prompt","tool_approvals":{}}}],"rings":[{"name":"bounded","members":["alpha"],"policy":{"enforcement":"required"}}],"skills":[]}`)
+	snapshot, err := ParseSnapshotJSON(payload)
+	if err != nil {
+		t.Fatalf("parse v10 policy snapshot: %v", err)
+	}
+	access := snapshot.Servers[0].Access
+	if access == nil || access.AllowedTools == nil || access.DeniedTools == nil || access.OAuthScopes == nil || access.ToolApprovals == nil {
+		t.Fatalf("expected v10 access field presence, got: %#v", access)
+	}
+	if !snapshot.Rings[0].RequiresPolicyEnforcement() {
+		t.Fatalf("expected v10 required ring policy: %#v", snapshot.Rings[0].Policy)
+	}
+
+	encoded, err := MarshalSnapshotJSON(snapshot)
+	if err != nil {
+		t.Fatalf("marshal v10 policy snapshot: %v", err)
+	}
+	for _, want := range []string{`"allowed_tools": [`, `"denied_tools": []`, `"oauth_scopes": []`, `"tool_approvals": {}`, `"enforcement": "required"`} {
+		if !strings.Contains(string(encoded), want) {
+			t.Fatalf("expected %s in v10 snapshot:\n%s", want, encoded)
+		}
 	}
 }
 
@@ -406,6 +465,146 @@ func TestImportSnapshotDetectsRemoteFieldChanges(t *testing.T) {
 	}
 	if len(result.Updated) != 0 || len(result.Unchanged) != 1 {
 		t.Fatalf("expected identical snapshot to be unchanged, got: %+v", result)
+	}
+}
+
+func TestImportSnapshotDetectsAccessAndPolicyChanges(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "servers"))
+	if err := store.Save(Manifest{
+		Name:    "alpha",
+		Command: "/usr/bin/env",
+		Enabled: true,
+		Clients: []string{"codex"},
+		Access:  &AccessProfile{AllowedTools: stringListPointer("read")},
+	}); err != nil {
+		t.Fatalf("save initial manifest: %v", err)
+	}
+	if err := store.SaveRing(Ring{Name: "bounded", Members: []string{"alpha"}}); err != nil {
+		t.Fatalf("save initial ring: %v", err)
+	}
+
+	snapshot := Snapshot{
+		Version: SnapshotVersion,
+		Servers: []Manifest{
+			{
+				Name:    "alpha",
+				Command: "/usr/bin/env",
+				Enabled: true,
+				Clients: []string{"codex"},
+				Access: &AccessProfile{
+					AllowedTools: stringListPointer("read"),
+					DeniedTools:  stringListPointer(),
+				},
+			},
+		},
+		Rings: []Ring{
+			{
+				Name:    "bounded",
+				Members: []string{"alpha"},
+				Policy:  &RingPolicy{Enforcement: PolicyEnforcementRequired},
+			},
+		},
+	}
+
+	result, err := ImportSnapshot(store, snapshot, true)
+	if err != nil {
+		t.Fatalf("import access/policy changes: %v", err)
+	}
+	if len(result.Updated) != 1 || result.Updated[0] != "alpha" {
+		t.Fatalf("expected access-only server update, got: %+v", result)
+	}
+	if len(result.RingsUpdated) != 1 || result.RingsUpdated[0] != "bounded" {
+		t.Fatalf("expected policy-only ring update, got: %+v", result)
+	}
+	manifest, err := store.Get("alpha")
+	if err != nil {
+		t.Fatalf("get imported manifest: %v", err)
+	}
+	if manifest.Access == nil || manifest.Access.DeniedTools == nil || len(*manifest.Access.DeniedTools) != 0 {
+		t.Fatalf("expected explicit denied_tools clear to persist: %#v", manifest.Access)
+	}
+	ring, err := store.GetRing("bounded")
+	if err != nil {
+		t.Fatalf("get imported ring: %v", err)
+	}
+	if !ring.RequiresPolicyEnforcement() {
+		t.Fatalf("expected imported required policy: %#v", ring.Policy)
+	}
+
+	result, err = ImportSnapshot(store, snapshot, false)
+	if err != nil {
+		t.Fatalf("repeat dry-run import: %v", err)
+	}
+	if len(result.Unchanged) != 1 || len(result.RingsUnchanged) != 1 {
+		t.Fatalf("expected identical access/policy snapshot unchanged, got: %+v", result)
+	}
+}
+
+func TestImportSnapshotPolicyPrevalidationUsesFinalStateBeforeWrites(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "servers"))
+	if err := store.Save(Manifest{
+		Name:    "alpha",
+		Command: "/usr/bin/env",
+		Enabled: true,
+		Clients: []string{"codex"},
+		Access:  &AccessProfile{AllowedTools: stringListPointer("read")},
+	}); err != nil {
+		t.Fatalf("save initial manifest: %v", err)
+	}
+	if err := store.SaveRing(Ring{
+		Name:    "bounded",
+		Members: []string{"alpha"},
+		Policy:  &RingPolicy{Enforcement: PolicyEnforcementRequired},
+	}); err != nil {
+		t.Fatalf("save required ring: %v", err)
+	}
+
+	snapshot := Snapshot{
+		Version: SnapshotVersion,
+		Servers: []Manifest{
+			{
+				Name:    "alpha",
+				Command: "/usr/bin/env",
+				Enabled: true,
+				Clients: []string{"codex"},
+				Access:  &AccessProfile{AllowedTools: stringListPointer()},
+			},
+			{
+				Name:    "beta",
+				Command: "/usr/bin/env",
+				Enabled: true,
+				Clients: []string{"codex"},
+			},
+		},
+	}
+
+	_, err := ImportSnapshot(store, snapshot, true)
+	if err == nil || !strings.Contains(err.Error(), "without an explicit non-empty allowed_tools allowlist: alpha") {
+		t.Fatalf("expected final-state policy rejection, got: %v", err)
+	}
+	alpha, getErr := store.Get("alpha")
+	if getErr != nil {
+		t.Fatalf("get alpha after rejected import: %v", getErr)
+	}
+	if !alpha.HasExplicitToolAllowlist() || len(*alpha.Access.AllowedTools) != 1 || (*alpha.Access.AllowedTools)[0] != "read" {
+		t.Fatalf("rejected import changed alpha: %#v", alpha.Access)
+	}
+	if _, getErr := store.Get("beta"); !errors.Is(getErr, ErrNotFound) {
+		t.Fatalf("rejected import partially wrote beta: %v", getErr)
+	}
+}
+
+func TestAccessAndPolicyEqualityPreserveExplicitClears(t *testing.T) {
+	baseAccess := &AccessProfile{AllowedTools: stringListPointer("read")}
+	withClear := &AccessProfile{AllowedTools: stringListPointer("read"), DeniedTools: stringListPointer()}
+	if accessProfilesEqual(baseAccess, withClear) {
+		t.Fatalf("absent denied_tools and explicit empty denied_tools must differ")
+	}
+	if !accessProfilesEqual(withClear, &AccessProfile{AllowedTools: stringListPointer("read"), DeniedTools: stringListPointer()}) {
+		t.Fatalf("equivalent explicit clears should compare equal")
+	}
+	if ringPoliciesEqual(nil, &RingPolicy{Enforcement: PolicyEnforcementRequired}) {
+		t.Fatalf("absent and required ring policies must differ")
 	}
 }
 
@@ -832,6 +1031,87 @@ func TestParseSnapshotRejectsInvalidPayloads(t *testing.T) {
 	}
 }
 
+func TestParseSnapshotRejectsUnknownFieldsAndTrailingData(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		expects string
+	}{
+		{
+			name:    "unknown top-level field",
+			payload: `{"version":10,"servers":[],"rings":[],"skills":[],"unknown":true}`,
+			expects: `unknown field "unknown"`,
+		},
+		{
+			name:    "unknown access field",
+			payload: `{"version":10,"servers":[{"name":"alpha","command":"/usr/bin/env","enabled":true,"clients":["codex"],"access":{"allowed_tools":["read"],"unknown":true}}],"rings":[],"skills":[]}`,
+			expects: `unknown field "unknown"`,
+		},
+		{
+			name:    "unknown policy field",
+			payload: `{"version":10,"servers":[],"rings":[{"name":"workflow","skills":["release"],"policy":{"enforcement":"required","unknown":true}}],"skills":[{"name":"release","content":"# Release\n"}]}`,
+			expects: `unknown field "unknown"`,
+		},
+		{
+			name:    "second document",
+			payload: `{"version":10,"servers":[],"rings":[],"skills":[]} {}`,
+			expects: "trailing data",
+		},
+		{
+			name:    "trailing garbage",
+			payload: `{"version":10,"servers":[],"rings":[],"skills":[]} nope`,
+			expects: "trailing data",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseSnapshotJSON([]byte(tt.payload))
+			if err == nil || !strings.Contains(err.Error(), tt.expects) {
+				t.Fatalf("expected error containing %q, got: %v", tt.expects, err)
+			}
+		})
+	}
+}
+
+func TestParseSnapshotRejectsNullPolicyPresenceFields(t *testing.T) {
+	baseServer := `{"name":"docs","command":"/bin/docs","args":[],"enabled":true,"clients":["codex"]}`
+	tests := []struct {
+		name    string
+		payload string
+		expects string
+	}{
+		{
+			name:    "access",
+			payload: `{"version":10,"servers":[{"name":"docs","command":"/bin/docs","args":[],"enabled":true,"clients":["codex"],"access":null}],"rings":[],"skills":[]}`,
+			expects: "servers[0].access must not be null",
+		},
+		{
+			name:    "allowed tools",
+			payload: `{"version":10,"servers":[{"name":"docs","command":"/bin/docs","args":[],"enabled":true,"clients":["codex"],"access":{"allowed_tools":null,"denied_tools":[]}}],"rings":[],"skills":[]}`,
+			expects: "servers[0].access.allowed_tools must not be null",
+		},
+		{
+			name:    "tool approvals",
+			payload: `{"version":10,"servers":[{"name":"docs","command":"/bin/docs","args":[],"enabled":true,"clients":["codex"],"access":{"allowed_tools":["read"],"tool_approvals":null}}],"rings":[],"skills":[]}`,
+			expects: "servers[0].access.tool_approvals must not be null",
+		},
+		{
+			name:    "policy",
+			payload: `{"version":10,"servers":[` + baseServer + `],"rings":[{"name":"research","members":["docs"],"skills":[],"policy":null}],"skills":[]}`,
+			expects: "rings[0].policy must not be null",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseSnapshotJSON([]byte(tt.payload))
+			if err == nil || !strings.Contains(err.Error(), tt.expects) {
+				t.Fatalf("expected error containing %q, got: %v", tt.expects, err)
+			}
+		})
+	}
+}
+
 func TestMarshalSnapshotWritesNewline(t *testing.T) {
 	snapshot := Snapshot{Version: SnapshotVersion, Servers: []Manifest{}}
 	payload, err := MarshalSnapshotJSON(snapshot)
@@ -937,5 +1217,28 @@ func TestExportSnapshotRejectsStaleRings(t *testing.T) {
 		!strings.Contains(err.Error(), `ring "research" references unknown servers: alpha`) ||
 		!strings.Contains(err.Error(), "update or delete the ring before exporting") {
 		t.Fatalf("expected stale-ring export refusal, got: %v", err)
+	}
+}
+
+func TestExportSnapshotRejectsUnboundedRequiredRing(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "servers"))
+	if err := store.Save(Manifest{Name: "alpha", Command: "/usr/bin/env", Enabled: true, Clients: []string{"codex"}}); err != nil {
+		t.Fatalf("save alpha: %v", err)
+	}
+	// SaveRing intentionally validates shape only, so export must still reject
+	// a required ring that cannot round-trip as a valid bounded policy set.
+	if err := store.SaveRing(Ring{
+		Name:    "bounded",
+		Members: []string{"alpha"},
+		Policy:  &RingPolicy{Enforcement: PolicyEnforcementRequired},
+	}); err != nil {
+		t.Fatalf("save unbounded required ring fixture: %v", err)
+	}
+
+	_, err := ExportSnapshot(store)
+	if err == nil ||
+		!strings.Contains(err.Error(), "without an explicit non-empty allowed_tools allowlist: alpha") ||
+		!strings.Contains(err.Error(), "update the ring or its server access profiles before exporting") {
+		t.Fatalf("expected unbounded required-ring export refusal, got: %v", err)
 	}
 }


### PR DESCRIPTION
## What changed

- define the portable server access profile and required ring policy in ADR 003
- add strict parsing, validation, deterministic marshal, and store support
- bump snapshots to V10 while retaining strict V1-V9 imports
- expose access and policy data through CLI, help, JSON, doctor, and docs
- centralize target/surface policy capabilities and fail required operations before output or mutation until a compiler opts in

## Why

This establishes the compatibility contract needed to prevent Madari from silently widening access. Existing manifests and rings remain backward compatible, while required policy operations fail closed until exact compilation exists.

## Validation

- `go test ./internal/registry`
- `go test ./internal/clients/codex`
- `go test ./cmd/madari`
- `go test ./internal/doctor`
- `make build`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
