### PR TITLE
Capability Policy V1: lossless Codex sync and render

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,12 +154,17 @@ MCP servers still receive the caller's non-secret `HOME`, `USERPROFILE`, and
 `CODEX_HOME` values when present so home-based server credentials keep working;
 secret declarations for those isolated env keys are blocked. Other clients
 remain dry-run only for now.
+Every access-bearing Codex run requires a stable Codex CLI 0.139.x release and
+passes the complete profile through one strict ephemeral config override. A
+required ring upgrades that supported profile from advisory to exact
+enforcement and blocks before temporary skill materialization on any downgrade.
 
 Capability Policy Contract V1 preserves existing behavior for manifests without
-`[access]` and rings without `[policy]`. Codex persistent sync/attach and render
-compile all five V1 access fields. Required operations fail during preflight if
-a member or native field cannot be represented exactly; Codex run and all other
-target policy surfaces remain unsupported until their own compilers land.
+`[access]` and rings without `[policy]`. Codex compiles all five V1 access fields
+for persistent sync/attach, render, and ephemeral run. Required operations fail
+during preflight if a member, native field, or installed Codex version cannot
+represent the contract exactly. Other target policy surfaces remain unsupported
+until their own compilers land.
 
 ## Safety Model
 
@@ -200,8 +205,8 @@ remote manifests and report them as pending. Remote entries that require
 `codex`.
 
 Transport, auth, and skill support are separate from capability-policy support.
-Codex supports exact policy compilation on persistent sync/attach and render.
-Codex run and every policy surface for other clients remain unsupported. Legacy
+Codex supports exact policy compilation on persistent sync/attach, render, and
+run. Every policy surface for other clients remains unsupported. Legacy
 operations remain available; rings with `[policy] enforcement = "required"`
 block whenever the selected target surface lacks an exact compiler.
 

--- a/README.md
+++ b/README.md
@@ -156,11 +156,10 @@ secret declarations for those isolated env keys are blocked. Other clients
 remain dry-run only for now.
 
 Capability Policy Contract V1 preserves existing behavior for manifests without
-`[access]` and rings without `[policy]`. In the schema-and-compatibility stage,
-policy capability declarations for sync/attach, render, and run are all
-unsupported. A policy-required operation therefore fails during preflight,
-before client config, managed state, skill files, render output, or execution can
-change. Target compilers opt into those surfaces in later implementation stages.
+`[access]` and rings without `[policy]`. Codex persistent sync/attach and render
+compile all five V1 access fields. Required operations fail during preflight if
+a member or native field cannot be represented exactly; Codex run and all other
+target policy surfaces remain unsupported until their own compilers land.
 
 ## Safety Model
 
@@ -201,10 +200,10 @@ remote manifests and report them as pending. Remote entries that require
 `codex`.
 
 Transport, auth, and skill support are separate from capability-policy support.
-The initial policy-contract release declares policy compilation unsupported for
-every client on persistent sync/attach, render, and run surfaces. Legacy
+Codex supports exact policy compilation on persistent sync/attach and render.
+Codex run and every policy surface for other clients remain unsupported. Legacy
 operations remain available; rings with `[policy] enforcement = "required"`
-block until a target compiler explicitly supports the selected surface.
+block whenever the selected target surface lacks an exact compiler.
 
 Madari can materialize skills for:
 

--- a/cmd/madari/codex_policy_render_test.go
+++ b/cmd/madari/codex_policy_render_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	codexclient "github.com/ankitvg/madari/internal/clients/codex"
+	"github.com/ankitvg/madari/internal/registry"
+	"github.com/pelletier/go-toml/v2"
+)
+
+func TestRenderCodexTOMLCompilesPolicyWithDottedNamesDeterministically(t *testing.T) {
+	access := codexclient.CompileAccess(codexPolicyRenderAccess())
+	servers := map[string]renderedServer{
+		"z-last": {
+			Command: "/bin/z-last",
+		},
+		"docs.server": {
+			Transport:   registry.TransportHTTP,
+			URL:         "https://example.com/mcp",
+			CodexAccess: &access,
+		},
+	}
+
+	var out strings.Builder
+	if err := renderCodexTOML(&out, servers); err != nil {
+		t.Fatalf("render Codex policy: %v", err)
+	}
+	want := `[mcp_servers."docs.server"]
+url = "https://example.com/mcp"
+enabled_tools = ["tools.inherit", "tools.read", "tools.write"]
+disabled_tools = ["tools.delete", "tools.remove"]
+scopes = ["repo.read", "repo.write"]
+default_tools_approval_mode = "prompt"
+
+[mcp_servers."docs.server".tools."tools.read"]
+approval_mode = "auto"
+
+[mcp_servers."docs.server".tools."tools.write"]
+approval_mode = "approve"
+
+[mcp_servers.z-last]
+command = "/bin/z-last"
+`
+	if out.String() != want {
+		t.Fatalf("Codex policy render drift:\nwant:\n%s\ngot:\n%s", want, out.String())
+	}
+	if strings.Contains(out.String(), `approval_mode = "inherit"`) || strings.Contains(out.String(), `approval_mode = ""`) {
+		t.Fatalf("portable inherit must omit the native per-tool override:\n%s", out.String())
+	}
+}
+
+func TestRenderCodexTOMLEscapesDeleteControlInToolNames(t *testing.T) {
+	tool := "read\x7f"
+	allowed := []string{tool}
+	approvals := map[string]string{tool: "prompt"}
+	access := codexclient.CompiledAccess{EnabledTools: &allowed, ToolApprovals: &approvals}
+	servers := map[string]renderedServer{
+		"docs": {Command: "/bin/docs", CodexAccess: &access},
+	}
+	var out strings.Builder
+	if err := renderCodexTOML(&out, servers); err != nil {
+		t.Fatalf("render Codex policy: %v", err)
+	}
+	if strings.ContainsRune(out.String(), '\x7f') || !strings.Contains(out.String(), `read\u007F`) {
+		t.Fatalf("DEL control was not deterministically escaped:\n%s", out.String())
+	}
+	var parsed map[string]any
+	if err := toml.Unmarshal([]byte(out.String()), &parsed); err != nil {
+		t.Fatalf("escaped policy output is invalid TOML: %v\n%s", err, out.String())
+	}
+}
+
+func TestRequiredCodexRingRenderCompilesEveryAccessField(t *testing.T) {
+	store := newTestStore(t)
+	manifest := registry.Manifest{
+		Name:      "docs.server",
+		Transport: registry.TransportHTTP,
+		URL:       "https://example.com/mcp",
+		Enabled:   true,
+		Clients:   []string{"codex"},
+		Access:    codexPolicyRenderAccess(),
+	}
+	if err := store.Save(manifest); err != nil {
+		t.Fatalf("save policy manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{
+		Name:    "restricted",
+		Members: []string{manifest.Name},
+		Policy: &registry.RingPolicy{
+			Enforcement: registry.PolicyEnforcementRequired,
+		},
+	}); err != nil {
+		t.Fatalf("save policy ring: %v", err)
+	}
+
+	result := runCmd(store, "ring", "render", "restricted", "--client", "codex")
+	if result.code != 0 {
+		t.Fatalf("required Codex policy render failed: %s", result.stderr)
+	}
+	for _, want := range []string{
+		`enabled_tools = ["tools.inherit", "tools.read", "tools.write"]`,
+		`disabled_tools = ["tools.delete", "tools.remove"]`,
+		`scopes = ["repo.read", "repo.write"]`,
+		`default_tools_approval_mode = "prompt"`,
+		`[mcp_servers."docs.server".tools."tools.read"]`,
+		`approval_mode = "auto"`,
+		`[mcp_servers."docs.server".tools."tools.write"]`,
+		`approval_mode = "approve"`,
+	} {
+		if !strings.Contains(result.stdout, want) {
+			t.Fatalf("render missing %q:\n%s", want, result.stdout)
+		}
+	}
+	if result.stderr != "" {
+		t.Fatalf("unexpected required render warning: %s", result.stderr)
+	}
+}
+
+func TestRequiredCodexRingRenderRejectsUnsupportedMemberBeforeOutput(t *testing.T) {
+	store := newTestStore(t)
+	allowed := []string{"events.read"}
+	manifest := registry.Manifest{
+		Name:      "events",
+		Transport: registry.TransportSSE,
+		URL:       "https://example.com/sse",
+		Enabled:   true,
+		Clients:   []string{"codex"},
+		Access:    &registry.AccessProfile{AllowedTools: &allowed},
+	}
+	if err := store.Save(manifest); err != nil {
+		t.Fatalf("save SSE manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{
+		Name:    "restricted",
+		Members: []string{manifest.Name},
+		Policy:  &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
+	}); err != nil {
+		t.Fatalf("save required ring: %v", err)
+	}
+
+	result := runCmd(store, "ring", "render", "restricted", "--client", "codex")
+	if result.code == 0 || !strings.Contains(result.stderr, "uses sse transport") {
+		t.Fatalf("expected fail-closed SSE refusal: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	if result.stdout != "" {
+		t.Fatalf("required render emitted partial output: %s", result.stdout)
+	}
+}
+
+func codexPolicyRenderAccess() *registry.AccessProfile {
+	allowed := []string{"tools.write", "tools.inherit", "tools.read"}
+	denied := []string{"tools.remove", "tools.delete"}
+	scopes := []string{"repo.write", "repo.read"}
+	defaultApproval := registry.ApprovalBehaviorAlwaysPrompt
+	toolApprovals := map[string]registry.ApprovalBehavior{
+		"tools.write":   registry.ApprovalBehaviorAlwaysAllow,
+		"tools.inherit": registry.ApprovalBehaviorInherit,
+		"tools.read":    registry.ApprovalBehaviorAutomatic,
+	}
+	return &registry.AccessProfile{
+		AllowedTools:    &allowed,
+		DeniedTools:     &denied,
+		OAuthScopes:     &scopes,
+		DefaultApproval: &defaultApproval,
+		ToolApprovals:   &toolApprovals,
+	}
+}

--- a/cmd/madari/json_output.go
+++ b/cmd/madari/json_output.go
@@ -162,6 +162,7 @@ type syncJSON struct {
 	DryRun            bool     `json:"dry_run"`
 	Added             []string `json:"added"`
 	Updated           []string `json:"updated"`
+	PolicyUpdated     []string `json:"policy_updated"`
 	Removed           []string `json:"removed"`
 	Unchanged         []string `json:"unchanged"`
 	Skipped           []string `json:"skipped"`

--- a/cmd/madari/json_output.go
+++ b/cmd/madari/json_output.go
@@ -110,14 +110,15 @@ func ringIssuesToJSON(issues []doctor.RingIssue) []ringIssueJSON {
 }
 
 type driftJSON struct {
-	Target     string   `json:"target"`
-	Scope      string   `json:"scope"`
-	ConfigPath string   `json:"config_path"`
-	Status     string   `json:"status"`
-	Stale      []string `json:"stale"`
-	Missing    []string `json:"missing"`
-	Orphaned   []string `json:"orphaned"`
-	Issue      string   `json:"issue"`
+	Target      string   `json:"target"`
+	Scope       string   `json:"scope"`
+	ConfigPath  string   `json:"config_path"`
+	Status      string   `json:"status"`
+	Stale       []string `json:"stale"`
+	PolicyStale []string `json:"policy_stale"`
+	Missing     []string `json:"missing"`
+	Orphaned    []string `json:"orphaned"`
+	Issue       string   `json:"issue"`
 }
 
 type doctorServerJSON struct {
@@ -383,14 +384,15 @@ func driftToJSON(reports []doctor.DriftReport) []driftJSON {
 			scope = "default"
 		}
 		out = append(out, driftJSON{
-			Target:     dr.Target,
-			Scope:      scope,
-			ConfigPath: dr.ConfigPath,
-			Status:     string(dr.Status),
-			Stale:      nonNilStrings(dr.Stale),
-			Missing:    nonNilStrings(dr.Missing),
-			Orphaned:   nonNilStrings(dr.Orphaned),
-			Issue:      dr.Issue,
+			Target:      dr.Target,
+			Scope:       scope,
+			ConfigPath:  dr.ConfigPath,
+			Status:      string(dr.Status),
+			Stale:       nonNilStrings(dr.Stale),
+			PolicyStale: nonNilStrings(dr.PolicyStale),
+			Missing:     nonNilStrings(dr.Missing),
+			Orphaned:    nonNilStrings(dr.Orphaned),
+			Issue:       dr.Issue,
 		})
 	}
 	return out

--- a/cmd/madari/policy_drift_output_test.go
+++ b/cmd/madari/policy_drift_output_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/ankitvg/madari/internal/doctor"
+)
+
+func TestDriftJSONReportsPolicyStale(t *testing.T) {
+	payload := driftToJSON([]doctor.DriftReport{{
+		Target:      "codex",
+		Status:      doctor.StatusWarning,
+		Stale:       []string{"docs.api", "issues"},
+		PolicyStale: []string{"docs.api"},
+	}})
+	if len(payload) != 1 {
+		t.Fatalf("expected one drift payload, got: %#v", payload)
+	}
+	data, err := json.Marshal(payload[0])
+	if err != nil {
+		t.Fatalf("marshal drift JSON: %v", err)
+	}
+	if !bytes.Contains(data, []byte(`"policy_stale":["docs.api"]`)) {
+		t.Fatalf("expected policy_stale JSON field, got: %s", data)
+	}
+}
+
+func TestPrintPolicyDriftText(t *testing.T) {
+	var out bytes.Buffer
+	printPolicyDriftDetail(
+		&out,
+		"codex (user scope)",
+		"madari sync codex --scope user",
+		doctor.StatusWarning,
+		[]string{"docs.api", "issues"},
+	)
+	want := "codex (user scope) policy drift: [warn] stale=docs.api,issues (fix: madari sync codex --scope user)\n"
+	if got := out.String(); got != want {
+		t.Fatalf("doctor policy drift output mismatch:\nwant: %q\n got: %q", want, got)
+	}
+
+	out.Reset()
+	printPolicyDriftSummary(&out, "codex-user", "madari sync codex --scope user", []string{"docs.api", "issues"})
+	want = "codex-user-policy-drift: stale=2 (fix: madari sync codex --scope user)\n"
+	if got := out.String(); got != want {
+		t.Fatalf("status policy drift output mismatch:\nwant: %q\n got: %q", want, got)
+	}
+}
+
+func TestPrintPolicyDriftTextOmitsEmptySubset(t *testing.T) {
+	var out bytes.Buffer
+	printPolicyDriftDetail(&out, "codex", "madari sync codex", doctor.StatusReady, nil)
+	printPolicyDriftSummary(&out, "codex", "madari sync codex", []string{})
+	if got := out.String(); got != "" {
+		t.Fatalf("expected legacy text output to remain unchanged, got: %q", got)
+	}
+}

--- a/cmd/madari/policy_preflight.go
+++ b/cmd/madari/policy_preflight.go
@@ -32,3 +32,34 @@ func preflightAttachedRequiredRingPolicies(rings []registry.Ring, attached []str
 	}
 	return nil
 }
+
+func hasAttachedRequiredRingPolicy(rings []registry.Ring, attached []string) bool {
+	attachedSet := make(map[string]bool, len(attached))
+	for _, name := range attached {
+		attachedSet[strings.TrimSpace(name)] = true
+	}
+	for _, ring := range rings {
+		if attachedSet[ring.Name] && ring.RequiresPolicyEnforcement() {
+			return true
+		}
+	}
+	return false
+}
+
+func preflightRequiredRingServerOwnership(rings []registry.Ring, policyAttached, serverAttached []string, target string) error {
+	policySet := make(map[string]bool, len(policyAttached))
+	for _, name := range policyAttached {
+		policySet[strings.TrimSpace(name)] = true
+	}
+	serverSet := make(map[string]bool, len(serverAttached))
+	for _, name := range serverAttached {
+		serverSet[strings.TrimSpace(name)] = true
+	}
+	for _, ring := range rings {
+		if !policySet[ring.Name] || serverSet[ring.Name] || !ring.RequiresPolicyEnforcement() || len(ring.Members) == 0 {
+			continue
+		}
+		return fmt.Errorf("ring %q requires policy enforcement and is attached only through skills; run `madari ring attach %s %s` to establish server ownership before sync", ring.Name, ring.Name, target)
+	}
+	return nil
+}

--- a/cmd/madari/policy_preflight.go
+++ b/cmd/madari/policy_preflight.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/ankitvg/madari/internal/policy"
 	"github.com/ankitvg/madari/internal/registry"
 )

--- a/cmd/madari/policy_preflight_test.go
+++ b/cmd/madari/policy_preflight_test.go
@@ -253,11 +253,11 @@ func TestPolicyRequiredAttachedRingSyncFailsBeforeConfigStateOrSkillMutation(t *
 		t.Fatalf("expected attached required ring sync refusal: stdout=%s stderr=%s", result.stdout, result.stderr)
 	}
 	doctorResult := runCmd(store, "doctor", "--client-config", "codex="+configPath)
-	if doctorResult.code == 0 || !strings.Contains(doctorResult.stdout, "codex drift: [error] policy preflight:") || !strings.Contains(doctorResult.stdout, "codex persistent policy support is unsupported") {
+	if doctorResult.code == 0 || !strings.Contains(doctorResult.stdout, "codex drift: [error] compute sync plan:") || !strings.Contains(doctorResult.stdout, "future_policy") {
 		t.Fatalf("doctor hid attached policy preflight failure: stdout=%s stderr=%s", doctorResult.stdout, doctorResult.stderr)
 	}
 	statusResult := runCmd(store, "status", "--client-config", "codex="+configPath)
-	if statusResult.code == 0 || !strings.Contains(statusResult.stdout, "codex-drift: error policy preflight:") || !strings.Contains(statusResult.stdout, "codex persistent policy support is unsupported") {
+	if statusResult.code == 0 || !strings.Contains(statusResult.stdout, "codex-drift: error compute sync plan:") || !strings.Contains(statusResult.stdout, "future_policy") {
 		t.Fatalf("status hid attached policy preflight failure: stdout=%s stderr=%s", statusResult.stdout, statusResult.stderr)
 	}
 	assertPolicyTestFileUnchanged(t, configPath, configBefore)

--- a/cmd/madari/policy_preflight_test.go
+++ b/cmd/madari/policy_preflight_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -268,8 +269,9 @@ func TestPolicyRequiredAttachedRingSyncFailsBeforeConfigStateOrSkillMutation(t *
 	}
 }
 
-func TestPolicyRequiredRingMakesRunPlanNotReady(t *testing.T) {
+func TestPolicyRequiredRingMakesCodexRunPlanExact(t *testing.T) {
 	store := newTestStore(t)
+	installFakeCodex(t, 0)
 	savePolicyTestManifest(t, store, "docs", "codex")
 	savePolicyTestRing(t, store, "restricted", []string{"docs"}, nil, true)
 
@@ -277,16 +279,20 @@ func TestPolicyRequiredRingMakesRunPlanNotReady(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build run plan: %v", err)
 	}
-	if plan.Ready {
-		t.Fatalf("required policy must block execution while run compiler is unsupported: %#v", plan)
+	if !plan.Ready {
+		t.Fatalf("required Codex policy run should be ready: %#v", plan)
 	}
-	if !containsPolicyTestSubstring(plan.Errors, "codex run policy support is unsupported") {
-		t.Fatalf("run plan missing policy support error: %#v", plan.Errors)
+	if len(plan.Servers) != 1 || plan.Servers[0].Policy.SupportState != "supported" || plan.Servers[0].Policy.EnforcementClassification != "exact" {
+		t.Fatalf("run plan missing exact policy classification: %#v", plan.Servers)
+	}
+	if plan.Servers[0].Policy.Effective == nil || !reflect.DeepEqual(plan.Servers[0].Policy.Effective.EnabledTools, []string{"read"}) {
+		t.Fatalf("run plan missing effective policy: %#v", plan.Servers[0].Policy)
 	}
 }
 
-func TestPolicyRequiredSkillOnlyRingAttachesButRunRemainsBlocked(t *testing.T) {
+func TestPolicyRequiredSkillOnlyRingAttachesAndRunCompilesAfterMemberEdit(t *testing.T) {
 	store := newTestStore(t)
+	installFakeCodex(t, 0)
 	projectDir := t.TempDir()
 	chdirForTest(t, projectDir)
 	skillSource := writeSkillFile(t, t.TempDir(), "release.md", "# Release\n")
@@ -318,8 +324,8 @@ func TestPolicyRequiredSkillOnlyRingAttachesButRunRemainsBlocked(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build run plan: %v", err)
 	}
-	if plan.Ready || !containsPolicyTestSubstring(plan.Errors, "codex run has no lossless policy compiler yet") {
-		t.Fatalf("skill-only required run must be blocked: %#v", plan)
+	if !plan.Ready || len(plan.Servers) != 1 || plan.Servers[0].Policy.EnforcementClassification != "exact" {
+		t.Fatalf("required run should compile independently of persistent ownership: %#v", plan)
 	}
 }
 

--- a/cmd/madari/policy_preflight_test.go
+++ b/cmd/madari/policy_preflight_test.go
@@ -15,6 +15,14 @@ func TestPolicyRequiredRingAttachFailsBeforeConfigStateOrSkillMutation(t *testin
 	projectDir := t.TempDir()
 	chdirForTest(t, projectDir)
 	savePolicyTestManifest(t, store, "docs", "codex")
+	manifest, err := store.Get("docs")
+	if err != nil {
+		t.Fatalf("load policy manifest: %v", err)
+	}
+	manifest.Command = filepath.Join(t.TempDir(), "missing-command")
+	if err := store.Save(manifest); err != nil {
+		t.Fatalf("save invalid command manifest: %v", err)
+	}
 
 	skillSource := writeSkillFile(t, t.TempDir(), "release.md", "# Release\n")
 	if result := runCmd(store, "skill", "add", "release", "--file", skillSource, "--description", "Release workflow"); result.code != 0 {
@@ -29,8 +37,7 @@ func TestPolicyRequiredRingAttachFailsBeforeConfigStateOrSkillMutation(t *testin
 	}
 	for _, want := range []string{
 		`ring "restricted" requires policy enforcement`,
-		"codex persistent policy support is unsupported",
-		"[access].allowed_tools",
+		`member "docs" cannot execute on Codex`,
 	} {
 		if !strings.Contains(result.stderr, want) {
 			t.Fatalf("attach error missing %q: %s", want, result.stderr)
@@ -49,19 +56,154 @@ func TestPolicyRequiredRingAttachFailsBeforeConfigStateOrSkillMutation(t *testin
 	}
 }
 
-func TestPolicyRequiredRingRenderFailsWithoutPartialOutput(t *testing.T) {
+func TestPolicyRequiredRingAttachNativeFidelityFailsBeforeSkillMutation(t *testing.T) {
 	store := newTestStore(t)
+	projectDir := t.TempDir()
+	chdirForTest(t, projectDir)
 	savePolicyTestManifest(t, store, "docs", "codex")
+	if err := store.SaveRing(registry.Ring{Name: "base", Members: []string{"docs"}}); err != nil {
+		t.Fatalf("save base ring: %v", err)
+	}
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if result := runCmd(store, "ring", "attach", "base", "codex", "--config-path", configPath); result.code != 0 {
+		t.Fatalf("attach base ring: %s", result.stderr)
+	}
+	serverStatePath := (cliApp{store: store}).ringOpStatePath("codex", "")
+	unknownConfig := "[mcp_servers.docs]\ncommand = " + tomlString(mustCurrentExecutable(t)) + "\nfuture_policy = \"strict\"\n"
+	if err := os.WriteFile(configPath, []byte(unknownConfig), 0o600); err != nil {
+		t.Fatalf("write unknown native policy: %v", err)
+	}
+	serverStateBefore, err := os.ReadFile(serverStatePath)
+	if err != nil {
+		t.Fatalf("read server state: %v", err)
+	}
+
+	skillSource := writeSkillFile(t, t.TempDir(), "release.md", "# Release\n")
+	if result := runCmd(store, "skill", "add", "release", "--file", skillSource, "--description", "Release workflow"); result.code != 0 {
+		t.Fatalf("skill setup failed: %s", result.stderr)
+	}
+	savePolicyTestRing(t, store, "restricted", []string{"docs"}, []string{"release"}, true)
+
+	result := runCmd(store, "ring", "attach", "restricted", "codex", "--config-path", configPath)
+	if result.code == 0 || !strings.Contains(result.stderr, "future_policy") {
+		t.Fatalf("expected native fidelity refusal: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	assertPolicyTestFileUnchanged(t, configPath, []byte(unknownConfig))
+	assertPolicyTestFileUnchanged(t, serverStatePath, serverStateBefore)
+	skillPath := filepath.Join(projectDir, ".agents", "skills", "release", registry.SkillFileName)
+	if _, err := os.Stat(skillPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("native fidelity preflight materialized skill: %v", err)
+	}
+	skillStatePath := (cliApp{store: store}).skillAttachmentStatePath("codex", "")
+	if _, err := os.Stat(skillStatePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("native fidelity preflight wrote skill state: %v", err)
+	}
+}
+
+func TestPolicyRequiredCodexAttachPreservesServerAndSkillRefcounts(t *testing.T) {
+	store := newTestStore(t)
+	projectDir := t.TempDir()
+	chdirForTest(t, projectDir)
+	allowed := []string{"read", "write"}
+	denied := []string{"delete"}
+	defaultApproval := registry.ApprovalBehaviorAlwaysPrompt
+	toolApprovals := map[string]registry.ApprovalBehavior{"read": registry.ApprovalBehaviorAlwaysAllow}
+	if err := store.Save(registry.Manifest{
+		Name: "docs", Command: mustCurrentExecutable(t), Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{
+			AllowedTools: &allowed, DeniedTools: &denied,
+			DefaultApproval: &defaultApproval, ToolApprovals: &toolApprovals,
+		},
+	}); err != nil {
+		t.Fatalf("save policy manifest: %v", err)
+	}
+	skillSource := writeSkillFile(t, t.TempDir(), "release.md", "# Release\n")
+	if result := runCmd(store, "skill", "add", "release", "--file", skillSource, "--description", "Release workflow"); result.code != 0 {
+		t.Fatalf("skill setup failed: %s", result.stderr)
+	}
+	for _, name := range []string{"r1", "r2"} {
+		savePolicyTestRing(t, store, name, []string{"docs"}, []string{"release"}, true)
+	}
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	for _, name := range []string{"r1", "r2"} {
+		result := runCmd(store, "ring", "attach", name, "codex", "--config-path", configPath)
+		if result.code != 0 {
+			t.Fatalf("attach %s: %s", name, result.stderr)
+		}
+	}
+	config, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read Codex config: %v", err)
+	}
+	for _, want := range []string{
+		`enabled_tools = ['read', 'write']`,
+		`disabled_tools = ['delete']`,
+		`default_tools_approval_mode = 'prompt'`,
+		`approval_mode = 'approve'`,
+	} {
+		if !strings.Contains(string(config), want) {
+			t.Fatalf("Codex policy config missing %q:\n%s", want, config)
+		}
+	}
+	serverStatePath := (cliApp{store: store}).ringOpStatePath("codex", "")
+	serverState, err := os.ReadFile(serverStatePath)
+	if err != nil {
+		t.Fatalf("read server state: %v", err)
+	}
+	skillStatePath := (cliApp{store: store}).skillAttachmentStatePath("codex", "")
+	skillState, err := os.ReadFile(skillStatePath)
+	if err != nil {
+		t.Fatalf("read skill state: %v", err)
+	}
+	for _, source := range []string{`"ring:r1"`, `"ring:r2"`} {
+		if !strings.Contains(string(serverState), source) || !strings.Contains(string(skillState), source) {
+			t.Fatalf("missing overlapping source %s: server=%s skill=%s", source, serverState, skillState)
+		}
+	}
+	skillPath := filepath.Join(projectDir, ".agents", "skills", "release", registry.SkillFileName)
+	if _, err := os.Stat(skillPath); err != nil {
+		t.Fatalf("required attach did not materialize skill: %v", err)
+	}
+
+	if result := runCmd(store, "ring", "detach", "r1", "codex", "--config-path", configPath); result.code != 0 {
+		t.Fatalf("detach r1: %s", result.stderr)
+	}
+	config, err = os.ReadFile(configPath)
+	if err != nil || !strings.Contains(string(config), "mcp_servers.docs") {
+		t.Fatalf("shared server removed while r2 owns it: err=%v config=%s", err, config)
+	}
+	if _, err := os.Stat(skillPath); err != nil {
+		t.Fatalf("shared skill removed while r2 owns it: %v", err)
+	}
+
+	if result := runCmd(store, "ring", "detach", "r2", "codex", "--config-path", configPath); result.code != 0 {
+		t.Fatalf("detach r2: %s", result.stderr)
+	}
+	config, err = os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config after detach: %v", err)
+	}
+	if strings.Contains(string(config), "mcp_servers.docs") {
+		t.Fatalf("last detach retained server: %s", config)
+	}
+	if _, err := os.Stat(skillPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("last detach retained skill: %v", err)
+	}
+}
+
+func TestPolicyRequiredRingRenderFailsForUnsupportedTargetWithoutPartialOutput(t *testing.T) {
+	store := newTestStore(t)
+	savePolicyTestManifest(t, store, "docs", "gemini")
 	savePolicyTestRing(t, store, "restricted", []string{"docs"}, nil, true)
 
-	result := runCmd(store, "ring", "render", "restricted", "--client", "codex")
+	result := runCmd(store, "ring", "render", "restricted", "--client", "gemini")
 	if result.code == 0 {
 		t.Fatalf("expected required policy render to fail closed: stdout=%s stderr=%s", result.stdout, result.stderr)
 	}
 	if result.stdout != "" {
 		t.Fatalf("required policy render must emit no partial config, got: %s", result.stdout)
 	}
-	if !strings.Contains(result.stderr, "codex render policy support is unsupported") {
+	if !strings.Contains(result.stderr, "gemini render policy support is unsupported") {
 		t.Fatalf("unexpected render error: %s", result.stderr)
 	}
 }
@@ -78,6 +220,10 @@ func TestPolicyRequiredAttachedRingSyncFailsBeforeConfigStateOrSkillMutation(t *
 		t.Fatalf("advisory ring attach failed: %s", result.stderr)
 	}
 	statePath := (cliApp{store: store}).ringOpStatePath("codex", "")
+	configWithUnknownPolicy := "[mcp_servers.docs]\ncommand = " + tomlString(mustCurrentExecutable(t)) + "\nfuture_policy = \"strict\"\n"
+	if err := os.WriteFile(configPath, []byte(configWithUnknownPolicy), 0o600); err != nil {
+		t.Fatalf("write unknown native policy fixture: %v", err)
+	}
 	configBefore, err := os.ReadFile(configPath)
 	if err != nil {
 		t.Fatalf("read attached config: %v", err)
@@ -103,7 +249,7 @@ func TestPolicyRequiredAttachedRingSyncFailsBeforeConfigStateOrSkillMutation(t *
 	}
 
 	result := runCmd(store, "sync", "codex", "--config-path", configPath)
-	if result.code == 0 || !strings.Contains(result.stderr, "codex persistent policy support is unsupported") {
+	if result.code == 0 || !strings.Contains(result.stderr, "behavior-affecting native fields") || !strings.Contains(result.stderr, "future_policy") {
 		t.Fatalf("expected attached required ring sync refusal: stdout=%s stderr=%s", result.stdout, result.stderr)
 	}
 	assertPolicyTestFileUnchanged(t, configPath, configBefore)
@@ -131,7 +277,7 @@ func TestPolicyRequiredRingMakesRunPlanNotReady(t *testing.T) {
 	}
 }
 
-func TestPolicyRequiredSkillOnlyRingFailsBeforeSkillMaterialization(t *testing.T) {
+func TestPolicyRequiredSkillOnlyRingAttachesButRunRemainsBlocked(t *testing.T) {
 	store := newTestStore(t)
 	projectDir := t.TempDir()
 	chdirForTest(t, projectDir)
@@ -142,12 +288,22 @@ func TestPolicyRequiredSkillOnlyRingFailsBeforeSkillMaterialization(t *testing.T
 	savePolicyTestRing(t, store, "workflow", nil, []string{"release"}, true)
 
 	result := runCmd(store, "ring", "attach", "workflow", "codex")
-	if result.code == 0 || !strings.Contains(result.stderr, "codex persistent has no lossless policy compiler yet") {
-		t.Fatalf("expected skill-only required ring refusal: stdout=%s stderr=%s", result.stdout, result.stderr)
+	if result.code != 0 {
+		t.Fatalf("skill-only required ring attach failed: stdout=%s stderr=%s", result.stdout, result.stderr)
 	}
 	skillPath := filepath.Join(projectDir, ".agents", "skills", "release", registry.SkillFileName)
-	if _, err := os.Stat(skillPath); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("skill-only required ring must fail before materialization: %v", err)
+	if _, err := os.Stat(skillPath); err != nil {
+		t.Fatalf("skill-only required ring should materialize with the persistent compiler: %v", err)
+	}
+	savePolicyTestManifest(t, store, "docs", "codex")
+	savePolicyTestRing(t, store, "workflow", []string{"docs"}, []string{"release"}, true)
+	syncResult := runCmd(store, "sync", "codex")
+	if syncResult.code == 0 || !strings.Contains(syncResult.stderr, "attached only through skills") {
+		t.Fatalf("expected missing server ownership refusal: stdout=%s stderr=%s", syncResult.stdout, syncResult.stderr)
+	}
+	serverStatePath := (cliApp{store: store}).ringOpStatePath("codex", "")
+	if _, err := os.Stat(serverStatePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("failed policy sync created server state: %v", err)
 	}
 
 	plan, err := (cliApp{store: store}).buildRunPlan("codex", []string{"workflow"}, "prepare release")

--- a/cmd/madari/render_targets.go
+++ b/cmd/madari/render_targets.go
@@ -6,21 +6,23 @@ import (
 	"sort"
 	"strings"
 
+	codexclient "github.com/ankitvg/madari/internal/clients/codex"
 	"github.com/ankitvg/madari/internal/registry"
 )
 
 // renderedServer is the self-contained client config entry ring render emits.
 type renderedServer struct {
-	Transport         string            `json:"type,omitempty"`
-	Command           string            `json:"command,omitempty"`
-	Args              []string          `json:"args,omitempty"`
-	URL               string            `json:"url,omitempty"`
-	Headers           map[string]string `json:"headers,omitempty"`
-	TimeoutMS         int               `json:"timeout,omitempty"`
-	OAuthResource     string            `json:"-"`
-	BearerTokenEnvVar string            `json:"-"`
-	Env               map[string]string `json:"env,omitempty"`
-	RuntimeEnvKeys    []string          `json:"-"`
+	Transport         string                      `json:"type,omitempty"`
+	Command           string                      `json:"command,omitempty"`
+	Args              []string                    `json:"args,omitempty"`
+	URL               string                      `json:"url,omitempty"`
+	Headers           map[string]string           `json:"headers,omitempty"`
+	TimeoutMS         int                         `json:"timeout,omitempty"`
+	OAuthResource     string                      `json:"-"`
+	BearerTokenEnvVar string                      `json:"-"`
+	Env               map[string]string           `json:"env,omitempty"`
+	RuntimeEnvKeys    []string                    `json:"-"`
+	CodexAccess       *codexclient.CompiledAccess `json:"-"`
 }
 
 type ringRenderTarget struct {
@@ -97,6 +99,7 @@ func renderCodexTOML(out io.Writer, servers map[string]renderedServer) error {
 			if entry.BearerTokenEnvVar != "" {
 				fmt.Fprintf(out, "bearer_token_env_var = %s\n", tomlString(entry.BearerTokenEnvVar))
 			}
+			renderCodexAccessFields(out, entry.CodexAccess)
 			if len(entry.Headers) > 0 {
 				fmt.Fprintln(out)
 				fmt.Fprintf(out, "[mcp_servers.%s.http_headers]\n", tomlKey(name))
@@ -112,6 +115,7 @@ func renderCodexTOML(out io.Writer, servers map[string]renderedServer) error {
 			if len(entry.RuntimeEnvKeys) > 0 {
 				fmt.Fprintf(out, "env_vars = %s\n", tomlStringArray(entry.RuntimeEnvKeys))
 			}
+			renderCodexAccessFields(out, entry.CodexAccess)
 			if len(entry.Env) > 0 {
 				fmt.Fprintln(out)
 				fmt.Fprintf(out, "[mcp_servers.%s.env]\n", tomlKey(name))
@@ -120,8 +124,47 @@ func renderCodexTOML(out io.Writer, servers map[string]renderedServer) error {
 				}
 			}
 		}
+		renderCodexToolApprovals(out, name, entry.CodexAccess)
 	}
 	return nil
+}
+
+func renderCodexAccessFields(out io.Writer, access *codexclient.CompiledAccess) {
+	if access == nil {
+		return
+	}
+	// Render output is self-contained, so explicit clears have the same
+	// effective value as omission. Persistent sync consumes the pointer
+	// presence on CompiledAccess to remove an existing native override.
+	if access.EnabledTools != nil && len(*access.EnabledTools) > 0 {
+		fmt.Fprintf(out, "enabled_tools = %s\n", tomlStringArray(*access.EnabledTools))
+	}
+	if access.DisabledTools != nil && len(*access.DisabledTools) > 0 {
+		fmt.Fprintf(out, "disabled_tools = %s\n", tomlStringArray(*access.DisabledTools))
+	}
+	if access.Scopes != nil && len(*access.Scopes) > 0 {
+		fmt.Fprintf(out, "scopes = %s\n", tomlStringArray(*access.Scopes))
+	}
+	if access.DefaultApproval != nil && *access.DefaultApproval != "" {
+		fmt.Fprintf(out, "default_tools_approval_mode = %s\n", tomlString(*access.DefaultApproval))
+	}
+}
+
+func renderCodexToolApprovals(out io.Writer, server string, access *codexclient.CompiledAccess) {
+	if access == nil || access.ToolApprovals == nil {
+		return
+	}
+	tools := sortedMapKeys(*access.ToolApprovals)
+	for _, tool := range tools {
+		approval := (*access.ToolApprovals)[tool]
+		if approval == "" {
+			// Portable inherit removes the target-native override.
+			continue
+		}
+		fmt.Fprintln(out)
+		fmt.Fprintf(out, "[mcp_servers.%s.tools.%s]\n", tomlKey(server), tomlKey(tool))
+		fmt.Fprintf(out, "approval_mode = %s\n", tomlString(approval))
+	}
 }
 
 func renderVibeTOML(out io.Writer, servers map[string]renderedServer) error {
@@ -243,7 +286,7 @@ func tomlString(value string) string {
 		case '\\':
 			b.WriteString(`\\`)
 		default:
-			if r < 0x20 {
+			if r < 0x20 || r == 0x7f {
 				fmt.Fprintf(&b, `\u%04X`, r)
 				continue
 			}

--- a/cmd/madari/ring.go
+++ b/cmd/madari/ring.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/ankitvg/madari/internal/clients"
+	codexclient "github.com/ankitvg/madari/internal/clients/codex"
 	"github.com/ankitvg/madari/internal/clients/syncshared"
 	"github.com/ankitvg/madari/internal/policy"
 	"github.com/ankitvg/madari/internal/registry"
@@ -393,6 +394,9 @@ func (a cliApp) cmdRingRender(args []string) error {
 	for _, manifest := range manifests {
 		byName[manifest.Name] = manifest
 	}
+	if err := preflightRequiredRingRenderEntries(ring, byName, target); err != nil {
+		return commandInputError("ring render", err.Error())
+	}
 
 	// Render mutates nothing: no state, no refcounts, no config files. The
 	// output is a self-contained config for ephemeral use (for example
@@ -438,7 +442,7 @@ func (a cliApp) cmdRingRender(args []string) error {
 				}
 				fmt.Fprintf(a.stderr, "warning: ring member %s: secret header values omitted from render: %s\n", member, strings.Join(secretNames, ", "))
 			}
-			servers[member] = renderedServer{
+			entry := renderedServer{
 				Transport:         manifest.TransportType(),
 				URL:               manifest.URL,
 				Headers:           headers,
@@ -446,6 +450,8 @@ func (a cliApp) cmdRingRender(args []string) error {
 				OAuthResource:     manifest.OAuthResource,
 				BearerTokenEnvVar: manifest.BearerTokenEnvVar,
 			}
+			entry.CodexAccess = compiledCodexAccessForRender(manifest, target)
+			servers[member] = entry
 			continue
 		}
 		if err := clients.ValidateCommandPath(manifest.Command); err != nil {
@@ -453,7 +459,10 @@ func (a cliApp) cmdRingRender(args []string) error {
 			continue
 		}
 
-		entry := renderedServer{Command: manifest.Command}
+		entry := renderedServer{
+			Command:     manifest.Command,
+			CodexAccess: compiledCodexAccessForRender(manifest, target),
+		}
 		if len(manifest.Args) > 0 {
 			entry.Args = append([]string(nil), manifest.Args...)
 		}
@@ -484,6 +493,48 @@ func (a cliApp) cmdRingRender(args []string) error {
 	}
 
 	return renderTarget.render(a.stdout, servers)
+}
+
+func compiledCodexAccessForRender(manifest registry.Manifest, target string) *codexclient.CompiledAccess {
+	if target != codexclient.Target || manifest.Access == nil {
+		return nil
+	}
+	compiled := codexclient.CompileAccess(manifest.Access)
+	return &compiled
+}
+
+// preflightRequiredRingRenderEntries closes the legacy render path's
+// omit-and-warn behavior for a required ring. Generic policy preflight checks
+// member existence, enabled state, target selection, and access bounds; this
+// target-materialization pass rejects members that render would otherwise omit
+// because their transport/auth shape or executable cannot be represented.
+func preflightRequiredRingRenderEntries(ring registry.Ring, manifests map[string]registry.Manifest, target string) error {
+	if !ring.RequiresPolicyEnforcement() {
+		return nil
+	}
+	members := append([]string(nil), ring.Members...)
+	sort.Strings(members)
+	for _, member := range members {
+		member = strings.TrimSpace(member)
+		manifest, exists := manifests[member]
+		if !exists || !manifest.Enabled || !manifest.HasClient(target) {
+			// The generic policy preflight reports these conditions first.
+			continue
+		}
+		if manifest.IsRemote() {
+			if detail, unsupported := unsupportedRemoteForTarget(manifest, target); unsupported {
+				if detail.Auth != "" {
+					return fmt.Errorf("ring %q requires exact policy rendering, but member %q uses unsupported %s for %s", ring.Name, member, detail.Auth, target)
+				}
+				return fmt.Errorf("ring %q requires exact policy rendering, but member %q uses unsupported %s transport for %s", ring.Name, member, detail.Transport, target)
+			}
+			continue
+		}
+		if err := clients.ValidateCommandPath(manifest.Command); err != nil {
+			return fmt.Errorf("ring %q requires exact policy rendering, but member %q cannot be rendered: %s", ring.Name, member, err.Message)
+		}
+	}
+	return nil
 }
 
 func printRingRenderHelp(out io.Writer) {
@@ -606,14 +657,14 @@ func (a cliApp) cmdRingAttach(args []string) error {
 		Rings:      rings,
 		Scope:      scope,
 	}
-	if len(ring.Skills) > 0 && !dryRun {
-		if _, err := a.attachRingSkills(ring, target, scope, true); err != nil {
-			return err
-		}
-	}
 	if len(ring.Members) > 0 && !dryRun {
 		opts.DryRun = true
 		if _, err := adapter.AttachRing(ring, syncable, opts); err != nil {
+			return err
+		}
+	}
+	if len(ring.Skills) > 0 && !dryRun {
+		if _, err := a.attachRingSkills(ring, target, scope, true); err != nil {
 			return err
 		}
 	}

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -1002,6 +1002,7 @@ func (a cliApp) cmdDoctor(args []string) error {
 			formatNameList(dr.Orphaned),
 			fix,
 		)
+		printPolicyDriftDetail(a.stdout, label, fix, dr.Status, dr.PolicyStale)
 	}
 
 	for _, issue := range report.RingIssues {
@@ -1212,6 +1213,7 @@ func (a cliApp) cmdStatus(args []string) error {
 			continue
 		}
 		fmt.Fprintf(a.stdout, "%s-drift: stale=%d missing=%d orphaned=%d (fix: %s)\n", label, len(dr.Stale), len(dr.Missing), len(dr.Orphaned), fix)
+		printPolicyDriftSummary(a.stdout, label, fix, dr.PolicyStale)
 	}
 	if len(report.ManifestErrors) > 0 {
 		fmt.Fprintf(a.stdout, "manifest-errors: %d\n", len(report.ManifestErrors))
@@ -1692,6 +1694,20 @@ func formatNameList(names []string) string {
 		return "-"
 	}
 	return strings.Join(names, ",")
+}
+
+func printPolicyDriftDetail(out io.Writer, label, fix string, status doctor.Status, stale []string) {
+	if len(stale) == 0 {
+		return
+	}
+	fmt.Fprintf(out, "%s policy drift: [%s] stale=%s (fix: %s)\n", label, status, formatNameList(stale), fix)
+}
+
+func printPolicyDriftSummary(out io.Writer, label, fix string, stale []string) {
+	if len(stale) == 0 {
+		return
+	}
+	fmt.Fprintf(out, "%s-policy-drift: stale=%d (fix: %s)\n", label, len(stale), fix)
 }
 
 func printSyncSummary(stdout, stderr io.Writer, target, configPath string, dryRun bool, added, updated, removed, unchanged, skipped []string, unsupportedRemote []unsupportedRemoteManifest, refused []string) {

--- a/cmd/madari/run.go
+++ b/cmd/madari/run.go
@@ -750,18 +750,29 @@ func (a cliApp) cmdSync(args []string) error {
 	if err := preflightAttachedRequiredRingPolicies(rings, policyAttachedRings, manifests, target); err != nil {
 		return commandInputError("sync", err.Error())
 	}
-	if !dryRun {
-		if _, err := a.syncRingSkills(target, scope, rings, true, attachedRingsBeforeSync); err != nil {
-			return err
-		}
+	if err := preflightRequiredRingServerOwnership(rings, policyAttachedRings, attachedRingsBeforeSync, target); err != nil {
+		return commandInputError("sync", err.Error())
 	}
-	result, err := adapter.Sync(syncable, clients.SyncOptions{
+	syncOpts := clients.SyncOptions{
 		ConfigPath: configPath,
 		StatePath:  statePath,
 		Rings:      rings,
 		Scope:      scope,
 		DryRun:     dryRun,
-	})
+	}
+	if !dryRun && hasAttachedRequiredRingPolicy(rings, policyAttachedRings) {
+		preflightOpts := syncOpts
+		preflightOpts.DryRun = true
+		if _, err := adapter.Sync(syncable, preflightOpts); err != nil {
+			return err
+		}
+	}
+	if !dryRun {
+		if _, err := a.syncRingSkills(target, scope, rings, true, attachedRingsBeforeSync); err != nil {
+			return err
+		}
+	}
+	result, err := adapter.Sync(syncable, syncOpts)
 	if err != nil {
 		return err
 	}
@@ -778,6 +789,7 @@ func (a cliApp) cmdSync(args []string) error {
 			DryRun:            result.DryRun,
 			Added:             nonNilStrings(result.Added),
 			Updated:           nonNilStrings(result.Updated),
+			PolicyUpdated:     nonNilStrings(result.PolicyUpdated),
 			Removed:           nonNilStrings(result.Removed),
 			Unchanged:         nonNilStrings(result.Unchanged),
 			Skipped:           nonNilStrings(skipped),

--- a/cmd/madari/run_codex.go
+++ b/cmd/madari/run_codex.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	codexclient "github.com/ankitvg/madari/internal/clients/codex"
 	"github.com/ankitvg/madari/internal/clients/syncshared"
 	"github.com/ankitvg/madari/internal/registry"
 )
@@ -19,6 +20,11 @@ func runCodex(a cliApp, plan runLaunchPlan, prompt string) error {
 	codexPath, err := exec.LookPath("codex")
 	if err != nil {
 		return fmt.Errorf("codex not found in PATH; install Codex CLI or use --dry-run to inspect the launch plan")
+	}
+	if runPlanUsesPolicyContract(plan) {
+		if err := validateCodexPolicyRunCompatibility(); err != nil {
+			return err
+		}
 	}
 
 	workingDir, err := os.Getwd()
@@ -48,7 +54,11 @@ func runCodex(a cliApp, plan runLaunchPlan, prompt string) error {
 		return err
 	}
 
-	args := []string{"exec", "--ephemeral", "--ignore-user-config", "--skip-git-repo-check", "--sandbox", "read-only", "--cd", runRoot}
+	args := []string{"exec"}
+	if runPlanHasDeclaredAccess(plan) {
+		args = append(args, "--strict-config")
+	}
+	args = append(args, "--ephemeral", "--ignore-user-config", "--skip-git-repo-check", "--sandbox", "read-only", "--cd", runRoot)
 	for _, override := range overrides {
 		args = append(args, "-c", override)
 	}
@@ -63,6 +73,22 @@ func runCodex(a cliApp, plan runLaunchPlan, prompt string) error {
 		return fmt.Errorf("run codex exec: %w", err)
 	}
 	return nil
+}
+
+func runPlanUsesPolicyContract(plan runLaunchPlan) bool {
+	if plan.PolicyRequired {
+		return true
+	}
+	return runPlanHasDeclaredAccess(plan)
+}
+
+func runPlanHasDeclaredAccess(plan runLaunchPlan) bool {
+	for _, server := range plan.Servers {
+		if server.Policy.Declared != nil || server.Manifest.Access != nil {
+			return true
+		}
+	}
+	return false
 }
 
 var codexAdminSkillRoots = []string{
@@ -189,17 +215,29 @@ func withEnvValue(env []string, key, value string) []string {
 }
 
 func codexRunConfigOverrides(store *registry.Store, plan runLaunchPlan, workingDir string) ([]string, error) {
-	manifests, err := store.List()
-	if err != nil {
-		return nil, err
-	}
 	callerEnv, err := codexCallerIsolatedEnv()
 	if err != nil {
 		return nil, err
 	}
-	byName := make(map[string]registry.Manifest, len(manifests))
-	for _, manifest := range manifests {
-		byName[manifest.Name] = manifest
+	byName := make(map[string]registry.Manifest, len(plan.Servers))
+	needsStoreFallback := false
+	for _, server := range plan.Servers {
+		if server.Manifest.Name == server.Name {
+			byName[server.Name] = server.Manifest
+		} else {
+			needsStoreFallback = true
+		}
+	}
+	if needsStoreFallback {
+		manifests, err := store.List()
+		if err != nil {
+			return nil, err
+		}
+		for _, manifest := range manifests {
+			if _, planned := byName[manifest.Name]; !planned {
+				byName[manifest.Name] = manifest
+			}
+		}
 	}
 
 	names := make([]string, 0, len(plan.Servers))
@@ -261,6 +299,7 @@ func codexRunServerConfigValue(manifest registry.Manifest, workingDir string, ca
 		if len(manifest.Headers) > 0 {
 			fields = append(fields, fmt.Sprintf("http_headers = %s", tomlInlineStringMap(manifest.Headers)))
 		}
+		fields = append(fields, codexRunAccessConfigFields(manifest.Access)...)
 		return "{ " + strings.Join(fields, ", ") + " }", nil
 	}
 	if issues := codexRunServerPlanIssues(manifest); len(issues) > 0 {
@@ -278,7 +317,39 @@ func codexRunServerConfigValue(manifest registry.Manifest, workingDir string, ca
 	if env := codexRunStaticEnv(manifest, callerEnv); len(env) > 0 {
 		fields = append(fields, fmt.Sprintf("env = %s", tomlInlineStringMap(env)))
 	}
+	fields = append(fields, codexRunAccessConfigFields(manifest.Access)...)
 	return "{ " + strings.Join(fields, ", ") + " }", nil
+}
+
+func codexRunAccessConfigFields(access *registry.AccessProfile) []string {
+	compiled := codexclient.CompileAccess(access)
+	fields := make([]string, 0, 5)
+	if compiled.EnabledTools != nil && len(*compiled.EnabledTools) > 0 {
+		fields = append(fields, fmt.Sprintf("enabled_tools = %s", tomlStringArray(*compiled.EnabledTools)))
+	}
+	if compiled.DisabledTools != nil && len(*compiled.DisabledTools) > 0 {
+		fields = append(fields, fmt.Sprintf("disabled_tools = %s", tomlStringArray(*compiled.DisabledTools)))
+	}
+	if compiled.Scopes != nil && len(*compiled.Scopes) > 0 {
+		fields = append(fields, fmt.Sprintf("scopes = %s", tomlStringArray(*compiled.Scopes)))
+	}
+	if compiled.DefaultApproval != nil && *compiled.DefaultApproval != "" {
+		fields = append(fields, fmt.Sprintf("default_tools_approval_mode = %s", tomlString(*compiled.DefaultApproval)))
+	}
+	if compiled.ToolApprovals != nil {
+		tools := make([]string, 0, len(*compiled.ToolApprovals))
+		for _, tool := range sortedMapKeys(*compiled.ToolApprovals) {
+			approval := (*compiled.ToolApprovals)[tool]
+			if approval == "" {
+				continue
+			}
+			tools = append(tools, fmt.Sprintf("%s = { approval_mode = %s }", tomlKey(tool), tomlString(approval)))
+		}
+		if len(tools) > 0 {
+			fields = append(fields, "tools = { "+strings.Join(tools, ", ")+" }")
+		}
+	}
+	return fields
 }
 
 func codexRunServerPlanIssues(manifest registry.Manifest) []string {

--- a/cmd/madari/run_codex_test.go
+++ b/cmd/madari/run_codex_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/ankitvg/madari/internal/registry"
+	"github.com/pelletier/go-toml/v2"
 )
 
 func TestRunWithStoreCodexRunExecutesWithRingServersAndPrompt(t *testing.T) {
@@ -423,6 +424,60 @@ func TestCodexRunServerConfigValueBlocksSecretIsolatedEnvKeys(t *testing.T) {
 	}
 }
 
+func TestCodexRunConfigOverridesCompilePolicyDeterministically(t *testing.T) {
+	store := newTestStore(t)
+	allowed := []string{"tools.write", "tools.inherit", "tools.read\x7f"}
+	denied := []string{"tools.remove", "tools.delete"}
+	scopes := []string{"repo.write", "repo.read"}
+	defaultApproval := registry.ApprovalBehaviorAlwaysPrompt
+	toolApprovals := map[string]registry.ApprovalBehavior{
+		"tools.write":    registry.ApprovalBehaviorAlwaysAllow,
+		"tools.inherit":  registry.ApprovalBehaviorInherit,
+		"tools.read\x7f": registry.ApprovalBehaviorAutomatic,
+	}
+	if err := store.Save(registry.Manifest{
+		Name: "docs.server", Transport: registry.TransportHTTP, URL: "https://example.com/mcp",
+		Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{
+			AllowedTools: &allowed, DeniedTools: &denied, OAuthScopes: &scopes,
+			DefaultApproval: &defaultApproval, ToolApprovals: &toolApprovals,
+		},
+	}); err != nil {
+		t.Fatalf("save policy server: %v", err)
+	}
+	empty := []string{}
+	inherit := registry.ApprovalBehaviorInherit
+	clearApprovals := map[string]registry.ApprovalBehavior{"tools.clear": registry.ApprovalBehaviorInherit}
+	if err := store.Save(registry.Manifest{
+		Name: "z-last", Transport: registry.TransportHTTP, URL: "https://example.com/last",
+		Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{
+			AllowedTools: &empty, DeniedTools: &empty, OAuthScopes: &empty,
+			DefaultApproval: &inherit, ToolApprovals: &clearApprovals,
+		},
+	}); err != nil {
+		t.Fatalf("save explicit-clear server: %v", err)
+	}
+
+	overrides, err := codexRunConfigOverrides(store, runLaunchPlan{
+		Servers: []runPlanServer{{Name: "z-last"}, {Name: "docs.server"}},
+	}, t.TempDir())
+	if err != nil {
+		t.Fatalf("compile Codex run overrides: %v", err)
+	}
+	want := `mcp_servers={ "docs.server" = { url = "https://example.com/mcp", required = true, enabled_tools = ["tools.inherit", "tools.read\u007F", "tools.write"], disabled_tools = ["tools.delete", "tools.remove"], scopes = ["repo.read", "repo.write"], default_tools_approval_mode = "prompt", tools = { "tools.read\u007F" = { approval_mode = "auto" }, "tools.write" = { approval_mode = "approve" } } }, z-last = { url = "https://example.com/last", required = true } }`
+	if len(overrides) != 1 || overrides[0] != want {
+		t.Fatalf("unexpected deterministic policy override:\nwant %#v\ngot  %#v", []string{want}, overrides)
+	}
+	if strings.ContainsRune(overrides[0], '\x7f') || strings.Contains(overrides[0], `approval_mode = ""`) {
+		t.Fatalf("override did not omit inherit or escape controls: %q", overrides[0])
+	}
+	var parsed map[string]any
+	if err := toml.Unmarshal([]byte(overrides[0]), &parsed); err != nil {
+		t.Fatalf("compiled policy override is not valid TOML: %v\n%s", err, overrides[0])
+	}
+}
+
 func withCodexAdminSkillRoots(t *testing.T, roots []string) {
 	t.Helper()
 	previous := codexAdminSkillRoots
@@ -448,6 +503,7 @@ func installFakeCodex(t *testing.T, exitCode int) string {
 	logPath := filepath.Join(t.TempDir(), "codex-args.bin")
 	name := "codex"
 	script := []byte("#!/bin/sh\n" +
+		"if [ \"$1\" = \"--version\" ]; then printf 'codex-cli 0.139.0\\n'; exit 0; fi\n" +
 		"printf '%s' \"$PWD\" > '" + logPath + ".pwd'\n" +
 		"printf '%s' \"$HOME\" > '" + logPath + ".home'\n" +
 		"printf '%s' \"$CODEX_HOME\" > '" + logPath + ".codexhome'\n" +
@@ -464,7 +520,7 @@ func installFakeCodex(t *testing.T, exitCode int) string {
 		"exit " + strconv.Itoa(exitCode) + "\n")
 	if runtime.GOOS == "windows" {
 		name = "codex.bat"
-		script = []byte("@echo off\r\nexit /b " + strconv.Itoa(exitCode) + "\r\n")
+		script = []byte("@echo off\r\nif \"%1\"==\"--version\" (\r\n  echo codex-cli 0.139.0\r\n  exit /b 0\r\n)\r\nexit /b " + strconv.Itoa(exitCode) + "\r\n")
 	}
 	codexPath := filepath.Join(binDir, name)
 	if err := os.WriteFile(codexPath, script, 0o755); err != nil {

--- a/cmd/madari/run_codex_version.go
+++ b/cmd/madari/run_codex_version.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const minimumCodexPolicyRunVersion = "0.139.0"
+
+var codexSemanticVersionPattern = regexp.MustCompile(`([0-9]+)\.([0-9]+)\.([0-9]+)(-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?`)
+
+type codexSemanticVersion struct {
+	major      int
+	minor      int
+	patch      int
+	prerelease string
+}
+
+func validateCodexPolicyRunCompatibility() error {
+	return validateCodexPolicyRunVersion()
+}
+
+func validateCodexPolicyRunVersion() error {
+	path, err := exec.LookPath("codex")
+	if err != nil {
+		return fmt.Errorf("codex executable not found in PATH; install a stable Codex CLI 0.139.x release (minimum %s) for capability policy runs", minimumCodexPolicyRunVersion)
+	}
+	output, err := exec.Command(path, "--version").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("inspect Codex version for capability policy run: %w", err)
+	}
+	current, err := parseCodexSemanticVersion(string(output))
+	if err != nil {
+		return fmt.Errorf("cannot verify Codex capability policy support from version output %q: %w", strings.TrimSpace(string(output)), err)
+	}
+	minimum, _ := parseCodexSemanticVersion(minimumCodexPolicyRunVersion)
+	if current.lessThan(minimum) || current.major != 0 || current.minor != 139 || current.prerelease != "" {
+		return fmt.Errorf("Codex %s is outside the validated capability policy run range; install a stable Codex CLI 0.139.x release (minimum %s)", current, minimumCodexPolicyRunVersion)
+	}
+	return nil
+}
+
+func parseCodexSemanticVersion(output string) (codexSemanticVersion, error) {
+	match := codexSemanticVersionPattern.FindStringSubmatch(strings.TrimSpace(output))
+	if len(match) != 5 {
+		return codexSemanticVersion{}, fmt.Errorf("expected MAJOR.MINOR.PATCH")
+	}
+	parts := [3]int{}
+	for i := range parts {
+		value, err := strconv.Atoi(match[i+1])
+		if err != nil {
+			return codexSemanticVersion{}, fmt.Errorf("parse version component %q: %w", match[i+1], err)
+		}
+		parts[i] = value
+	}
+	return codexSemanticVersion{major: parts[0], minor: parts[1], patch: parts[2], prerelease: match[4]}, nil
+}
+
+func (v codexSemanticVersion) lessThan(other codexSemanticVersion) bool {
+	if v.major != other.major {
+		return v.major < other.major
+	}
+	if v.minor != other.minor {
+		return v.minor < other.minor
+	}
+	if v.patch != other.patch {
+		return v.patch < other.patch
+	}
+	return v.prerelease != "" && other.prerelease == ""
+}
+
+func (v codexSemanticVersion) String() string {
+	return fmt.Sprintf("%d.%d.%d%s", v.major, v.minor, v.patch, v.prerelease)
+}

--- a/cmd/madari/run_codex_version_test.go
+++ b/cmd/madari/run_codex_version_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestParseCodexSemanticVersion(t *testing.T) {
+	cases := []struct {
+		output string
+		want   string
+	}{
+		{"codex-cli 0.139.0", "0.139.0"},
+		{"codex-cli 0.140.1-beta.2", "0.140.1-beta.2"},
+		{"1.0.0", "1.0.0"},
+	}
+	for _, tc := range cases {
+		got, err := parseCodexSemanticVersion(tc.output)
+		if err != nil {
+			t.Fatalf("parse %q: %v", tc.output, err)
+		}
+		if got.String() != tc.want {
+			t.Fatalf("parse %q: got %s want %s", tc.output, got, tc.want)
+		}
+	}
+	if _, err := parseCodexSemanticVersion("codex development build"); err == nil {
+		t.Fatalf("expected unversioned build to fail closed")
+	}
+	minimum, _ := parseCodexSemanticVersion("0.139.0")
+	boundaries := []struct {
+		version string
+		older   bool
+	}{
+		{"0.138.9", true},
+		{"0.139.0-beta.1", true},
+		{"0.139.0", false},
+		{"0.140.0-beta.1", false},
+	}
+	for _, boundary := range boundaries {
+		version, err := parseCodexSemanticVersion(boundary.version)
+		if err != nil {
+			t.Fatalf("parse boundary %s: %v", boundary.version, err)
+		}
+		if got := version.lessThan(minimum); got != boundary.older {
+			t.Fatalf("boundary %s older=%t want %t", boundary.version, got, boundary.older)
+		}
+	}
+}
+
+func TestValidateCodexPolicyRunVersionRejectsOlderCLI(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-specific")
+	}
+	binDir := t.TempDir()
+	path := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nprintf 'codex-cli 0.138.9\\n'\n"), 0o755); err != nil {
+		t.Fatalf("write fake Codex: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+	err := validateCodexPolicyRunVersion()
+	if err == nil || !strings.Contains(err.Error(), "stable Codex CLI 0.139.x") {
+		t.Fatalf("expected old Codex refusal, got: %v", err)
+	}
+}
+
+func TestValidateCodexPolicyRunCompatibilityRejectsUnvalidatedNewerSeries(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-specific")
+	}
+	binDir := t.TempDir()
+	path := filepath.Join(binDir, "codex")
+	script := "#!/bin/sh\nprintf 'codex-cli 0.140.0\\n'\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake Codex: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+	err := validateCodexPolicyRunCompatibility()
+	if err == nil || !strings.Contains(err.Error(), "stable Codex CLI 0.139.x") {
+		t.Fatalf("expected unvalidated version refusal, got: %v", err)
+	}
+}

--- a/cmd/madari/run_plan.go
+++ b/cmd/madari/run_plan.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/ankitvg/madari/internal/clients"
+	codexclient "github.com/ankitvg/madari/internal/clients/codex"
 	"github.com/ankitvg/madari/internal/policy"
 	"github.com/ankitvg/madari/internal/registry"
 )
@@ -18,18 +19,20 @@ import (
 const runDryRunOnlyMessage = "madari run execution is only implemented for codex; pass --dry-run to inspect the launch plan"
 
 type runPlanJSON struct {
-	SchemaVersion   int             `json:"schema_version"`
-	Command         string          `json:"command"`
-	Target          string          `json:"target"`
-	Rings           []string        `json:"rings"`
-	Ready           bool            `json:"ready"`
-	RunnerAvailable bool            `json:"runner_available"`
-	PromptProvided  bool            `json:"prompt_provided"`
-	Servers         []runPlanServer `json:"servers"`
-	Skills          []runPlanSkill  `json:"skills"`
-	Env             []runPlanEnv    `json:"env"`
-	Warnings        []string        `json:"warnings"`
-	Errors          []string        `json:"errors"`
+	SchemaVersion   int               `json:"schema_version"`
+	Command         string            `json:"command"`
+	Target          string            `json:"target"`
+	Rings           []string          `json:"rings"`
+	Ready           bool              `json:"ready"`
+	RunnerAvailable bool              `json:"runner_available"`
+	PromptProvided  bool              `json:"prompt_provided"`
+	PolicyRequired  bool              `json:"policy_required"`
+	PolicyControls  runPolicyControls `json:"policy_controls"`
+	Servers         []runPlanServer   `json:"servers"`
+	Skills          []runPlanSkill    `json:"skills"`
+	Env             []runPlanEnv      `json:"env"`
+	Warnings        []string          `json:"warnings"`
+	Errors          []string          `json:"errors"`
 }
 
 type runLaunchPlan struct {
@@ -38,6 +41,8 @@ type runLaunchPlan struct {
 	Ready           bool
 	RunnerAvailable bool
 	PromptProvided  bool
+	PolicyRequired  bool
+	PolicyControls  runPolicyControls
 	Servers         []runPlanServer
 	Skills          []runPlanSkill
 	Env             []runPlanEnv
@@ -46,14 +51,40 @@ type runLaunchPlan struct {
 }
 
 type runPlanServer struct {
-	Name       string   `json:"name"`
-	Transport  string   `json:"transport"`
-	Endpoint   string   `json:"endpoint"`
-	Status     string   `json:"status"`
-	Auth       string   `json:"auth,omitempty"`
-	RuntimeEnv []string `json:"runtime_env"`
-	Rings      []string `json:"rings"`
-	Issues     []string `json:"issues"`
+	Name       string              `json:"name"`
+	Transport  string              `json:"transport"`
+	Endpoint   string              `json:"endpoint"`
+	Status     string              `json:"status"`
+	Auth       string              `json:"auth,omitempty"`
+	RuntimeEnv []string            `json:"runtime_env"`
+	Rings      []string            `json:"rings"`
+	Issues     []string            `json:"issues"`
+	Policy     runPlanServerPolicy `json:"policy"`
+	Manifest   registry.Manifest   `json:"-"`
+}
+
+type runPolicyControls struct {
+	ToolFiltering string `json:"tool_filtering"`
+	OAuthScopes   string `json:"oauth_scopes"`
+	Approvals     string `json:"approvals"`
+	Instructions  string `json:"instructions"`
+}
+
+type runPlanServerPolicy struct {
+	Declared                  *accessJSON                  `json:"declared,omitempty"`
+	RingEnforcement           string                       `json:"ring_enforcement"`
+	RequiredBy                []string                     `json:"required_by"`
+	Effective                 *runPlanEffectiveCodexPolicy `json:"effective,omitempty"`
+	SupportState              string                       `json:"support_state"`
+	EnforcementClassification string                       `json:"enforcement_classification"`
+}
+
+type runPlanEffectiveCodexPolicy struct {
+	EnabledTools             []string          `json:"enabled_tools"`
+	DisabledTools            []string          `json:"disabled_tools"`
+	RequestedOAuthScopes     []string          `json:"requested_oauth_scopes"`
+	DefaultToolsApprovalMode string            `json:"default_tools_approval_mode,omitempty"`
+	ToolApprovalModes        map[string]string `json:"tool_approval_modes"`
 }
 
 type runPlanSkill struct {
@@ -146,6 +177,12 @@ func (a cliApp) buildRunPlan(target string, ringNames []string, prompt string) (
 		Rings:           nonNilStrings(normalizedRingNames(ringNames)),
 		RunnerAvailable: false,
 		PromptProvided:  strings.TrimSpace(prompt) != "",
+		PolicyControls: runPolicyControls{
+			ToolFiltering: "client-enforced",
+			OAuthScopes:   "requested/client-configured/provider-unverified",
+			Approvals:     "client-control/not-authorization",
+			Instructions:  "contracts-and-skills-advisory",
+		},
 	}
 	addPlanError := func(message string) {
 		plan.Errors = append(plan.Errors, message)
@@ -188,6 +225,8 @@ func (a cliApp) buildRunPlan(target string, ringNames []string, prompt string) (
 
 	serverRings := map[string][]string{}
 	skillRings := map[string][]string{}
+	requiredByServer := map[string][]string{}
+	policySupportByServer := map[string]string{}
 	for _, name := range plan.Rings {
 		ring, err := a.store.GetRing(name)
 		if err != nil {
@@ -197,8 +236,32 @@ func (a cliApp) buildRunPlan(target string, ringNames []string, prompt string) (
 			}
 			return runLaunchPlan{}, err
 		}
-		if err := preflightRequiredRingPolicy(ring, manifests, target, policy.SurfaceRun); err != nil {
+		validation := policy.ValidateRequiredRing(ring, manifests, target, policy.SurfaceRun)
+		if err := validation.Err(); err != nil {
 			addPlanError(err.Error())
+		}
+		if ring.RequiresPolicyEnforcement() {
+			plan.PolicyRequired = true
+			for _, member := range ring.Members {
+				member = strings.TrimSpace(member)
+				if member != "" {
+					requiredByServer[member] = appendUniqueName(requiredByServer[member], name)
+					policySupportByServer[member] = strongestPolicySupport(policySupportByServer[member], "supported")
+				}
+			}
+			for _, issue := range validation.Issues {
+				state := policySupportForIssue(issue)
+				if issue.Member != "" {
+					policySupportByServer[issue.Member] = strongestPolicySupport(policySupportByServer[issue.Member], state)
+					continue
+				}
+				for _, member := range ring.Members {
+					member = strings.TrimSpace(member)
+					if member != "" {
+						policySupportByServer[member] = strongestPolicySupport(policySupportByServer[member], state)
+					}
+				}
+			}
 		}
 		for _, member := range ring.Members {
 			member = strings.TrimSpace(member)
@@ -210,6 +273,29 @@ func (a cliApp) buildRunPlan(target string, ringNames []string, prompt string) (
 			skill = strings.TrimSpace(skill)
 			if skill != "" {
 				skillRings[skill] = appendUniqueName(skillRings[skill], name)
+			}
+		}
+	}
+	declaredAccessServers := map[string]bool{}
+	for name := range serverRings {
+		if manifest, exists := manifestByName[name]; exists && manifest.Access != nil {
+			declaredAccessServers[name] = true
+		}
+	}
+	policyRuntimeBlocked := false
+	if target == codexclient.Target && (plan.PolicyRequired || len(declaredAccessServers) > 0) {
+		if !plan.RunnerAvailable {
+			policyRuntimeBlocked = true
+		} else if err := validateCodexPolicyRunCompatibility(); err != nil {
+			policyRuntimeBlocked = true
+			addPlanError(err.Error())
+		}
+		if policyRuntimeBlocked {
+			for name := range requiredByServer {
+				policySupportByServer[name] = strongestPolicySupport(policySupportByServer[name], "unsupported")
+			}
+			for name := range declaredAccessServers {
+				policySupportByServer[name] = strongestPolicySupport(policySupportByServer[name], "unsupported")
 			}
 		}
 	}
@@ -229,10 +315,13 @@ func (a cliApp) buildRunPlan(target string, ringNames []string, prompt string) (
 		if !exists {
 			server.Status = "blocked"
 			server.Issues = append(server.Issues, "server is missing from the registry")
+			policySupportByServer[name] = strongestPolicySupport(policySupportByServer[name], "invalid")
+			server.Policy = buildRunPlanServerPolicy(nil, target, requiredByServer[name], policySupportByServer[name], true)
 			plan.Servers = append(plan.Servers, server)
 			addPlanError(fmt.Sprintf("ring member %s no longer exists in the registry", name))
 			continue
 		}
+		server.Manifest = manifest
 		server.Transport = manifest.TransportType()
 		server.Endpoint = manifestEndpoint(manifest)
 		server.Auth = runPlanAuth(manifest)
@@ -279,6 +368,13 @@ func (a cliApp) buildRunPlan(target string, ringNames []string, prompt string) (
 			for _, issue := range server.Issues {
 				addPlanError(fmt.Sprintf("server %s: %s", name, issue))
 			}
+		}
+		server.Policy = buildRunPlanServerPolicy(&manifest, target, requiredByServer[name], policySupportByServer[name], policyRuntimeBlocked || server.Status == "blocked")
+		if server.Policy.EnforcementClassification == "blocked" && server.Status != "blocked" {
+			server.Status = "blocked"
+			issue := fmt.Sprintf("capability policy enforcement is blocked: support=%s", server.Policy.SupportState)
+			server.Issues = append(server.Issues, issue)
+			addPlanError(fmt.Sprintf("server %s: %s", name, issue))
 		}
 		plan.Servers = append(plan.Servers, server)
 	}
@@ -341,6 +437,8 @@ func (p runLaunchPlan) toJSON() runPlanJSON {
 		Ready:           p.Ready,
 		RunnerAvailable: p.RunnerAvailable,
 		PromptProvided:  p.PromptProvided,
+		PolicyRequired:  p.PolicyRequired,
+		PolicyControls:  p.PolicyControls,
 		Servers:         nonNilRunPlanServers(p.Servers),
 		Skills:          nonNilRunPlanSkills(p.Skills),
 		Env:             nonNilRunPlanEnv(p.Env),
@@ -358,6 +456,96 @@ func runPlanAuth(manifest registry.Manifest) string {
 	default:
 		return ""
 	}
+}
+
+func strongestPolicySupport(current, candidate string) string {
+	rank := map[string]int{"": 0, "not-declared": 1, "supported": 2, "unsupported": 3, "invalid": 4}
+	if rank[candidate] > rank[current] {
+		return candidate
+	}
+	return current
+}
+
+func policySupportForIssue(issue policy.Issue) string {
+	switch issue.Code {
+	case policy.IssueUnsupportedCompiler, policy.IssueUnsupportedFeature,
+		policy.IssueUnsupportedTransport, policy.IssueUnsupportedServerField:
+		return "unsupported"
+	default:
+		return "invalid"
+	}
+}
+
+func buildRunPlanServerPolicy(manifest *registry.Manifest, target string, requiredBy []string, support string, blocked bool) runPlanServerPolicy {
+	requiredBy = nonNilStrings(sortedUniqueStrings(requiredBy))
+	out := runPlanServerPolicy{
+		RingEnforcement: "none",
+		RequiredBy:      requiredBy,
+		SupportState:    support,
+	}
+	if manifest != nil {
+		out.Declared = accessToJSON(manifest.Access)
+	}
+	if len(requiredBy) > 0 {
+		out.RingEnforcement = registry.PolicyEnforcementRequired
+		if out.SupportState == "" {
+			out.SupportState = "supported"
+		}
+		if blocked || out.SupportState != "supported" {
+			out.EnforcementClassification = "blocked"
+		} else {
+			out.EnforcementClassification = "exact"
+		}
+	} else if manifest != nil && manifest.Access != nil {
+		capabilities, known := policy.CapabilitiesFor(target, policy.SurfaceRun)
+		if !known || !capabilities.Compiler {
+			out.SupportState = "unsupported"
+		} else {
+			out.SupportState = strongestPolicySupport(out.SupportState, "supported")
+		}
+		if blocked && out.SupportState != "supported" {
+			out.EnforcementClassification = "blocked"
+		} else {
+			out.EnforcementClassification = "advisory"
+		}
+	} else {
+		out.EnforcementClassification = "none"
+		out.SupportState = "not-declared"
+	}
+
+	if manifest != nil && manifest.Access != nil && target == codexclient.Target {
+		capabilities, known := policy.CapabilitiesFor(target, policy.SurfaceRun)
+		if known && capabilities.Compiler {
+			compiled := codexclient.CompileAccess(manifest.Access)
+			effective := &runPlanEffectiveCodexPolicy{
+				EnabledTools:         []string{},
+				DisabledTools:        []string{},
+				RequestedOAuthScopes: []string{},
+				ToolApprovalModes:    map[string]string{},
+			}
+			if compiled.EnabledTools != nil {
+				effective.EnabledTools = append([]string(nil), (*compiled.EnabledTools)...)
+			}
+			if compiled.DisabledTools != nil {
+				effective.DisabledTools = append([]string(nil), (*compiled.DisabledTools)...)
+			}
+			if compiled.Scopes != nil {
+				effective.RequestedOAuthScopes = append([]string(nil), (*compiled.Scopes)...)
+			}
+			if compiled.DefaultApproval != nil {
+				effective.DefaultToolsApprovalMode = *compiled.DefaultApproval
+			}
+			if compiled.ToolApprovals != nil {
+				for tool, approval := range *compiled.ToolApprovals {
+					if approval != "" {
+						effective.ToolApprovalModes[tool] = approval
+					}
+				}
+			}
+			out.Effective = effective
+		}
+	}
+	return out
 }
 
 func normalizedRingNames(names []string) []string {
@@ -444,6 +632,12 @@ func printRunPlan(out io.Writer, plan runLaunchPlan) {
 	} else {
 		fmt.Fprintln(out, "runner: unavailable")
 	}
+	fmt.Fprintf(out, "policy controls: tool-filtering=%s oauth-scopes=%s approvals=%s instructions=%s\n",
+		plan.PolicyControls.ToolFiltering,
+		plan.PolicyControls.OAuthScopes,
+		plan.PolicyControls.Approvals,
+		plan.PolicyControls.Instructions,
+	)
 	fmt.Fprintln(out)
 
 	fmt.Fprintln(out, "servers:")
@@ -465,6 +659,7 @@ func printRunPlan(out io.Writer, plan runLaunchPlan) {
 			for _, issue := range server.Issues {
 				fmt.Fprintf(out, "    issue: %s\n", issue)
 			}
+			printRunPlanServerPolicy(out, server.Policy)
 		}
 	}
 
@@ -521,6 +716,90 @@ func printRunPlan(out io.Writer, plan runLaunchPlan) {
 	}
 }
 
+func printRunPlanServerPolicy(out io.Writer, policyPlan runPlanServerPolicy) {
+	fmt.Fprintf(out, "    policy: support=%s enforcement=%s ring_enforcement=%s",
+		policyPlan.SupportState,
+		policyPlan.EnforcementClassification,
+		policyPlan.RingEnforcement,
+	)
+	if len(policyPlan.RequiredBy) > 0 {
+		fmt.Fprintf(out, " required_by=%s", formatNameList(policyPlan.RequiredBy))
+	}
+	fmt.Fprintln(out)
+	if policyPlan.Declared == nil {
+		fmt.Fprintln(out, "    declared policy: none")
+	} else {
+		fmt.Fprintf(out, "    declared policy: allowed_tools=%s denied_tools=%s oauth_scopes=%s default_approval=%s tool_approvals=%s\n",
+			formatOptionalStringList(policyPlan.Declared.AllowedTools),
+			formatOptionalStringList(policyPlan.Declared.DeniedTools),
+			formatOptionalStringList(policyPlan.Declared.OAuthScopes),
+			formatOptionalString(policyPlan.Declared.DefaultApproval),
+			formatOptionalStringMap(policyPlan.Declared.ToolApprovals),
+		)
+	}
+	if policyPlan.Effective == nil {
+		fmt.Fprintln(out, "    effective policy: none")
+		return
+	}
+	fmt.Fprintf(out, "    effective policy: enabled_tools=%s disabled_tools=%s requested_oauth_scopes=%s default_tools_approval_mode=%s tool_approval_modes=%s\n",
+		formatEffectiveStringList(policyPlan.Effective.EnabledTools),
+		formatEffectiveStringList(policyPlan.Effective.DisabledTools),
+		formatEffectiveStringList(policyPlan.Effective.RequestedOAuthScopes),
+		formatOptionalEffectiveString(policyPlan.Effective.DefaultToolsApprovalMode),
+		formatStringMap(policyPlan.Effective.ToolApprovalModes),
+	)
+}
+
+func formatEffectiveStringList(values []string) string {
+	if len(values) == 0 {
+		return "target-default"
+	}
+	return strings.Join(values, ",")
+}
+
+func formatOptionalStringList(values *[]string) string {
+	if values == nil {
+		return "absent"
+	}
+	if len(*values) == 0 {
+		return "[]"
+	}
+	return "[" + strings.Join(*values, ",") + "]"
+}
+
+func formatOptionalString(value *string) string {
+	if value == nil {
+		return "absent"
+	}
+	return *value
+}
+
+func formatOptionalEffectiveString(value string) string {
+	if value == "" {
+		return "target-default"
+	}
+	return value
+}
+
+func formatOptionalStringMap(values *map[string]string) string {
+	if values == nil {
+		return "absent"
+	}
+	return formatStringMap(*values)
+}
+
+func formatStringMap(values map[string]string) string {
+	if len(values) == 0 {
+		return "{}"
+	}
+	keys := sortedMapKeys(values)
+	pairs := make([]string, 0, len(keys))
+	for _, key := range keys {
+		pairs = append(pairs, key+"="+values[key])
+	}
+	return "{" + strings.Join(pairs, ",") + "}"
+}
+
 func printRunHelp(out io.Writer) {
 	fmt.Fprintln(out, "Usage:")
 	fmt.Fprintln(out, "  madari run <client> --ring <ring> [--ring <ring> ...] [--dry-run] -- <prompt>")
@@ -540,6 +819,10 @@ func printRunHelp(out io.Writer) {
 	fmt.Fprintln(out, "  working directory and caller HOME/USERPROFILE; Codex gets temporary")
 	fmt.Fprintln(out, "  HOME/CODEX_HOME roots with auth copied in. Other clients are dry-run only")
 	fmt.Fprintln(out, "  for now.")
+	fmt.Fprintln(out, "  Access-bearing Codex runs add --strict-config; legacy no-access runs omit it.")
+	fmt.Fprintln(out, "  Codex policy runs require a validated stable CLI 0.139.x release; dry-run")
+	fmt.Fprintln(out, "  reports declared/effective policy separately from client enforcement and")
+	fmt.Fprintln(out, "  advisory instructions.")
 	fmt.Fprintln(out, "  Run never writes client config, managed state, or permanent skill files.")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Examples:")

--- a/cmd/madari/run_policy_test.go
+++ b/cmd/madari/run_policy_test.go
@@ -1,0 +1,449 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+func TestRunDryRunReportsDeclaredEffectiveAndStrongestRequiredPolicy(t *testing.T) {
+	store := newTestStore(t)
+	installFakeCodex(t, 0)
+	manifest := registry.Manifest{
+		Name: "docs.server", Transport: registry.TransportHTTP, URL: "https://example.com/mcp",
+		Enabled: true, Clients: []string{"codex"}, Access: codexPolicyRenderAccess(),
+	}
+	if err := store.Save(manifest); err != nil {
+		t.Fatalf("save policy manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{Name: "advisory", Members: []string{manifest.Name}}); err != nil {
+		t.Fatalf("save advisory ring: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{
+		Name: "required", Members: []string{manifest.Name},
+		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
+	}); err != nil {
+		t.Fatalf("save required ring: %v", err)
+	}
+
+	result := runCmd(store, "run", "codex", "--ring", "advisory", "--ring", "required", "--dry-run", "--json", "--", "inspect")
+	if result.code != 0 {
+		t.Fatalf("required policy dry-run failed: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	plan := decodeRunPlan(t, result.stdout)
+	if !plan.Ready || len(plan.Servers) != 1 {
+		t.Fatalf("unexpected plan: %#v", plan)
+	}
+	server := plan.Servers[0]
+	if server.Policy.RingEnforcement != registry.PolicyEnforcementRequired ||
+		server.Policy.SupportState != "supported" ||
+		server.Policy.EnforcementClassification != "exact" ||
+		!reflect.DeepEqual(server.Policy.RequiredBy, []string{"required"}) {
+		t.Fatalf("required ring did not win for shared server: %#v", server.Policy)
+	}
+	if server.Policy.Declared == nil || server.Policy.Declared.DefaultApproval == nil || *server.Policy.Declared.DefaultApproval != string(registry.ApprovalBehaviorAlwaysPrompt) {
+		t.Fatalf("portable declared policy missing: %#v", server.Policy.Declared)
+	}
+	effective := server.Policy.Effective
+	if effective == nil ||
+		!reflect.DeepEqual(effective.EnabledTools, []string{"tools.inherit", "tools.read", "tools.write"}) ||
+		!reflect.DeepEqual(effective.DisabledTools, []string{"tools.delete", "tools.remove"}) ||
+		!reflect.DeepEqual(effective.RequestedOAuthScopes, []string{"repo.read", "repo.write"}) ||
+		effective.DefaultToolsApprovalMode != "prompt" ||
+		effective.ToolApprovalModes["tools.read"] != "auto" ||
+		effective.ToolApprovalModes["tools.write"] != "approve" {
+		t.Fatalf("Codex effective policy mismatch: %#v", effective)
+	}
+	if plan.PolicyControls.ToolFiltering != "client-enforced" ||
+		plan.PolicyControls.OAuthScopes != "requested/client-configured/provider-unverified" ||
+		plan.PolicyControls.Approvals != "client-control/not-authorization" ||
+		plan.PolicyControls.Instructions != "contracts-and-skills-advisory" {
+		t.Fatalf("policy controls are ambiguous: %#v", plan.PolicyControls)
+	}
+
+	textResult := runCmd(store, "run", "codex", "--ring", "required", "--dry-run", "--", "inspect")
+	if textResult.code != 0 {
+		t.Fatalf("text dry-run failed: %s", textResult.stderr)
+	}
+	for _, want := range []string{
+		"policy controls: tool-filtering=client-enforced",
+		"oauth-scopes=requested/client-configured/provider-unverified",
+		"approvals=client-control/not-authorization",
+		"instructions=contracts-and-skills-advisory",
+		"policy: support=supported enforcement=exact",
+		"declared policy: allowed_tools=[tools.inherit,tools.read,tools.write]",
+		"effective policy: enabled_tools=tools.inherit,tools.read,tools.write",
+	} {
+		if !strings.Contains(textResult.stdout, want) {
+			t.Fatalf("text policy report missing %q:\n%s", want, textResult.stdout)
+		}
+	}
+}
+
+func TestRunDryRunReportsAdvisoryPolicyWithoutMandatoryClaim(t *testing.T) {
+	store := newTestStore(t)
+	installFakeCodex(t, 0)
+	allowed := []string{"read"}
+	if err := store.Save(registry.Manifest{
+		Name: "docs", Command: mustCurrentExecutable(t), Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{AllowedTools: &allowed},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{Name: "advisory", Members: []string{"docs"}}); err != nil {
+		t.Fatalf("save ring: %v", err)
+	}
+	result := runCmd(store, "run", "codex", "--ring", "advisory", "--dry-run", "--json", "--", "inspect")
+	if result.code != 0 {
+		t.Fatalf("advisory dry-run failed: %s", result.stderr)
+	}
+	policy := decodeRunPlan(t, result.stdout).Servers[0].Policy
+	if policy.SupportState != "supported" || policy.EnforcementClassification != "advisory" || policy.RingEnforcement != "none" || len(policy.RequiredBy) != 0 {
+		t.Fatalf("advisory policy made a mandatory claim: %#v", policy)
+	}
+}
+
+func TestRunAdvisoryPolicyReportsUnsupportedOldCodexTruthfully(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-specific")
+	}
+	store := newTestStore(t)
+	marker := filepath.Join(t.TempDir(), "executed")
+	installPolicyVersionCodex(t, "0.138.9", marker)
+	allowed := []string{"read"}
+	if err := store.Save(registry.Manifest{
+		Name: "docs", Command: mustCurrentExecutable(t), Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{AllowedTools: &allowed},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{Name: "advisory", Members: []string{"docs"}}); err != nil {
+		t.Fatalf("save ring: %v", err)
+	}
+	result := runCmd(store, "run", "codex", "--ring", "advisory", "--dry-run", "--json", "--", "inspect")
+	if result.code == 0 {
+		t.Fatalf("old Codex should not report a runnable advisory policy: %s", result.stdout)
+	}
+	plan := decodeRunPlan(t, result.stdout)
+	policy := plan.Servers[0].Policy
+	if plan.PolicyRequired || policy.RingEnforcement != "none" || policy.SupportState != "unsupported" || policy.EnforcementClassification != "blocked" {
+		t.Fatalf("advisory support state was not truthful: %#v", policy)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("old Codex executed advisory policy: %v", err)
+	}
+}
+
+func TestRunLegacyNoAccessRemainsCompatibleWithOlderCodex(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-specific")
+	}
+	store := newTestStore(t)
+	marker := filepath.Join(t.TempDir(), "executed")
+	installPolicyVersionCodex(t, "0.138.9", marker)
+	if err := store.Save(registry.Manifest{
+		Name: "docs", Command: mustCurrentExecutable(t), Enabled: true, Clients: []string{"codex"},
+	}); err != nil {
+		t.Fatalf("save legacy manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{Name: "legacy", Members: []string{"docs"}}); err != nil {
+		t.Fatalf("save legacy ring: %v", err)
+	}
+	result := runCmd(store, "run", "codex", "--ring", "legacy", "--", "inspect")
+	if result.code != 0 {
+		t.Fatalf("legacy run was broken by policy compatibility checks: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("legacy Codex did not execute: %v", err)
+	}
+}
+
+func TestRunDryRunPreservesDeclaredClearAndReportsTargetDefault(t *testing.T) {
+	store := newTestStore(t)
+	installFakeCodex(t, 0)
+	allowed := []string{"read"}
+	empty := []string{}
+	inherit := registry.ApprovalBehaviorInherit
+	toolApprovals := map[string]registry.ApprovalBehavior{"read": registry.ApprovalBehaviorInherit}
+	if err := store.Save(registry.Manifest{
+		Name: "docs", Command: mustCurrentExecutable(t), Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{
+			AllowedTools: &allowed, DeniedTools: &empty, OAuthScopes: &empty,
+			DefaultApproval: &inherit, ToolApprovals: &toolApprovals,
+		},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{
+		Name: "required", Members: []string{"docs"},
+		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
+	}); err != nil {
+		t.Fatalf("save ring: %v", err)
+	}
+	result := runCmd(store, "run", "codex", "--ring", "required", "--dry-run", "--json", "--", "inspect")
+	if result.code != 0 {
+		t.Fatalf("clear policy dry-run failed: %s", result.stderr)
+	}
+	policy := decodeRunPlan(t, result.stdout).Servers[0].Policy
+	if policy.Declared == nil || policy.Declared.DeniedTools == nil || len(*policy.Declared.DeniedTools) != 0 ||
+		policy.Declared.OAuthScopes == nil || len(*policy.Declared.OAuthScopes) != 0 ||
+		policy.Declared.DefaultApproval == nil || *policy.Declared.DefaultApproval != string(registry.ApprovalBehaviorInherit) ||
+		policy.Declared.ToolApprovals == nil || (*policy.Declared.ToolApprovals)["read"] != string(registry.ApprovalBehaviorInherit) {
+		t.Fatalf("declared clear presence was lost: %#v", policy.Declared)
+	}
+	if policy.Effective == nil || !reflect.DeepEqual(policy.Effective.EnabledTools, []string{"read"}) ||
+		len(policy.Effective.DisabledTools) != 0 || len(policy.Effective.RequestedOAuthScopes) != 0 ||
+		policy.Effective.DefaultToolsApprovalMode != "" || len(policy.Effective.ToolApprovalModes) != 0 {
+		t.Fatalf("effective clear did not resolve to target defaults: %#v", policy.Effective)
+	}
+	textResult := runCmd(store, "run", "codex", "--ring", "required", "--dry-run", "--", "inspect")
+	if textResult.code != 0 || !strings.Contains(textResult.stdout, "disabled_tools=target-default requested_oauth_scopes=target-default default_tools_approval_mode=target-default tool_approval_modes={}") {
+		t.Fatalf("text clear reporting is ambiguous: code=%d stdout=%s stderr=%s", textResult.code, textResult.stdout, textResult.stderr)
+	}
+}
+
+func TestRunRequiredPolicyBlocksOldCodexBeforeExecution(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-specific")
+	}
+	store := newTestStore(t)
+	projectDir := t.TempDir()
+	chdirForTest(t, projectDir)
+	marker := filepath.Join(t.TempDir(), "executed")
+	installPolicyVersionCodex(t, "0.138.9", marker)
+	allowed := []string{"read"}
+	if err := store.Save(registry.Manifest{
+		Name: "docs", Command: mustCurrentExecutable(t), Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{AllowedTools: &allowed},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	saveTestSkillPackage(t, store, "release", "Release workflow")
+	if err := store.SaveRing(registry.Ring{
+		Name: "required", Members: []string{"docs"}, Skills: []string{"release"},
+		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
+	}); err != nil {
+		t.Fatalf("save ring: %v", err)
+	}
+	result := runCmd(store, "run", "codex", "--ring", "required", "--dry-run", "--json", "--", "inspect")
+	if result.code == 0 || !strings.Contains(result.stderr, "launch plan is not ready") {
+		t.Fatalf("old Codex should block readiness: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	plan := decodeRunPlan(t, result.stdout)
+	server := plan.Servers[0]
+	if plan.Ready || server.Status != "blocked" || server.Policy.SupportState != "unsupported" || server.Policy.EnforcementClassification != "blocked" {
+		t.Fatalf("old Codex downgrade was not classified: %#v", plan)
+	}
+	if !strings.Contains(strings.Join(plan.Errors, "\n"), "stable Codex CLI 0.139.x") {
+		t.Fatalf("old Codex error is not actionable: %#v", plan.Errors)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("old Codex was executed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(projectDir, ".agents", "skills", "release", registry.SkillFileName)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("required run materialized a permanent skill before readiness: %v", err)
+	}
+	nonDry := runCmd(store, "run", "codex", "--ring", "required", "--", "inspect")
+	if nonDry.code == 0 || !strings.Contains(nonDry.stderr, "launch plan is not ready") {
+		t.Fatalf("non-dry old Codex run crossed readiness boundary: stdout=%s stderr=%s", nonDry.stdout, nonDry.stderr)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("non-dry old Codex executed: %v", err)
+	}
+}
+
+func TestRunSkillOnlyRequiredPolicyStillGatesCodexCompatibility(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-specific")
+	}
+	store := newTestStore(t)
+	projectDir := t.TempDir()
+	chdirForTest(t, projectDir)
+	marker := filepath.Join(t.TempDir(), "executed")
+	installPolicyVersionCodex(t, "0.138.9", marker)
+	saveTestSkillPackage(t, store, "release", "Release workflow")
+	if err := store.SaveRing(registry.Ring{
+		Name: "workflow", Skills: []string{"release"},
+		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
+	}); err != nil {
+		t.Fatalf("save skill-only ring: %v", err)
+	}
+	result := runCmd(store, "run", "codex", "--ring", "workflow", "--dry-run", "--json", "--", "release")
+	if result.code == 0 {
+		t.Fatalf("skill-only required policy bypassed compatibility gate: %s", result.stdout)
+	}
+	plan := decodeRunPlan(t, result.stdout)
+	if !plan.PolicyRequired || plan.Ready || !strings.Contains(strings.Join(plan.Errors, "\n"), "stable Codex CLI 0.139.x") {
+		t.Fatalf("skill-only policy gate was not reported: %#v", plan)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("old Codex was executed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(projectDir, ".agents", "skills", "release", registry.SkillFileName)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("skill-only required run materialized before compatibility: %v", err)
+	}
+}
+
+func TestRunRequiredPolicyReportsUnrepresentableTimeoutBlocked(t *testing.T) {
+	store := newTestStore(t)
+	installFakeCodex(t, 0)
+	allowed := []string{"read"}
+	if err := store.Save(registry.Manifest{
+		Name: "docs", Transport: registry.TransportHTTP, URL: "https://example.com/mcp", TimeoutMS: 1000,
+		Enabled: true, Clients: []string{"codex"}, Access: &registry.AccessProfile{AllowedTools: &allowed},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{
+		Name: "required", Members: []string{"docs"},
+		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
+	}); err != nil {
+		t.Fatalf("save ring: %v", err)
+	}
+	result := runCmd(store, "run", "codex", "--ring", "required", "--dry-run", "--json", "--", "inspect")
+	if result.code == 0 {
+		t.Fatalf("unrepresentable timeout should block: %s", result.stdout)
+	}
+	server := decodeRunPlan(t, result.stdout).Servers[0]
+	if server.Policy.SupportState != "unsupported" || server.Policy.EnforcementClassification != "blocked" || server.Status != "blocked" {
+		t.Fatalf("timeout downgrade not classified: %#v", server)
+	}
+}
+
+func TestCodexRunOverridesUsePlannedManifestSnapshot(t *testing.T) {
+	store := newTestStore(t)
+	installFakeCodex(t, 0)
+	allowed := []string{"read"}
+	manifest := registry.Manifest{
+		Name: "docs", Command: mustCurrentExecutable(t), Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{AllowedTools: &allowed},
+	}
+	if err := store.Save(manifest); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{
+		Name: "required", Members: []string{"docs"},
+		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
+	}); err != nil {
+		t.Fatalf("save ring: %v", err)
+	}
+	plan, err := (cliApp{store: store}).buildRunPlan("codex", []string{"required"}, "inspect")
+	if err != nil || !plan.Ready {
+		t.Fatalf("build plan: ready=%t err=%v errors=%v", plan.Ready, err, plan.Errors)
+	}
+	changed := []string{"write"}
+	manifest.Access.AllowedTools = &changed
+	if err := store.Save(manifest); err != nil {
+		t.Fatalf("mutate store after plan: %v", err)
+	}
+	overrides, err := codexRunConfigOverrides(store, plan, t.TempDir())
+	if err != nil {
+		t.Fatalf("compile planned overrides: %v", err)
+	}
+	if len(overrides) != 1 || !strings.Contains(overrides[0], `enabled_tools = ["read"]`) || strings.Contains(overrides[0], `enabled_tools = ["write"]`) {
+		t.Fatalf("override re-read a changed manifest instead of using the plan snapshot: %#v", overrides)
+	}
+}
+
+func TestRunRequiredPolicyExecutesWithStrictCompiledOverride(t *testing.T) {
+	store := newTestStore(t)
+	logPath := installFakeCodex(t, 0)
+	allowed := []string{"read"}
+	defaultApproval := registry.ApprovalBehaviorAlwaysPrompt
+	if err := store.Save(registry.Manifest{
+		Name: "docs.server", Command: mustCurrentExecutable(t), Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{AllowedTools: &allowed, DefaultApproval: &defaultApproval},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{
+		Name: "required", Members: []string{"docs.server"},
+		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
+	}); err != nil {
+		t.Fatalf("save ring: %v", err)
+	}
+	result := runCmd(store, "run", "codex", "--ring", "required", "--", "inspect")
+	if result.code != 0 {
+		t.Fatalf("required policy execution failed: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	args := readNULArgs(t, logPath)
+	if len(args) < 2 || args[0] != "exec" || args[1] != "--strict-config" {
+		t.Fatalf("required run did not enable strict config: %#v", args)
+	}
+	overrides := collectConfigOverrides(args)
+	if len(overrides) != 1 || !strings.Contains(overrides[0], `"docs.server"`) ||
+		!strings.Contains(overrides[0], `enabled_tools = ["read"]`) ||
+		!strings.Contains(overrides[0], `default_tools_approval_mode = "prompt"`) {
+		t.Fatalf("required run omitted compiled policy: %#v", overrides)
+	}
+}
+
+func TestRunCodexRechecksPolicyCompatibilityBeforeSkillMaterialization(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-specific")
+	}
+	store := newTestStore(t)
+	installFakeCodex(t, 0)
+	allowed := []string{"read"}
+	if err := store.Save(registry.Manifest{
+		Name: "docs", Command: mustCurrentExecutable(t), Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{AllowedTools: &allowed},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	saveTestSkillPackage(t, store, "release", "Release workflow")
+	if err := store.SaveRing(registry.Ring{
+		Name: "required", Members: []string{"docs"}, Skills: []string{"release"},
+		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
+	}); err != nil {
+		t.Fatalf("save ring: %v", err)
+	}
+	plan, err := (cliApp{store: store}).buildRunPlan("codex", []string{"required"}, "inspect")
+	if err != nil || !plan.Ready {
+		t.Fatalf("build exact plan: ready=%t err=%v errors=%v", plan.Ready, err, plan.Errors)
+	}
+	codexPath, err := exec.LookPath("codex")
+	if err != nil {
+		t.Fatalf("locate fake Codex: %v", err)
+	}
+	marker := filepath.Join(t.TempDir(), "executed")
+	replaced := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--version\" ]; then printf 'codex-cli 0.138.9\\n'; exit 0; fi\n" +
+		"printf executed > '" + marker + "'\n"
+	if err := os.WriteFile(codexPath, []byte(replaced), 0o755); err != nil {
+		t.Fatalf("replace Codex after plan: %v", err)
+	}
+	if err := store.RemoveSkill("release"); err != nil {
+		t.Fatalf("remove planned skill to detect materialization: %v", err)
+	}
+	err = runCodex(cliApp{store: store}, plan, "inspect")
+	if err == nil || !strings.Contains(err.Error(), "stable Codex CLI 0.139.x") {
+		t.Fatalf("executor did not recheck compatibility first: %v", err)
+	}
+	if strings.Contains(err.Error(), "skill") {
+		t.Fatalf("skill materialization happened before compatibility check: %v", err)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("replaced Codex executed: %v", err)
+	}
+}
+
+func installPolicyVersionCodex(t *testing.T, version, executionMarker string) {
+	t.Helper()
+	binDir := t.TempDir()
+	path := filepath.Join(binDir, "codex")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--version\" ]; then printf 'codex-cli " + version + "\\n'; exit 0; fi\n" +
+		"printf executed > '" + executionMarker + "'\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write versioned Codex fixture: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -3200,13 +3200,16 @@ func TestRunWithStoreStatusReportsDrift(t *testing.T) {
 		t.Fatalf("expected one drift entry, got: %v", drift)
 	}
 	entry := drift[0].(map[string]any)
-	assertJSONKeys(t, entry, "target", "scope", "config_path", "status", "stale", "missing", "orphaned", "issue")
+	assertJSONKeys(t, entry, "target", "scope", "config_path", "status", "stale", "policy_stale", "missing", "orphaned", "issue")
 	if entry["target"] != "claude-code" || entry["status"] != "warn" {
 		t.Fatalf("unexpected drift entry: %v", entry)
 	}
 	orphaned := entry["orphaned"].([]any)
 	if len(orphaned) != 1 || orphaned[0] != "driftee" {
 		t.Fatalf("expected driftee orphaned, got: %v", orphaned)
+	}
+	if policyStale := entry["policy_stale"].([]any); len(policyStale) != 0 {
+		t.Fatalf("expected no policy drift for legacy manifest, got: %v", policyStale)
 	}
 }
 

--- a/cmd/madari/run_test.go
+++ b/cmd/madari/run_test.go
@@ -2742,6 +2742,7 @@ func TestRunWithStoreSyncDryRunJSON(t *testing.T) {
     "stewreads"
   ],
   "updated": [],
+  "policy_updated": [],
   "removed": [],
   "unchanged": [],
   "skipped": [],
@@ -2794,6 +2795,7 @@ func TestRunWithStoreSyncReportsUnsupportedRemote(t *testing.T) {
   "dry_run": true,
   "added": [],
   "updated": [],
+  "policy_updated": [],
   "removed": [],
   "unchanged": [],
   "skipped": [],
@@ -2852,6 +2854,7 @@ func TestRunWithStoreSyncReportsUnsupportedRemoteAuth(t *testing.T) {
   "dry_run": true,
   "added": [],
   "updated": [],
+  "policy_updated": [],
   "removed": [],
   "unchanged": [],
   "skipped": [],

--- a/docs/adr/003-capability-policy-contract-v1.md
+++ b/docs/adr/003-capability-policy-contract-v1.md
@@ -133,8 +133,10 @@ stale attachment can always be cleaned up.
 
 Target support is declared centrally and separately for persistent sync/attach,
 render, and run. A compiler must opt into a surface; an unspecified compiler is
-unsupported. The policy-schema PR intentionally leaves every compiler disabled,
-so required operations fail closed until the corresponding compiler lands.
+unsupported. The policy-schema PR initially left every compiler disabled. The
+Codex compiler now opts into persistent sync/attach and render for all five V1
+access fields; Codex run and other target surfaces remain disabled until their
+corresponding lossless compilers land.
 
 For persistent sync, undeclared native policy fields are preserved. Declared
 fields are compiled exactly. A required operation blocks on unknown

--- a/docs/adr/003-capability-policy-contract-v1.md
+++ b/docs/adr/003-capability-policy-contract-v1.md
@@ -134,9 +134,11 @@ stale attachment can always be cleaned up.
 Target support is declared centrally and separately for persistent sync/attach,
 render, and run. A compiler must opt into a surface; an unspecified compiler is
 unsupported. The policy-schema PR initially left every compiler disabled. The
-Codex compiler now opts into persistent sync/attach and render for all five V1
-access fields; Codex run and other target surfaces remain disabled until their
-corresponding lossless compilers land.
+Codex compiler now opts into persistent sync/attach, render, and run for all
+five V1 access fields; other target surfaces remain disabled until their
+corresponding lossless compilers land. Codex run support is additionally bounded
+to stable CLI 0.139.x releases; other runtime versions fail closed until their
+complete field semantics are validated.
 
 For persistent sync, undeclared native policy fields are preserved. Declared
 fields are compiled exactly. A required operation blocks on unknown
@@ -182,5 +184,6 @@ write.
   narrow serializer.
 - Supporting another client requires an explicit compiler and fidelity tests;
   approximate mappings are not accepted for required rings.
-- Environment sanitization, TTLs, receipts, credential brokers, audit, and
-  runtime `[policy.execution]` semantics remain outside this decision.
+- Environment sanitization, TTLs, receipts, credential brokers, audit,
+  OpenCode support, production examples, and runtime `[policy.execution]`
+  semantics remain outside this decision.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,9 +64,9 @@ member profiles. `[contract]` and skill content remain advisory, while
 - Translate registry entries into client-specific config.
 - Current adapters: Claude Desktop, Claude Code, Gemini, Codex, and Vibe.
 - Adapters own read/merge/write behavior for their client format.
-- An unspecified policy compiler is unsupported. In the policy schema stage all
-  target/surface policy declarations are unsupported, so required operations
-  fail closed until a compiler explicitly opts in.
+- An unspecified policy compiler is unsupported. Codex persistent sync/attach
+  and render opt into all five V1 access features; Codex run and every other
+  target policy surface remain fail-closed.
 
 3. Sync Engine
 - Reads registry + client config.
@@ -145,6 +145,10 @@ member profiles. `[contract]` and skill content remain advisory, while
 - Required sync/attach fails before config, managed state, or skills change;
   render fails before partial output; run fails before skill materialization or
   execution. Detach remains available.
+- Codex sync patches cloned native server tables instead of serializing a narrow
+  replacement. Undeclared native policy fields survive legacy updates; declared
+  fields compile exactly, explicit clears remove only their native overrides,
+  and required operations reject unknown behavior-affecting fields.
 - OAuth scopes are requested and client-configured, not proof of a provider
   grant. Approval behavior is a client prompt control, not authorization.
 - Environment sanitization, TTLs, receipts, credential brokers, audit, and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,9 +64,10 @@ member profiles. `[contract]` and skill content remain advisory, while
 - Translate registry entries into client-specific config.
 - Current adapters: Claude Desktop, Claude Code, Gemini, Codex, and Vibe.
 - Adapters own read/merge/write behavior for their client format.
-- An unspecified policy compiler is unsupported. Codex persistent sync/attach
-  and render opt into all five V1 access features; Codex run and every other
-  target policy surface remain fail-closed.
+- An unspecified policy compiler is unsupported. Codex persistent sync/attach,
+  render, and run opt into all five V1 access features; every other target
+  policy surface remains fail-closed. Access-bearing Codex runs additionally
+  require a validated stable CLI 0.139.x release.
 
 3. Sync Engine
 - Reads registry + client config.
@@ -151,8 +152,9 @@ member profiles. `[contract]` and skill content remain advisory, while
   and required operations reject unknown behavior-affecting fields.
 - OAuth scopes are requested and client-configured, not proof of a provider
   grant. Approval behavior is a client prompt control, not authorization.
-- Environment sanitization, TTLs, receipts, credential brokers, audit, and
-  `[policy.execution]` are outside V1.
+- Environment sanitization, TTLs, receipts, credential brokers, audit,
+  OpenCode support, production examples, and `[policy.execution]` are outside
+  V1.
 
 7. Skills
 - Standalone Agent Skill packages stored at `skills/<name>/` with `SKILL.md`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -81,16 +81,17 @@ unsupported, and unrepresentable members are errors; Madari never substitutes
 an advisory prompt or a weaker native control.
 
 Policy support is declared independently for persistent sync/attach, render,
-and run. In the schema-and-compatibility stage every target/surface compiler is
-unsupported. Required sync or attach therefore fails before config, managed
-state, or skill mutation; required render fails before partial output; and
-required run fails before skill materialization or client execution. Detach
-remains available for cleanup. Manifests without `[access]` and rings without
-`[policy]` preserve existing behavior.
+and run. Codex persistent sync/attach and render compile all five V1 fields.
+Codex run and every policy surface for other targets remain unsupported.
+Required sync or attach fails before config, managed state, or skill mutation;
+required render fails before partial output; and required run fails before skill
+materialization or client execution. Detach remains available for cleanup.
+Manifests without `[access]` and rings without `[policy]` preserve existing
+behavior.
 
-Access profiles outside required rings are still stored, validated, exported,
-imported, and reported, but the schema stage makes no exact-enforcement claim
-for them and has no target compiler that materializes them.
+Access profiles outside required rings are stored, validated, exported,
+imported, reported, and compiled when the selected target surface supports
+them. They do not turn an advisory ring into a mandatory enforcement claim.
 
 `oauth_scopes` is requested and client-configured; it does not prove that an
 OAuth provider granted the scopes or that a token contains them.
@@ -152,6 +153,17 @@ as Codex `http_headers`. `sse` manifests stay pending (Codex's documented
 remote support is Streamable HTTP), and `timeout_ms` has no Codex equivalent
 and is not emitted.
 
+Codex compiles `allowed_tools`, `denied_tools`, `oauth_scopes`,
+`default_approval`, and per-tool approvals into `enabled_tools`,
+`disabled_tools`, `scopes`, `default_tools_approval_mode`, and
+`tools.<tool>.approval_mode`. Routine sync preserves undeclared native policy
+fields, including on core command or URL updates. Explicit empty declarations
+and portable `inherit` remove the corresponding native override. A required
+ring refuses unknown behavior-affecting native fields or native approval values
+that Madari cannot prove equivalent instead of rewriting them. Policy-only
+differences are reported separately by doctor/status while remaining a subset
+of ordinary stale entries.
+
 `vibe` sync targets Vibe's user config (`$VIBE_HOME/config.toml`, or
 `~/.vibe/config.toml` when `VIBE_HOME` is unset). Static `[env]` values are
 written into `[[mcp_servers]]` stdio entries. Existing unmanaged HTTP,
@@ -200,9 +212,9 @@ behavior, or render output.
 
 Ring policy is distinct from the advisory contract. A ring file may set
 `[policy] enforcement = "required"`, but each referenced server remains the
-source of truth for its own `[access]` profile. The initial policy-contract
-release stores and reports this declaration but has no enabled target compiler,
-so required attach, render, and run operations fail during preflight.
+source of truth for its own `[access]` profile. Codex required attach and render
+are supported when every member compiles exactly. Required Codex run and all
+other unsupported target surfaces fail during preflight.
 
 ```toml
 summary = "Collect source context and prepare a research brief."
@@ -254,8 +266,9 @@ Ring skill members are not embedded in MCP render output; use `ring attach`
 for native skill materialization.
 Policy-required render does not use the legacy omit-and-warn behavior: if any
 restriction cannot be represented exactly, it fails before writing partial
-stdout. In the schema-and-compatibility stage every required render is blocked
-because no render policy compiler is enabled.
+stdout. Codex render emits the five native policy fields, with dotted server and
+tool names quoted as literal TOML keys. Other render targets remain unsupported
+for required policy.
 Ephemeral-session recipe:
 
 ```bash
@@ -311,9 +324,8 @@ present, because Madari cannot guarantee ring-only skill isolation in that
 case.
 Policy-required run adds a stricter preflight boundary: every declared member
 restriction must compile exactly before any temporary skill package is
-materialized or the client starts. No run policy compiler is enabled in the
-schema-and-compatibility stage, so required runs are currently blocked while
-legacy runs remain unchanged.
+materialized or the client starts. No run policy compiler is enabled yet, so
+required runs are currently blocked while legacy runs remain unchanged.
 
 ## Skills
 
@@ -560,6 +572,7 @@ warning-level and never changes the exit code by itself.
   "dry_run": true,
   "added": ["stewreads"],
   "updated": [],
+  "policy_updated": [],
   "removed": [],
   "unchanged": [],
   "skipped": [],
@@ -571,6 +584,10 @@ warning-level and never changes the exit code by itself.
   "skills_unchanged": []
 }
 ```
+
+For Codex, `policy_updated` is the sorted subset of `updated` whose declared
+access fields differ from the native configuration. Undeclared preserved fields
+do not appear as policy drift.
 
 `madari run <client> --ring <ring> --dry-run --json`:
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -477,6 +477,7 @@ summaries cover every sync target):
       "config_path": "/path/to/claude_desktop_config.json",
       "status": "ready",
       "stale": [],
+      "policy_stale": [],
       "missing": [],
       "orphaned": [],
       "issue": ""
@@ -486,10 +487,14 @@ summaries cover every sync target):
 ```
 
 Drift entries appear per target+scope that has managed entries: `stale`
-(materialized value differs from the manifest), `missing` (managed entry
-deleted from the client config), and `orphaned` (no longer desired; the next
-sync removes it). Drift is warning-level and never changes the exit code by
-itself.
+(materialized value differs from the manifest), `policy_stale` (the subset of
+`stale` whose declared access policy differs from the target's materialized
+policy), `missing` (managed entry deleted from the client config), and
+`orphaned` (no longer desired; the next sync removes it). Policy drift covers
+client-enforced tool filtering, requested/client-configured OAuth scopes, and
+client approval controls. It does not prove scopes were granted by the OAuth
+provider, and approval behavior is not an authorization boundary. Drift is
+warning-level and never changes the exit code by itself.
 
 `madari doctor --json`:
 
@@ -534,6 +539,7 @@ itself.
       "config_path": "/path/to/claude_desktop_config.json",
       "status": "warn",
       "stale": ["stewreads"],
+      "policy_stale": [],
       "missing": [],
       "orphaned": [],
       "issue": ""

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -81,8 +81,8 @@ unsupported, and unrepresentable members are errors; Madari never substitutes
 an advisory prompt or a weaker native control.
 
 Policy support is declared independently for persistent sync/attach, render,
-and run. Codex persistent sync/attach and render compile all five V1 fields.
-Codex run and every policy surface for other targets remain unsupported.
+and run. Codex compiles all five V1 fields on all three surfaces. Every policy
+surface for other targets remains unsupported.
 Required sync or attach fails before config, managed state, or skill mutation;
 required render fails before partial output; and required run fails before skill
 materialization or client execution. Detach remains available for cleanup.
@@ -212,9 +212,9 @@ behavior, or render output.
 
 Ring policy is distinct from the advisory contract. A ring file may set
 `[policy] enforcement = "required"`, but each referenced server remains the
-source of truth for its own `[access]` profile. Codex required attach and render
-are supported when every member compiles exactly. Required Codex run and all
-other unsupported target surfaces fail during preflight.
+source of truth for its own `[access]` profile. Codex required attach, render,
+and run are supported when every member compiles exactly. Unsupported target
+surfaces fail during preflight.
 
 ```toml
 summary = "Collect source context and prepare a research brief."
@@ -315,6 +315,12 @@ checks runtime env keys by name, and reports the launch plan. Run never writes
 client config, creates managed state, or permanently materializes skill
 packages.
 
+When any selected server declares `[access]`, Codex execution also adds
+`--strict-config` and requires a stable Codex CLI 0.139.x release. This applies
+to advisory profiles as well as policy-required rings so Madari never drops a
+declared restriction. Legacy runs with no access declarations omit the newer
+flag and version gate, preserving their existing compatibility behavior.
+
 Unlike `ring render`, `run` is fail-closed. A disabled member, missing member,
 unsupported remote transport or auth mode, missing runtime env key, or
 unsupported skill target blocks the plan instead of silently omitting that
@@ -324,8 +330,19 @@ present, because Madari cannot guarantee ring-only skill isolation in that
 case.
 Policy-required run adds a stricter preflight boundary: every declared member
 restriction must compile exactly before any temporary skill package is
-materialized or the client starts. No run policy compiler is enabled yet, so
-required runs are currently blocked while legacy runs remain unchanged.
+materialized or the client starts. Codex maps every V1 access field into the
+single ephemeral `mcp_servers={...}` override. The plan and executor both check
+the bounded version range Madari has validated for this complete contract.
+`--strict-config` is an additional config-parser safeguard, not proof that
+nested MCP policy fields retain their semantics outside the validated range.
+
+Dry-run text and JSON report each server's portable declared policy, the
+Codex-native effective policy, support state, and enforcement classification.
+If a server is shared, any selected required ring wins and is listed in
+`required_by`. The control labels are intentionally distinct: tool filtering is
+client-enforced; OAuth scopes are requested/client-configured and
+provider-unverified; approval modes are client controls rather than an
+authorization boundary; contracts and skills remain advisory instructions.
 
 ## Skills
 
@@ -600,6 +617,13 @@ do not appear as policy drift.
   "ready": true,
   "runner_available": true,
   "prompt_provided": true,
+  "policy_required": true,
+  "policy_controls": {
+    "tool_filtering": "client-enforced",
+    "oauth_scopes": "requested/client-configured/provider-unverified",
+    "approvals": "client-control/not-authorization",
+    "instructions": "contracts-and-skills-advisory"
+  },
   "servers": [
     {
       "name": "cloud-sql",
@@ -609,7 +633,20 @@ do not appear as policy drift.
       "auth": "bearer_token_env_var",
       "runtime_env": ["CLOUDSQL_MCP_TOKEN"],
       "rings": ["cloudsql-readonly"],
-      "issues": []
+      "issues": [],
+      "policy": {
+        "declared": {"allowed_tools": ["query"]},
+        "ring_enforcement": "required",
+        "required_by": ["cloudsql-readonly"],
+        "effective": {
+          "enabled_tools": ["query"],
+          "disabled_tools": [],
+          "requested_oauth_scopes": [],
+          "tool_approval_modes": {}
+        },
+        "support_state": "supported",
+        "enforcement_classification": "exact"
+      }
     }
   ],
   "skills": [],

--- a/docs/manifest-spec.md
+++ b/docs/manifest-spec.md
@@ -253,11 +253,12 @@ wrong-target, unbounded, unsupported, or unrepresentable members block the
 operation.
 
 Policy capability support is declared separately for persistent sync/attach,
-render, and run. The schema-and-compatibility stage declares every target and
-surface unsupported, so a required operation currently fails during preflight:
-sync and attach before config, state, or skills change; render before partial
-output; and run before skill materialization or client execution. Detach remains
-available for cleanup. Rings without `[policy]` preserve legacy behavior.
+render, and run. Codex persistent sync/attach and render compile every V1 access
+field. Codex run and all other target policy surfaces remain unsupported. Any
+required operation that cannot compile exactly fails during preflight: sync and
+attach before config, state, or skills change; render before partial output; and
+run before skill materialization or client execution. Detach remains available
+for cleanup. Rings without `[policy]` preserve legacy behavior.
 
 `[policy.execution]` is reserved for a later runtime-policy contract and is
 rejected in V1.

--- a/docs/manifest-spec.md
+++ b/docs/manifest-spec.md
@@ -253,8 +253,9 @@ wrong-target, unbounded, unsupported, or unrepresentable members block the
 operation.
 
 Policy capability support is declared separately for persistent sync/attach,
-render, and run. Codex persistent sync/attach and render compile every V1 access
-field. Codex run and all other target policy surfaces remain unsupported. Any
+render, and run. Codex compiles every V1 access field on all three surfaces.
+Access-bearing Codex runs additionally require a validated stable CLI 0.139.x
+release. All other target policy surfaces remain unsupported. Any
 required operation that cannot compile exactly fails during preflight: sync and
 attach before config, state, or skills change; render before partial output; and
 run before skill materialization or client execution. Detach remains available

--- a/internal/clients/adapter.go
+++ b/internal/clients/adapter.go
@@ -97,6 +97,10 @@ type SyncResult struct {
 	Added []string
 	// Updated are names managed by Madari whose values changed.
 	Updated []string
+	// PolicyUpdated are updated names whose declared access policy differs
+	// from the target's materialized policy. It is a sorted subset of Updated;
+	// adapters that do not compile access policy leave it empty.
+	PolicyUpdated []string
 	// Removed are previously managed names no longer desired.
 	Removed []string
 	// Unchanged are desired names already matching target config values.

--- a/internal/clients/codex/access.go
+++ b/internal/clients/codex/access.go
@@ -1,0 +1,78 @@
+package codex
+
+import (
+	"sort"
+
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+// CompiledAccess is the Codex-native representation of one portable Madari
+// access profile. Presence is part of the contract: nil fields were not
+// declared and must preserve an existing native value during persistent sync,
+// while non-nil empty slices and maps explicitly clear that native override.
+// An empty approval string is the native omission produced by portable
+// "inherit"; non-empty values are Codex's auto, prompt, or approve enums.
+type CompiledAccess struct {
+	EnabledTools    *[]string
+	DisabledTools   *[]string
+	Scopes          *[]string
+	DefaultApproval *string
+	ToolApprovals   *map[string]string
+}
+
+// CompileAccess maps Madari's portable access vocabulary into Codex-native
+// values without mutating the registry profile. Registry validation guarantees
+// the input approval values belong to the portable V1 vocabulary.
+func CompileAccess(access *registry.AccessProfile) CompiledAccess {
+	if access == nil {
+		return CompiledAccess{}
+	}
+
+	compiled := CompiledAccess{
+		EnabledTools:  sortedStringSetCopy(access.AllowedTools),
+		DisabledTools: sortedStringSetCopy(access.DeniedTools),
+		Scopes:        sortedStringSetCopy(access.OAuthScopes),
+	}
+	if access.DefaultApproval != nil {
+		value := compileApproval(*access.DefaultApproval)
+		compiled.DefaultApproval = &value
+	}
+	if access.ToolApprovals != nil {
+		values := make(map[string]string, len(*access.ToolApprovals))
+		for tool, approval := range *access.ToolApprovals {
+			values[tool] = compileApproval(approval)
+		}
+		compiled.ToolApprovals = &values
+	}
+	return compiled
+}
+
+func compileApproval(approval registry.ApprovalBehavior) string {
+	switch approval {
+	case registry.ApprovalBehaviorAutomatic:
+		return "auto"
+	case registry.ApprovalBehaviorAlwaysPrompt:
+		return "prompt"
+	case registry.ApprovalBehaviorAlwaysAllow:
+		return "approve"
+	case registry.ApprovalBehaviorInherit:
+		return ""
+	default:
+		// Invalid portable values are rejected by registry validation before a
+		// manifest reaches a client compiler. Keep unknown values fail-closed by
+		// omitting rather than forwarding a raw client-native enum.
+		return ""
+	}
+}
+
+func sortedStringSetCopy(values *[]string) *[]string {
+	if values == nil {
+		return nil
+	}
+	copyOfValues := append([]string(nil), (*values)...)
+	sort.Strings(copyOfValues)
+	if copyOfValues == nil {
+		copyOfValues = []string{}
+	}
+	return &copyOfValues
+}

--- a/internal/clients/codex/access_test.go
+++ b/internal/clients/codex/access_test.go
@@ -1,0 +1,97 @@
+package codex
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+func TestCompileAccessMapsPortableVocabularyAndSortsSets(t *testing.T) {
+	allowed := []string{"tools.write", "tools.read"}
+	denied := []string{"tools.remove", "tools.delete"}
+	scopes := []string{"repo.write", "repo.read"}
+	defaultApproval := registry.ApprovalBehaviorAlwaysPrompt
+	toolApprovals := map[string]registry.ApprovalBehavior{
+		"tools.write": registry.ApprovalBehaviorAlwaysAllow,
+		"tools.read":  registry.ApprovalBehaviorAutomatic,
+	}
+	access := &registry.AccessProfile{
+		AllowedTools:    &allowed,
+		DeniedTools:     &denied,
+		OAuthScopes:     &scopes,
+		DefaultApproval: &defaultApproval,
+		ToolApprovals:   &toolApprovals,
+	}
+
+	compiled := CompileAccess(access)
+	if got, want := *compiled.EnabledTools, []string{"tools.read", "tools.write"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("enabled tools mismatch: got %#v want %#v", got, want)
+	}
+	if got, want := *compiled.DisabledTools, []string{"tools.delete", "tools.remove"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("disabled tools mismatch: got %#v want %#v", got, want)
+	}
+	if got, want := *compiled.Scopes, []string{"repo.read", "repo.write"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("scopes mismatch: got %#v want %#v", got, want)
+	}
+	if compiled.DefaultApproval == nil || *compiled.DefaultApproval != "prompt" {
+		t.Fatalf("default approval mismatch: %#v", compiled.DefaultApproval)
+	}
+	wantApprovals := map[string]string{"tools.read": "auto", "tools.write": "approve"}
+	if compiled.ToolApprovals == nil || !reflect.DeepEqual(*compiled.ToolApprovals, wantApprovals) {
+		t.Fatalf("tool approvals mismatch: got %#v want %#v", compiled.ToolApprovals, wantApprovals)
+	}
+
+	// Compilation must not reorder or alias registry input.
+	if got, want := allowed, []string{"tools.write", "tools.read"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("compiler mutated allowed tools: got %#v want %#v", got, want)
+	}
+	(*compiled.EnabledTools)[0] = "changed"
+	if allowed[0] == "changed" || allowed[1] == "changed" {
+		t.Fatalf("compiled tools alias registry input: %#v", allowed)
+	}
+}
+
+func TestCompileAccessPreservesAbsenceAndExplicitClear(t *testing.T) {
+	if got := CompileAccess(nil); got.EnabledTools != nil || got.DisabledTools != nil || got.Scopes != nil || got.DefaultApproval != nil || got.ToolApprovals != nil {
+		t.Fatalf("nil profile must compile to undeclared fields: %#v", got)
+	}
+
+	emptyTools := []string{}
+	emptyApprovals := map[string]registry.ApprovalBehavior{}
+	inherit := registry.ApprovalBehaviorInherit
+	compiled := CompileAccess(&registry.AccessProfile{
+		AllowedTools:    &emptyTools,
+		DefaultApproval: &inherit,
+		ToolApprovals:   &emptyApprovals,
+	})
+	if compiled.EnabledTools == nil || len(*compiled.EnabledTools) != 0 {
+		t.Fatalf("explicit empty tools must remain a present clear: %#v", compiled.EnabledTools)
+	}
+	if compiled.DisabledTools != nil || compiled.Scopes != nil {
+		t.Fatalf("undeclared fields must remain absent: %#v", compiled)
+	}
+	if compiled.DefaultApproval == nil || *compiled.DefaultApproval != "" {
+		t.Fatalf("inherit must compile to a present native omission: %#v", compiled.DefaultApproval)
+	}
+	if compiled.ToolApprovals == nil || len(*compiled.ToolApprovals) != 0 {
+		t.Fatalf("explicit empty approvals must remain a present clear: %#v", compiled.ToolApprovals)
+	}
+}
+
+func TestCompileAccessMapsPerToolInheritToOmission(t *testing.T) {
+	approvals := map[string]registry.ApprovalBehavior{
+		"tools.inherit": registry.ApprovalBehaviorInherit,
+		"tools.prompt":  registry.ApprovalBehaviorAlwaysPrompt,
+	}
+	compiled := CompileAccess(&registry.AccessProfile{ToolApprovals: &approvals})
+	if compiled.ToolApprovals == nil {
+		t.Fatal("expected declared tool approval table")
+	}
+	if got := (*compiled.ToolApprovals)["tools.inherit"]; got != "" {
+		t.Fatalf("inherit should compile to native omission, got %q", got)
+	}
+	if got := (*compiled.ToolApprovals)["tools.prompt"]; got != "prompt" {
+		t.Fatalf("prompt mapping mismatch: %q", got)
+	}
+}

--- a/internal/clients/codex/native_policy.go
+++ b/internal/clients/codex/native_policy.go
@@ -1,0 +1,448 @@
+package codex
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/ankitvg/madari/internal/clients/syncshared"
+	"github.com/ankitvg/madari/internal/policy"
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+type fidelityIssueKind string
+
+const (
+	fidelityUnknown         fidelityIssueKind = "unknown"
+	fidelityDefaultApproval fidelityIssueKind = "default-approval"
+	fidelityToolApproval    fidelityIssueKind = "tool-approval"
+)
+
+type nativeFidelityIssue struct {
+	Kind fidelityIssueKind
+	Path string
+}
+
+var knownServerFields = map[string]bool{
+	"command": true, "args": true, "env": true, "env_vars": true, "cwd": true,
+	"url": true, "bearer_token_env_var": true, "http_headers": true,
+	"env_http_headers": true, "oauth_resource": true, "enabled": true,
+	"required": true, "startup_timeout_sec": true, "tool_timeout_sec": true,
+	"enabled_tools": true, "disabled_tools": true, "scopes": true,
+	"default_tools_approval_mode": true, "tools": true,
+}
+
+func parseNativeAccess(name string, table map[string]any) (CompiledAccess, []nativeFidelityIssue, error) {
+	var access CompiledAccess
+	issues := make([]nativeFidelityIssue, 0)
+
+	for _, field := range []struct {
+		key string
+		set func(*[]string)
+	}{
+		{key: "enabled_tools", set: func(value *[]string) { access.EnabledTools = value }},
+		{key: "disabled_tools", set: func(value *[]string) { access.DisabledTools = value }},
+		{key: "scopes", set: func(value *[]string) { access.Scopes = value }},
+	} {
+		values, present, err := optionalStringSlice(table, field.key)
+		if err != nil {
+			return CompiledAccess{}, nil, fmt.Errorf("parse mcp_servers.%s.%s: %w", name, field.key, err)
+		}
+		if present {
+			copyOfValues := append([]string(nil), values...)
+			field.set(&copyOfValues)
+		}
+	}
+
+	if raw, present := table["default_tools_approval_mode"]; present {
+		value, ok := raw.(string)
+		if !ok {
+			return CompiledAccess{}, nil, fmt.Errorf("parse mcp_servers.%s.default_tools_approval_mode: expected string", name)
+		}
+		access.DefaultApproval = &value
+		if !supportedNativeApproval(value) {
+			issues = append(issues, nativeFidelityIssue{
+				Kind: fidelityDefaultApproval,
+				Path: fmt.Sprintf("mcp_servers.%s.default_tools_approval_mode=%q", name, value),
+			})
+		}
+	}
+
+	if raw, present := table["tools"]; present {
+		tools, ok := raw.(map[string]any)
+		if !ok {
+			return CompiledAccess{}, nil, fmt.Errorf("parse mcp_servers.%s.tools: expected table", name)
+		}
+		approvals := make(map[string]string)
+		toolNames := sortedAnyMapKeys(tools)
+		for _, tool := range toolNames {
+			rawTool := tools[tool]
+			toolTable, ok := rawTool.(map[string]any)
+			if !ok {
+				return CompiledAccess{}, nil, fmt.Errorf("parse mcp_servers.%s.tools.%s: expected table", name, tool)
+			}
+			for _, key := range sortedAnyMapKeys(toolTable) {
+				if key != "approval_mode" {
+					issues = append(issues, nativeFidelityIssue{
+						Kind: fidelityUnknown,
+						Path: fmt.Sprintf("mcp_servers.%s.tools.%s.%s", name, tool, key),
+					})
+				}
+			}
+			if rawApproval, exists := toolTable["approval_mode"]; exists {
+				approval, ok := rawApproval.(string)
+				if !ok {
+					return CompiledAccess{}, nil, fmt.Errorf("parse mcp_servers.%s.tools.%s.approval_mode: expected string", name, tool)
+				}
+				approvals[tool] = approval
+				if !supportedNativeApproval(approval) {
+					issues = append(issues, nativeFidelityIssue{
+						Kind: fidelityToolApproval,
+						Path: fmt.Sprintf("mcp_servers.%s.tools.%s.approval_mode=%q", name, tool, approval),
+					})
+				}
+			}
+		}
+		access.ToolApprovals = &approvals
+	}
+
+	for _, key := range sortedAnyMapKeys(table) {
+		if !knownServerFields[key] {
+			issues = append(issues, nativeFidelityIssue{
+				Kind: fidelityUnknown,
+				Path: fmt.Sprintf("mcp_servers.%s.%s", name, key),
+			})
+		}
+	}
+	if rawEnabled, present := table["enabled"]; present && rawEnabled == false {
+		issues = append(issues, nativeFidelityIssue{
+			Kind: fidelityUnknown,
+			Path: fmt.Sprintf("mcp_servers.%s.enabled=false", name),
+		})
+	}
+	if err := validateKnownNativeExtras(name, table); err != nil {
+		return CompiledAccess{}, nil, err
+	}
+	return access, issues, nil
+}
+
+func validateKnownNativeExtras(name string, table map[string]any) error {
+	if raw, ok := table["cwd"]; ok {
+		if _, valid := raw.(string); !valid {
+			return fmt.Errorf("parse mcp_servers.%s.cwd: expected string", name)
+		}
+	}
+	if _, _, err := optionalStringMap(table, "env_http_headers"); err != nil {
+		return fmt.Errorf("parse mcp_servers.%s.env_http_headers: %w", name, err)
+	}
+	if _, _, err := optionalBool(table, "required"); err != nil {
+		return fmt.Errorf("parse mcp_servers.%s.required: %w", name, err)
+	}
+	for _, key := range []string{"startup_timeout_sec", "tool_timeout_sec"} {
+		if raw, ok := table[key]; ok {
+			switch raw.(type) {
+			case int64, float64:
+			default:
+				return fmt.Errorf("parse mcp_servers.%s.%s: expected number", name, key)
+			}
+		}
+	}
+	return nil
+}
+
+func supportedNativeApproval(value string) bool {
+	switch value {
+	case "auto", "prompt", "approve":
+		return true
+	default:
+		return false
+	}
+}
+
+func equalDeclaredAccess(existing, desired CompiledAccess) bool {
+	if !equalDeclaredStringSet(existing.EnabledTools, desired.EnabledTools) ||
+		!equalDeclaredStringSet(existing.DisabledTools, desired.DisabledTools) ||
+		!equalDeclaredStringSet(existing.Scopes, desired.Scopes) {
+		return false
+	}
+	if desired.DefaultApproval != nil {
+		if *desired.DefaultApproval == "" {
+			if existing.DefaultApproval != nil {
+				return false
+			}
+		} else if existing.DefaultApproval == nil || *existing.DefaultApproval != *desired.DefaultApproval {
+			return false
+		}
+	}
+	if desired.ToolApprovals != nil {
+		wanted := effectiveToolApprovals(*desired.ToolApprovals)
+		got := map[string]string{}
+		if existing.ToolApprovals != nil {
+			got = effectiveToolApprovals(*existing.ToolApprovals)
+		}
+		if !equalStringMap(got, wanted) {
+			return false
+		}
+	}
+	return true
+}
+
+func equalDeclaredStringSet(existing, desired *[]string) bool {
+	if desired == nil {
+		return true
+	}
+	if len(*desired) == 0 {
+		return existing == nil
+	}
+	if existing == nil || len(*existing) != len(*desired) {
+		return false
+	}
+	got := append([]string(nil), (*existing)...)
+	want := append([]string(nil), (*desired)...)
+	sort.Strings(got)
+	sort.Strings(want)
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func effectiveToolApprovals(values map[string]string) map[string]string {
+	out := make(map[string]string, len(values))
+	for tool, approval := range values {
+		if approval != "" {
+			out[tool] = approval
+		}
+	}
+	return out
+}
+
+func equalStringMap(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for key, value := range a {
+		if b[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func policyUpdatedNames(updated []string, existing, desired map[string]serverConfig) []string {
+	result := make([]string, 0, len(updated))
+	for _, name := range updated {
+		current, currentOK := existing[name]
+		want, desiredOK := desired[name]
+		if currentOK && desiredOK && !equalDeclaredAccess(current.Access, want.Access) {
+			result = append(result, name)
+		}
+	}
+	sort.Strings(result)
+	return result
+}
+
+func mergeServerTable(raw any, desired serverConfig) (map[string]any, error) {
+	table := map[string]any{}
+	if raw != nil {
+		existing, ok := raw.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("expected existing table")
+		}
+		table = cloneAnyMap(existing)
+	}
+
+	if desired.URL != "" {
+		deleteKeys(table, "command", "args", "env", "env_vars", "cwd")
+		table["url"] = desired.URL
+		setOrDeleteString(table, "oauth_resource", desired.OAuthResource)
+		setOrDeleteString(table, "bearer_token_env_var", desired.BearerTokenEnvVar)
+		setOrDeleteStringMap(table, "http_headers", desired.HTTPHeaders)
+	} else {
+		deleteKeys(table, "url", "oauth_resource", "bearer_token_env_var", "http_headers", "env_http_headers")
+		table["command"] = desired.Command
+		setOrDeleteStringSlice(table, "args", desired.Args)
+		setOrDeleteStringSlice(table, "env_vars", desired.EnvVars)
+		setOrDeleteStringMap(table, "env", desired.Env)
+	}
+	applyDeclaredAccess(table, desired.Access)
+	return table, nil
+}
+
+func applyDeclaredAccess(table map[string]any, access CompiledAccess) {
+	applyStringSliceField(table, "enabled_tools", access.EnabledTools)
+	applyStringSliceField(table, "disabled_tools", access.DisabledTools)
+	applyStringSliceField(table, "scopes", access.Scopes)
+	if access.DefaultApproval != nil {
+		if *access.DefaultApproval == "" {
+			delete(table, "default_tools_approval_mode")
+		} else {
+			table["default_tools_approval_mode"] = *access.DefaultApproval
+		}
+	}
+	if access.ToolApprovals == nil {
+		return
+	}
+	tools := map[string]any{}
+	if rawTools, ok := table["tools"].(map[string]any); ok {
+		tools = cloneAnyMap(rawTools)
+	}
+	for tool, rawTool := range tools {
+		toolTable, ok := rawTool.(map[string]any)
+		if !ok {
+			continue
+		}
+		copyOfTool := cloneAnyMap(toolTable)
+		delete(copyOfTool, "approval_mode")
+		if len(copyOfTool) == 0 {
+			delete(tools, tool)
+		} else {
+			tools[tool] = copyOfTool
+		}
+	}
+	for tool, approval := range *access.ToolApprovals {
+		if approval == "" {
+			continue
+		}
+		toolTable := map[string]any{}
+		if rawTool, ok := tools[tool].(map[string]any); ok {
+			toolTable = cloneAnyMap(rawTool)
+		}
+		toolTable["approval_mode"] = approval
+		tools[tool] = toolTable
+	}
+	if len(tools) == 0 {
+		delete(table, "tools")
+	} else {
+		table["tools"] = tools
+	}
+}
+
+func applyStringSliceField(table map[string]any, key string, value *[]string) {
+	if value == nil {
+		return
+	}
+	if len(*value) == 0 {
+		delete(table, key)
+		return
+	}
+	table[key] = append([]string(nil), (*value)...)
+}
+
+func preflightAttachedPolicyRings(rings []registry.Ring, manifests []registry.Manifest, state map[string][]string, existing map[string]serverConfig) error {
+	byName := make(map[string]registry.Ring, len(rings))
+	for _, ring := range rings {
+		byName[ring.Name] = ring
+	}
+	for _, name := range syncshared.AttachedRings(state) {
+		ring, ok := byName[name]
+		if !ok {
+			return fmt.Errorf("attached ring %q is missing; restore its definition or detach it before sync so policy requirements cannot be bypassed", name)
+		}
+		if err := preflightPolicyRing(ring, manifests, state, existing); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func preflightPolicyRing(ring registry.Ring, manifests []registry.Manifest, state map[string][]string, existing map[string]serverConfig) error {
+	if err := policy.ValidateRequiredRing(ring, manifests, Target, policy.SurfacePersistent).Err(); err != nil {
+		return err
+	}
+	if !ring.RequiresPolicyEnforcement() {
+		return nil
+	}
+	manifestByName := make(map[string]registry.Manifest, len(manifests))
+	for _, manifest := range manifests {
+		manifestByName[manifest.Name] = manifest
+	}
+	for _, member := range ring.Members {
+		member = strings.TrimSpace(member)
+		server, exists := existing[member]
+		if !exists {
+			continue
+		}
+		if len(state[member]) == 0 {
+			return fmt.Errorf("ring %q requires policy enforcement, but Codex entry %q is unmanaged and cannot satisfy ring ownership; remove or rename the unmanaged native entry, then retry sync or attach", ring.Name, member)
+		}
+		desired := CompileAccess(manifestByName[member].Access)
+		paths := make([]string, 0, len(server.FidelityIssues))
+		for _, issue := range server.FidelityIssues {
+			if issue.Kind == fidelityDefaultApproval && desired.DefaultApproval != nil {
+				continue
+			}
+			if issue.Kind == fidelityToolApproval && desired.ToolApprovals != nil {
+				continue
+			}
+			paths = append(paths, issue.Path)
+		}
+		if len(paths) > 0 {
+			sort.Strings(paths)
+			return fmt.Errorf("ring %q requires policy enforcement, but existing managed Codex entry %q has behavior-affecting native fields Madari cannot prove equivalent: %s; remove or migrate those fields before retrying", ring.Name, member, strings.Join(paths, ", "))
+		}
+	}
+	return nil
+}
+
+func cloneAnyMap(input map[string]any) map[string]any {
+	out := make(map[string]any, len(input))
+	for key, value := range input {
+		switch typed := value.(type) {
+		case map[string]any:
+			out[key] = cloneAnyMap(typed)
+		case []any:
+			out[key] = append([]any(nil), typed...)
+		case []string:
+			out[key] = append([]string(nil), typed...)
+		default:
+			out[key] = value
+		}
+	}
+	return out
+}
+
+func sortedAnyMapKeys(values map[string]any) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func deleteKeys(table map[string]any, keys ...string) {
+	for _, key := range keys {
+		delete(table, key)
+	}
+}
+
+func setOrDeleteString(table map[string]any, key, value string) {
+	if value == "" {
+		delete(table, key)
+	} else {
+		table[key] = value
+	}
+}
+
+func setOrDeleteStringSlice(table map[string]any, key string, values []string) {
+	if len(values) == 0 {
+		delete(table, key)
+	} else {
+		table[key] = append([]string(nil), values...)
+	}
+}
+
+func setOrDeleteStringMap(table map[string]any, key string, values map[string]string) {
+	if len(values) == 0 {
+		delete(table, key)
+		return
+	}
+	copyOfValues := make(map[string]string, len(values))
+	for mapKey, value := range values {
+		copyOfValues[mapKey] = value
+	}
+	table[key] = copyOfValues
+}

--- a/internal/clients/codex/native_policy.go
+++ b/internal/clients/codex/native_policy.go
@@ -27,7 +27,7 @@ var knownServerFields = map[string]bool{
 	"command": true, "args": true, "env": true, "env_vars": true, "cwd": true,
 	"url": true, "bearer_token_env_var": true, "http_headers": true,
 	"env_http_headers": true, "oauth_resource": true, "enabled": true,
-	"required": true, "startup_timeout_sec": true, "tool_timeout_sec": true,
+	"required": true, "startup_timeout_ms": true, "startup_timeout_sec": true, "tool_timeout_sec": true,
 	"enabled_tools": true, "disabled_tools": true, "scopes": true,
 	"default_tools_approval_mode": true, "tools": true,
 }
@@ -114,12 +114,6 @@ func parseNativeAccess(name string, table map[string]any) (CompiledAccess, []nat
 			})
 		}
 	}
-	if rawEnabled, present := table["enabled"]; present && rawEnabled == false {
-		issues = append(issues, nativeFidelityIssue{
-			Kind: fidelityUnknown,
-			Path: fmt.Sprintf("mcp_servers.%s.enabled=false", name),
-		})
-	}
 	if err := validateKnownNativeExtras(name, table); err != nil {
 		return CompiledAccess{}, nil, err
 	}
@@ -138,7 +132,7 @@ func validateKnownNativeExtras(name string, table map[string]any) error {
 	if _, _, err := optionalBool(table, "required"); err != nil {
 		return fmt.Errorf("parse mcp_servers.%s.required: %w", name, err)
 	}
-	for _, key := range []string{"startup_timeout_sec", "tool_timeout_sec"} {
+	for _, key := range []string{"startup_timeout_ms", "startup_timeout_sec", "tool_timeout_sec"} {
 		if raw, ok := table[key]; ok {
 			switch raw.(type) {
 			case int64, float64:
@@ -152,7 +146,7 @@ func validateKnownNativeExtras(name string, table map[string]any) error {
 
 func supportedNativeApproval(value string) bool {
 	switch value {
-	case "auto", "prompt", "approve":
+	case "auto", "prompt", "writes", "approve":
 		return true
 	default:
 		return false
@@ -252,6 +246,11 @@ func mergeServerTable(raw any, desired serverConfig) (map[string]any, error) {
 			return nil, fmt.Errorf("expected existing table")
 		}
 		table = cloneAnyMap(existing)
+	}
+	if effectiveServerEnabled(desired.Enabled) {
+		delete(table, "enabled")
+	} else {
+		table["enabled"] = false
 	}
 
 	if desired.URL != "" {

--- a/internal/clients/codex/native_policy.go
+++ b/internal/clients/codex/native_policy.go
@@ -27,6 +27,7 @@ var knownServerFields = map[string]bool{
 	"command": true, "args": true, "env": true, "env_vars": true, "cwd": true,
 	"url": true, "bearer_token_env_var": true, "http_headers": true,
 	"env_http_headers": true, "oauth_resource": true, "enabled": true,
+	"auth": true, "experimental_environment": true,
 	"required": true, "startup_timeout_ms": true, "startup_timeout_sec": true, "tool_timeout_sec": true,
 	"enabled_tools": true, "disabled_tools": true, "scopes": true,
 	"default_tools_approval_mode": true, "tools": true,
@@ -121,6 +122,26 @@ func parseNativeAccess(name string, table map[string]any) (CompiledAccess, []nat
 }
 
 func validateKnownNativeExtras(name string, table map[string]any) error {
+	for key, allowed := range map[string]map[string]bool{
+		"auth": {
+			"oauth":   true,
+			"chatgpt": true,
+		},
+		"experimental_environment": {
+			"local":  true,
+			"remote": true,
+		},
+	} {
+		if raw, ok := table[key]; ok {
+			value, valid := raw.(string)
+			if !valid {
+				return fmt.Errorf("parse mcp_servers.%s.%s: expected string", name, key)
+			}
+			if !allowed[value] {
+				return fmt.Errorf("parse mcp_servers.%s.%s: unsupported value %q", name, key, value)
+			}
+		}
+	}
 	if raw, ok := table["cwd"]; ok {
 		if _, valid := raw.(string); !valid {
 			return fmt.Errorf("parse mcp_servers.%s.cwd: expected string", name)

--- a/internal/clients/codex/policy_sync_test.go
+++ b/internal/clients/codex/policy_sync_test.go
@@ -57,6 +57,8 @@ disabled_tools = ["delete"]
 scopes = ["repo:read"]
 default_tools_approval_mode = "writes"
 startup_timeout_ms = 1500
+auth = "chatgpt"
+experimental_environment = "remote"
 future_restriction = "strict"
 
 [mcp_servers.stewreads.tools.read]
@@ -87,6 +89,9 @@ classification = "sensitive"
 	}
 	if table["startup_timeout_ms"] != int64(1500) {
 		t.Fatalf("documented millisecond timeout alias was stripped: %#v", table)
+	}
+	if table["auth"] != "chatgpt" || table["experimental_environment"] != "remote" {
+		t.Fatalf("documented native fields were stripped: %#v", table)
 	}
 	tool := table["tools"].(map[string]any)["read"].(map[string]any)
 	if tool["approval_mode"] != "prompt" || tool["classification"] != "sensitive" {
@@ -283,7 +288,7 @@ func TestRequiredSyncAcceptsDocumentedNativeCompatibilityFields(t *testing.T) {
 	configPath := filepath.Join(tmp, "config.toml")
 	statePath := filepath.Join(tmp, "state.json")
 	command := currentTestExecutable(t)
-	payload := "[mcp_servers.docs]\ncommand = " + tomlQuoted(command) + "\nenabled = false\nenabled_tools = [\"read\"]\ndefault_tools_approval_mode = \"writes\"\nstartup_timeout_ms = 1500\n\n[mcp_servers.docs.tools.read]\napproval_mode = \"writes\"\n"
+	payload := "[mcp_servers.docs]\ncommand = " + tomlQuoted(command) + "\nenabled = false\nenabled_tools = [\"read\"]\ndefault_tools_approval_mode = \"writes\"\nstartup_timeout_ms = 1500\nauth = \"chatgpt\"\nexperimental_environment = \"remote\"\n\n[mcp_servers.docs.tools.read]\napproval_mode = \"writes\"\n"
 	if err := os.WriteFile(configPath, []byte(payload), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -307,8 +312,42 @@ func TestRequiredSyncAcceptsDocumentedNativeCompatibilityFields(t *testing.T) {
 	if table["default_tools_approval_mode"] != "writes" || table["startup_timeout_ms"] != int64(1500) {
 		t.Fatalf("documented native fields were not preserved: %#v", table)
 	}
+	if table["auth"] != "chatgpt" || table["experimental_environment"] != "remote" {
+		t.Fatalf("documented native compatibility fields were not preserved: %#v", table)
+	}
 	if table["tools"].(map[string]any)["read"].(map[string]any)["approval_mode"] != "writes" {
 		t.Fatalf("documented per-tool writes approval was not preserved: %#v", table)
+	}
+}
+
+func TestSyncRejectsUnsupportedDocumentedNativeValuesWithoutMutation(t *testing.T) {
+	command := currentTestExecutable(t)
+	for _, tc := range []struct {
+		name  string
+		field string
+		value string
+	}{
+		{name: "auth", field: "auth", value: "future"},
+		{name: "experimental environment", field: "experimental_environment", value: "cloud"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			configPath := filepath.Join(tmp, "config.toml")
+			statePath := filepath.Join(tmp, "state.json")
+			original := []byte("[mcp_servers.docs]\ncommand = " + tomlQuoted(command) + "\n" + tc.field + " = " + tomlQuoted(tc.value) + "\n")
+			if err := os.WriteFile(configPath, original, 0o600); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+
+			_, err := Sync([]registry.Manifest{{Name: "docs", Command: command, Enabled: true, Clients: []string{Target}}}, SyncOptions{ConfigPath: configPath, StatePath: statePath})
+			if err == nil || !strings.Contains(err.Error(), tc.field) || !strings.Contains(err.Error(), tc.value) {
+				t.Fatalf("expected unsupported native value error, got: %v", err)
+			}
+			assertFileEquals(t, configPath, original)
+			if _, statErr := os.Stat(statePath); !errors.Is(statErr, os.ErrNotExist) {
+				t.Fatalf("parse failure wrote state: %v", statErr)
+			}
+		})
 	}
 }
 

--- a/internal/clients/codex/policy_sync_test.go
+++ b/internal/clients/codex/policy_sync_test.go
@@ -1,0 +1,442 @@
+package codex
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/ankitvg/madari/internal/clients/syncshared"
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+func TestSyncCompilesAllCodexAccessFields(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state.json")
+	manifest := newCloudSQLManifest()
+	manifest.Access = fullPolicyAccess()
+
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{ConfigPath: configPath, StatePath: statePath})
+	if err != nil {
+		t.Fatalf("sync policy: %v", err)
+	}
+	if !reflect.DeepEqual(result.Added, []string{"cloud-sql"}) {
+		t.Fatalf("unexpected plan: %#v", result)
+	}
+	table := rawServerTable(t, configPath, "cloud-sql")
+	assertRawStringSlice(t, table, "enabled_tools", []string{"issues.get", "issues.inherit", "issues.list"})
+	assertRawStringSlice(t, table, "disabled_tools", []string{"issues.delete"})
+	assertRawStringSlice(t, table, "scopes", []string{"issues:read", "profile:read"})
+	if table["default_tools_approval_mode"] != "prompt" {
+		t.Fatalf("default approval not compiled: %#v", table)
+	}
+	tools := table["tools"].(map[string]any)
+	if got := tools["issues.get"].(map[string]any)["approval_mode"]; got != "approve" {
+		t.Fatalf("per-tool approval not compiled: %#v", tools)
+	}
+	if got := tools["issues.list"].(map[string]any)["approval_mode"]; got != "auto" {
+		t.Fatalf("automatic approval not compiled: %#v", tools)
+	}
+	if _, exists := tools["issues.inherit"]; exists {
+		t.Fatalf("inherit must omit the native approval override: %#v", tools)
+	}
+}
+
+func TestSyncPreservesLegacyNativeRestrictionsDuringCoreUpdate(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state.json")
+	original := `[mcp_servers.stewreads]
+command = "stewreads-mcp"
+args = ["--old"]
+enabled_tools = ["read"]
+disabled_tools = ["delete"]
+scopes = ["repo:read"]
+default_tools_approval_mode = "writes"
+future_restriction = "strict"
+
+[mcp_servers.stewreads.tools.read]
+approval_mode = "prompt"
+classification = "sensitive"
+`
+	if err := os.WriteFile(configPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := syncshared.SaveManagedState(statePath, map[string][]string{"stewreads": {syncshared.SourceStandalone}}); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	manifest := newStewreadsManifest()
+	manifest.Args = []string{"--new"}
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{ConfigPath: configPath, StatePath: statePath})
+	if err != nil {
+		t.Fatalf("sync legacy entry: %v", err)
+	}
+	if !reflect.DeepEqual(result.Updated, []string{"stewreads"}) || len(result.PolicyUpdated) != 0 {
+		t.Fatalf("unexpected plan: %#v", result)
+	}
+	table := rawServerTable(t, configPath, "stewreads")
+	assertRawStringSlice(t, table, "enabled_tools", []string{"read"})
+	assertRawStringSlice(t, table, "disabled_tools", []string{"delete"})
+	assertRawStringSlice(t, table, "scopes", []string{"repo:read"})
+	if table["default_tools_approval_mode"] != "writes" || table["future_restriction"] != "strict" {
+		t.Fatalf("legacy native fields were stripped: %#v", table)
+	}
+	tool := table["tools"].(map[string]any)["read"].(map[string]any)
+	if tool["approval_mode"] != "prompt" || tool["classification"] != "sensitive" {
+		t.Fatalf("legacy nested fields were stripped: %#v", tool)
+	}
+}
+
+func TestSyncExplicitAccessClearsRemoveNativeOverrides(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state.json")
+	original := `[mcp_servers.cloud-sql]
+url = "https://sqladmin.googleapis.com/mcp"
+oauth_resource = "https://sqladmin.googleapis.com/"
+bearer_token_env_var = "CLOUDSQL_MCP_TOKEN"
+enabled_tools = ["read"]
+disabled_tools = ["delete"]
+scopes = ["repo:read"]
+default_tools_approval_mode = "prompt"
+
+[mcp_servers.cloud-sql.tools.read]
+approval_mode = "approve"
+`
+	if err := os.WriteFile(configPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := syncshared.SaveManagedState(statePath, map[string][]string{"cloud-sql": {syncshared.SourceStandalone}}); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	empty := []string{}
+	inherit := registry.ApprovalBehaviorInherit
+	emptyTools := map[string]registry.ApprovalBehavior{}
+	manifest := newCloudSQLManifest()
+	manifest.Access = &registry.AccessProfile{
+		AllowedTools: &empty, DeniedTools: &empty, OAuthScopes: &empty,
+		DefaultApproval: &inherit, ToolApprovals: &emptyTools,
+	}
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{ConfigPath: configPath, StatePath: statePath})
+	if err != nil {
+		t.Fatalf("sync explicit clears: %v", err)
+	}
+	if !reflect.DeepEqual(result.PolicyUpdated, []string{"cloud-sql"}) {
+		t.Fatalf("expected policy drift classification: %#v", result)
+	}
+	table := rawServerTable(t, configPath, "cloud-sql")
+	for _, key := range []string{"enabled_tools", "disabled_tools", "scopes", "default_tools_approval_mode", "tools"} {
+		if _, exists := table[key]; exists {
+			t.Fatalf("explicit clear left %s behind: %#v", key, table)
+		}
+	}
+}
+
+func TestSyncDeclaredToolApprovalsPreserveUnknownNestedDataAdvisory(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state.json")
+	original := `[mcp_servers.stewreads]
+command = "stewreads-mcp"
+
+[mcp_servers.stewreads.tools.read]
+approval_mode = "prompt"
+classification = "sensitive"
+
+[mcp_servers.stewreads.tools.stale]
+approval_mode = "approve"
+`
+	if err := os.WriteFile(configPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := syncshared.SaveManagedState(statePath, map[string][]string{"stewreads": {syncshared.SourceStandalone}}); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	approval := map[string]registry.ApprovalBehavior{
+		"read": registry.ApprovalBehaviorAlwaysAllow,
+		"new":  registry.ApprovalBehaviorAlwaysPrompt,
+	}
+	manifest := newStewreadsManifest()
+	manifest.Access = &registry.AccessProfile{ToolApprovals: &approval}
+	if _, err := Sync([]registry.Manifest{manifest}, SyncOptions{ConfigPath: configPath, StatePath: statePath}); err != nil {
+		t.Fatalf("sync approvals: %v", err)
+	}
+	tools := rawServerTable(t, configPath, "stewreads")["tools"].(map[string]any)
+	read := tools["read"].(map[string]any)
+	if read["approval_mode"] != "approve" || read["classification"] != "sensitive" {
+		t.Fatalf("declared approval or unknown nested data lost: %#v", read)
+	}
+	if _, exists := tools["stale"]; exists {
+		t.Fatalf("stale approval was not cleared: %#v", tools)
+	}
+	if tools["new"].(map[string]any)["approval_mode"] != "prompt" {
+		t.Fatalf("new approval missing: %#v", tools)
+	}
+}
+
+func TestRequiredSyncUnknownNativeFieldFailsBeforeMutation(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state.json")
+	command := currentTestExecutable(t)
+	originalConfig := "[mcp_servers.docs]\ncommand = " + tomlQuoted(command) + "\nfuture_policy = \"strict\"\n"
+	if err := os.WriteFile(configPath, []byte(originalConfig), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := syncshared.SaveManagedState(statePath, map[string][]string{"docs": {syncshared.RingSource("restricted")}}); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	originalState, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	allowed := []string{"read"}
+	manifest := registry.Manifest{Name: "docs", Command: command, Enabled: true, Clients: []string{Target}, Access: &registry.AccessProfile{AllowedTools: &allowed}}
+	ring := registry.Ring{Name: "restricted", Members: []string{"docs"}, Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired}}
+	_, err = Sync([]registry.Manifest{manifest}, SyncOptions{ConfigPath: configPath, StatePath: statePath, Rings: []registry.Ring{ring}})
+	if err == nil || !strings.Contains(err.Error(), "future_policy") || !strings.Contains(err.Error(), "behavior-affecting native fields") {
+		t.Fatalf("expected native fidelity refusal, got: %v", err)
+	}
+	assertFileEquals(t, configPath, []byte(originalConfig))
+	assertFileEquals(t, statePath, originalState)
+	backups, globErr := filepath.Glob(configPath + ".bak.*")
+	if globErr != nil || len(backups) != 0 {
+		t.Fatalf("preflight created backups: %#v err=%v", backups, globErr)
+	}
+}
+
+func TestRequiredSyncRejectsNewMemberCollidingWithUnmanagedEntry(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state.json")
+	command := currentTestExecutable(t)
+	config := "[mcp_servers.docs]\ncommand = " + tomlQuoted(command) + "\nenabled_tools = [\"read\"]\n"
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := syncshared.SaveManagedState(statePath, map[string][]string{"existing": {syncshared.RingSource("restricted")}}); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	allowed := []string{"read"}
+	manifests := []registry.Manifest{
+		{Name: "existing", Command: command, Enabled: true, Clients: []string{Target}, Access: &registry.AccessProfile{AllowedTools: &allowed}},
+		{Name: "docs", Command: command, Enabled: true, Clients: []string{Target}, Access: &registry.AccessProfile{AllowedTools: &allowed}},
+	}
+	ring := registry.Ring{Name: "restricted", Members: []string{"existing", "docs"}, Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired}}
+	_, err := Sync(manifests, SyncOptions{ConfigPath: configPath, StatePath: statePath, Rings: []registry.Ring{ring}, DryRun: true})
+	if err == nil || !strings.Contains(err.Error(), "unmanaged") || !strings.Contains(err.Error(), "docs") {
+		t.Fatalf("expected unmanaged required-member refusal, got: %v", err)
+	}
+}
+
+func TestRequiredSyncBlocksUnknownNestedAndVersionSkewApproval(t *testing.T) {
+	command := currentTestExecutable(t)
+	cases := []struct {
+		name       string
+		nativeTOML string
+		want       string
+	}{
+		{
+			name: "unknown nested tool field",
+			nativeTOML: "\n[mcp_servers.docs.tools.read]\n" +
+				"approval_mode = \"prompt\"\nclassification = \"sensitive\"\n",
+			want: "classification",
+		},
+		{
+			name:       "version skew approval",
+			nativeTOML: "\ndefault_tools_approval_mode = \"writes\"\n",
+			want:       "writes",
+		},
+		{
+			name:       "native disabled entry",
+			nativeTOML: "\nenabled = false\n",
+			want:       "enabled=false",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			configPath := filepath.Join(tmp, "config.toml")
+			statePath := filepath.Join(tmp, "state.json")
+			payload := "[mcp_servers.docs]\ncommand = " + tomlQuoted(command) + tc.nativeTOML
+			if err := os.WriteFile(configPath, []byte(payload), 0o600); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+			if err := syncshared.SaveManagedState(statePath, map[string][]string{"docs": {syncshared.RingSource("restricted")}}); err != nil {
+				t.Fatalf("write state: %v", err)
+			}
+			allowed := []string{"read"}
+			manifest := registry.Manifest{Name: "docs", Command: command, Enabled: true, Clients: []string{Target}, Access: &registry.AccessProfile{AllowedTools: &allowed}}
+			ring := registry.Ring{Name: "restricted", Members: []string{"docs"}, Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired}}
+			_, err := Sync([]registry.Manifest{manifest}, SyncOptions{ConfigPath: configPath, StatePath: statePath, Rings: []registry.Ring{ring}, DryRun: true})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected fidelity refusal containing %q, got: %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestSyncRejectsMalformedNativePolicyTypesWithoutMutation(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state.json")
+	original := []byte("[mcp_servers.stewreads]\ncommand = \"stewreads-mcp\"\nenabled_tools = [1]\n")
+	if err := os.WriteFile(configPath, original, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	_, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{ConfigPath: configPath, StatePath: statePath})
+	if err == nil || !strings.Contains(err.Error(), "enabled_tools") {
+		t.Fatalf("expected native policy parse failure, got: %v", err)
+	}
+	assertFileEquals(t, configPath, original)
+	if _, statErr := os.Stat(statePath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("parse failure wrote state: %v", statErr)
+	}
+}
+
+func TestRequiredAttachRejectsInvalidInMemoryPortableApproval(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state.json")
+	allowed := []string{"read"}
+	invalid := registry.ApprovalBehavior("prompt")
+	manifest := registry.Manifest{
+		Name: "docs", Command: currentTestExecutable(t), Enabled: true, Clients: []string{Target},
+		Access: &registry.AccessProfile{AllowedTools: &allowed, DefaultApproval: &invalid},
+	}
+	ring := registry.Ring{Name: "restricted", Members: []string{"docs"}, Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired}}
+	_, err := AttachRing(ring, []registry.Manifest{manifest}, SyncOptions{ConfigPath: configPath, StatePath: statePath, Rings: []registry.Ring{ring}})
+	if err == nil || !strings.Contains(err.Error(), "invalid default_approval") {
+		t.Fatalf("expected invalid portable approval refusal, got: %v", err)
+	}
+	for _, path := range []string{configPath, statePath} {
+		if _, statErr := os.Stat(path); !errors.Is(statErr, os.ErrNotExist) {
+			t.Fatalf("invalid approval mutated %s: %v", path, statErr)
+		}
+	}
+}
+
+func TestRequiredAttachRejectsUnsupportedSSEBeforeMutation(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state.json")
+	manifest := newCloudSQLManifest()
+	manifest.Transport = registry.TransportSSE
+	allowed := []string{"read"}
+	manifest.Access = &registry.AccessProfile{AllowedTools: &allowed}
+	ring := registry.Ring{Name: "restricted", Members: []string{manifest.Name}, Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired}}
+	_, err := AttachRing(ring, []registry.Manifest{manifest}, SyncOptions{ConfigPath: configPath, StatePath: statePath, Rings: []registry.Ring{ring}})
+	if err == nil || !strings.Contains(err.Error(), "uses sse transport") {
+		t.Fatalf("expected SSE refusal, got: %v", err)
+	}
+	for _, path := range []string{configPath, statePath} {
+		if _, statErr := os.Stat(path); !errors.Is(statErr, os.ErrNotExist) {
+			t.Fatalf("required preflight mutated %s: %v", path, statErr)
+		}
+	}
+}
+
+func TestSyncPolicyOnlyDriftIsClassifiedAndSetOrderIsSemantic(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state.json")
+	command := currentTestExecutable(t)
+	original := "[mcp_servers.docs]\ncommand = " + tomlQuoted(command) + "\nenabled_tools = [\"write\", \"read\"]\n"
+	if err := os.WriteFile(configPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := syncshared.SaveManagedState(statePath, map[string][]string{"docs": {syncshared.SourceStandalone}}); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	matching := []string{"read", "write"}
+	manifest := registry.Manifest{Name: "docs", Command: command, Enabled: true, Clients: []string{Target}, Access: &registry.AccessProfile{AllowedTools: &matching}}
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{ConfigPath: configPath, StatePath: statePath, DryRun: true})
+	if err != nil {
+		t.Fatalf("dry-run matching set: %v", err)
+	}
+	if !reflect.DeepEqual(result.Unchanged, []string{"docs"}) || len(result.PolicyUpdated) != 0 {
+		t.Fatalf("array ordering must not create drift: %#v", result)
+	}
+
+	changed := []string{"read"}
+	manifest.Access.AllowedTools = &changed
+	result, err = Sync([]registry.Manifest{manifest}, SyncOptions{ConfigPath: configPath, StatePath: statePath, DryRun: true})
+	if err != nil {
+		t.Fatalf("dry-run policy drift: %v", err)
+	}
+	if !reflect.DeepEqual(result.Updated, []string{"docs"}) || !reflect.DeepEqual(result.PolicyUpdated, []string{"docs"}) {
+		t.Fatalf("policy-only drift not classified: %#v", result)
+	}
+}
+
+func fullPolicyAccess() *registry.AccessProfile {
+	allowed := []string{"issues.list", "issues.inherit", "issues.get"}
+	denied := []string{"issues.delete"}
+	scopes := []string{"profile:read", "issues:read"}
+	defaultApproval := registry.ApprovalBehaviorAlwaysPrompt
+	toolApprovals := map[string]registry.ApprovalBehavior{
+		"issues.get":     registry.ApprovalBehaviorAlwaysAllow,
+		"issues.list":    registry.ApprovalBehaviorAutomatic,
+		"issues.inherit": registry.ApprovalBehaviorInherit,
+	}
+	return &registry.AccessProfile{
+		AllowedTools: &allowed, DeniedTools: &denied, OAuthScopes: &scopes,
+		DefaultApproval: &defaultApproval, ToolApprovals: &toolApprovals,
+	}
+}
+
+func rawServerTable(t *testing.T, path, name string) map[string]any {
+	t.Helper()
+	root := readRoot(t, path)
+	servers, ok := root["mcp_servers"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing mcp_servers table: %#v", root)
+	}
+	table, ok := servers[name].(map[string]any)
+	if !ok {
+		t.Fatalf("missing server %s: %#v", name, servers)
+	}
+	return table
+}
+
+func assertRawStringSlice(t *testing.T, table map[string]any, key string, want []string) {
+	t.Helper()
+	raw, ok := table[key].([]any)
+	if !ok {
+		t.Fatalf("%s is not an array: %#v", key, table[key])
+	}
+	got := make([]string, len(raw))
+	for i, value := range raw {
+		got[i] = value.(string)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("%s mismatch: got %#v want %#v", key, got, want)
+	}
+}
+
+func currentTestExecutable(t *testing.T) string {
+	t.Helper()
+	path, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve executable: %v", err)
+	}
+	return path
+}
+
+func tomlQuoted(value string) string {
+	return `"` + strings.ReplaceAll(strings.ReplaceAll(value, `\`, `\\`), `"`, `\"`) + `"`
+}
+
+func assertFileEquals(t *testing.T, path string, want []byte) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("file %s changed\nwant:\n%s\ngot:\n%s", path, want, got)
+	}
+}

--- a/internal/clients/codex/policy_sync_test.go
+++ b/internal/clients/codex/policy_sync_test.go
@@ -56,6 +56,7 @@ enabled_tools = ["read"]
 disabled_tools = ["delete"]
 scopes = ["repo:read"]
 default_tools_approval_mode = "writes"
+startup_timeout_ms = 1500
 future_restriction = "strict"
 
 [mcp_servers.stewreads.tools.read]
@@ -83,6 +84,9 @@ classification = "sensitive"
 	assertRawStringSlice(t, table, "scopes", []string{"repo:read"})
 	if table["default_tools_approval_mode"] != "writes" || table["future_restriction"] != "strict" {
 		t.Fatalf("legacy native fields were stripped: %#v", table)
+	}
+	if table["startup_timeout_ms"] != int64(1500) {
+		t.Fatalf("documented millisecond timeout alias was stripped: %#v", table)
 	}
 	tool := table["tools"].(map[string]any)["read"].(map[string]any)
 	if tool["approval_mode"] != "prompt" || tool["classification"] != "sensitive" {
@@ -247,13 +251,8 @@ func TestRequiredSyncBlocksUnknownNestedAndVersionSkewApproval(t *testing.T) {
 		},
 		{
 			name:       "version skew approval",
-			nativeTOML: "\ndefault_tools_approval_mode = \"writes\"\n",
-			want:       "writes",
-		},
-		{
-			name:       "native disabled entry",
-			nativeTOML: "\nenabled = false\n",
-			want:       "enabled=false",
+			nativeTOML: "\ndefault_tools_approval_mode = \"future\"\n",
+			want:       "future",
 		},
 	}
 	for _, tc := range cases {
@@ -276,6 +275,40 @@ func TestRequiredSyncBlocksUnknownNestedAndVersionSkewApproval(t *testing.T) {
 				t.Fatalf("expected fidelity refusal containing %q, got: %v", tc.want, err)
 			}
 		})
+	}
+}
+
+func TestRequiredSyncAcceptsDocumentedNativeCompatibilityFields(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state.json")
+	command := currentTestExecutable(t)
+	payload := "[mcp_servers.docs]\ncommand = " + tomlQuoted(command) + "\nenabled = false\nenabled_tools = [\"read\"]\ndefault_tools_approval_mode = \"writes\"\nstartup_timeout_ms = 1500\n\n[mcp_servers.docs.tools.read]\napproval_mode = \"writes\"\n"
+	if err := os.WriteFile(configPath, []byte(payload), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := syncshared.SaveManagedState(statePath, map[string][]string{"docs": {syncshared.RingSource("restricted")}}); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	allowed := []string{"read"}
+	manifest := registry.Manifest{Name: "docs", Command: command, Enabled: true, Clients: []string{Target}, Access: &registry.AccessProfile{AllowedTools: &allowed}}
+	ring := registry.Ring{Name: "restricted", Members: []string{"docs"}, Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired}}
+	result, err := Sync([]registry.Manifest{manifest}, SyncOptions{ConfigPath: configPath, StatePath: statePath, Rings: []registry.Ring{ring}})
+	if err != nil {
+		t.Fatalf("sync documented native compatibility fields: %v", err)
+	}
+	if !reflect.DeepEqual(result.Updated, []string{"docs"}) {
+		t.Fatalf("native disabled state was not reconciled: %#v", result)
+	}
+	table := rawServerTable(t, configPath, "docs")
+	if _, exists := table["enabled"]; exists {
+		t.Fatalf("native disabled state survived reconciliation: %#v", table)
+	}
+	if table["default_tools_approval_mode"] != "writes" || table["startup_timeout_ms"] != int64(1500) {
+		t.Fatalf("documented native fields were not preserved: %#v", table)
+	}
+	if table["tools"].(map[string]any)["read"].(map[string]any)["approval_mode"] != "writes" {
+		t.Fatalf("documented per-tool writes approval was not preserved: %#v", table)
 	}
 }
 

--- a/internal/clients/codex/sync.go
+++ b/internal/clients/codex/sync.go
@@ -31,6 +31,9 @@ type SyncResult = clients.SyncResult
 // config file. Codex's native `codex mcp add` command writes global MCP
 // servers to $CODEX_HOME/config.toml, defaulting to ~/.codex/config.toml.
 func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
+	if err := validateInputManifests(manifests); err != nil {
+		return SyncResult{}, err
+	}
 	if err := validateScope(opts.Scope); err != nil {
 		return SyncResult{}, err
 	}
@@ -51,11 +54,15 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 	if err != nil {
 		return SyncResult{}, err
 	}
+	if err := preflightAttachedPolicyRings(opts.Rings, manifests, managedState, existingServers); err != nil {
+		return SyncResult{}, err
+	}
 
 	result, nextState, writeSet, err := syncshared.PlanSync(existingServers, managedState, entriesForTarget(manifests), opts.Rings, equalServer, ErrConflict)
 	if err != nil {
 		return SyncResult{}, err
 	}
+	result.PolicyUpdated = policyUpdatedNames(result.Updated, existingServers, writeSet)
 	result.ConfigPath = configPath
 	result.DryRun = opts.DryRun
 
@@ -73,6 +80,9 @@ func Sync(manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
 // eligible ones into Codex config. Attaching onto any pre-existing unmanaged
 // entry, equal values included, refuses with ErrConflict.
 func AttachRing(ring registry.Ring, manifests []registry.Manifest, opts SyncOptions) (SyncResult, error) {
+	if err := validateInputManifests(manifests); err != nil {
+		return SyncResult{}, err
+	}
 	if err := validateScope(opts.Scope); err != nil {
 		return SyncResult{}, err
 	}
@@ -93,11 +103,15 @@ func AttachRing(ring registry.Ring, manifests []registry.Manifest, opts SyncOpti
 	if err != nil {
 		return SyncResult{}, err
 	}
+	if err := preflightPolicyRing(ring, manifests, managedState, existingServers); err != nil {
+		return SyncResult{}, err
+	}
 
 	result, nextState, writeSet, err := syncshared.PlanAttach(existingServers, managedState, ring.Name, ring.Members, entriesForTarget(manifests), opts.Rings, equalServer, ErrConflict)
 	if err != nil {
 		return SyncResult{}, err
 	}
+	result.PolicyUpdated = policyUpdatedNames(result.Updated, existingServers, writeSet)
 	result.ConfigPath = configPath
 	result.DryRun = opts.DryRun
 
@@ -165,7 +179,11 @@ func applyPlan(
 		delete(mutated, name)
 	}
 	for name, server := range writeSet {
-		mutated[name] = server
+		merged, err := mergeServerTable(rawServers[name], server)
+		if err != nil {
+			return fmt.Errorf("merge Codex server %q: %w", name, err)
+		}
+		mutated[name] = merged
 	}
 
 	updatedRoot := make(map[string]any, len(root)+1)
@@ -234,6 +252,18 @@ func validateScope(scope string) error {
 	}
 }
 
+func validateInputManifests(manifests []registry.Manifest) error {
+	for _, manifest := range manifests {
+		if !manifest.HasClient(Target) {
+			continue
+		}
+		if err := manifest.Validate(); err != nil {
+			return fmt.Errorf("validate manifest %q before Codex policy compilation: %w", manifest.Name, err)
+		}
+	}
+	return nil
+}
+
 func entriesForTarget(manifests []registry.Manifest) map[string]syncshared.Entry[serverConfig] {
 	entries := map[string]syncshared.Entry[serverConfig]{}
 	for _, manifest := range manifests {
@@ -268,6 +298,7 @@ func materializeServer(manifest registry.Manifest) serverConfig {
 			URL:               manifest.URL,
 			OAuthResource:     manifest.OAuthResource,
 			BearerTokenEnvVar: manifest.BearerTokenEnvVar,
+			Access:            CompileAccess(manifest.Access),
 		}
 		if len(manifest.Headers) > 0 {
 			entry.HTTPHeaders = make(map[string]string, len(manifest.Headers))
@@ -280,6 +311,7 @@ func materializeServer(manifest registry.Manifest) serverConfig {
 
 	entry := serverConfig{
 		Command: manifest.Command,
+		Access:  CompileAccess(manifest.Access),
 		EnvVars: runtimeEnvKeys(
 			manifest.RequiredEnv.Keys,
 			manifest.SecretEnv.Keys,
@@ -345,9 +377,6 @@ func equalServer(a, b serverConfig) bool {
 			return false
 		}
 	}
-	if effectiveEnabled(a) != effectiveEnabled(b) {
-		return false
-	}
 	if !equalStringSlices(a.Args, b.Args) {
 		return false
 	}
@@ -359,11 +388,10 @@ func equalServer(a, b serverConfig) bool {
 			return false
 		}
 	}
-	return equalStringSlices(a.EnvVars, b.EnvVars)
-}
-
-func effectiveEnabled(server serverConfig) bool {
-	return server.Enabled == nil || *server.Enabled
+	if !equalStringSlices(a.EnvVars, b.EnvVars) {
+		return false
+	}
+	return equalDeclaredAccess(a.Access, b.Access)
 }
 
 func equalStringSlices(a, b []string) bool {
@@ -487,6 +515,12 @@ func parseServer(name string, raw any) (serverConfig, error) {
 	} else if ok {
 		entry.EnvVars = envVars
 	}
+	access, fidelityIssues, err := parseNativeAccess(name, table)
+	if err != nil {
+		return serverConfig{}, err
+	}
+	entry.Access = access
+	entry.FidelityIssues = fidelityIssues
 	return entry, nil
 }
 
@@ -553,13 +587,15 @@ func optionalStringMap(table map[string]any, key string) (map[string]string, boo
 }
 
 type serverConfig struct {
-	Command           string            `toml:"command,omitempty"`
-	URL               string            `toml:"url,omitempty"`
-	OAuthResource     string            `toml:"oauth_resource,omitempty"`
-	BearerTokenEnvVar string            `toml:"bearer_token_env_var,omitempty"`
-	Enabled           *bool             `toml:"enabled,omitempty"`
-	Args              []string          `toml:"args,omitempty"`
-	EnvVars           []string          `toml:"env_vars,omitempty"`
-	Env               map[string]string `toml:"env,omitempty"`
-	HTTPHeaders       map[string]string `toml:"http_headers,omitempty"`
+	Command           string                `toml:"command,omitempty"`
+	URL               string                `toml:"url,omitempty"`
+	OAuthResource     string                `toml:"oauth_resource,omitempty"`
+	BearerTokenEnvVar string                `toml:"bearer_token_env_var,omitempty"`
+	Enabled           *bool                 `toml:"enabled,omitempty"`
+	Args              []string              `toml:"args,omitempty"`
+	EnvVars           []string              `toml:"env_vars,omitempty"`
+	Env               map[string]string     `toml:"env,omitempty"`
+	HTTPHeaders       map[string]string     `toml:"http_headers,omitempty"`
+	Access            CompiledAccess        `toml:"-"`
+	FidelityIssues    []nativeFidelityIssue `toml:"-"`
 }

--- a/internal/clients/codex/sync.go
+++ b/internal/clients/codex/sync.go
@@ -357,6 +357,9 @@ func runtimeEnvKeys(keyGroups ...[]string) []string {
 }
 
 func equalServer(a, b serverConfig) bool {
+	if effectiveServerEnabled(a.Enabled) != effectiveServerEnabled(b.Enabled) {
+		return false
+	}
 	if a.Command != b.Command {
 		return false
 	}
@@ -392,6 +395,10 @@ func equalServer(a, b serverConfig) bool {
 		return false
 	}
 	return equalDeclaredAccess(a.Access, b.Access)
+}
+
+func effectiveServerEnabled(enabled *bool) bool {
+	return enabled == nil || *enabled
 }
 
 func equalStringSlices(a, b []string) bool {

--- a/internal/clients/codex/sync_test.go
+++ b/internal/clients/codex/sync_test.go
@@ -211,7 +211,7 @@ STEWREADS_CONFIG_PATH = "~/.config/stewreads/config.toml"
 	}
 }
 
-func TestSyncPreservesDisabledUnmanagedEntry(t *testing.T) {
+func TestSyncRefusesDisabledUnmanagedEntry(t *testing.T) {
 	tmp := t.TempDir()
 	configPath := filepath.Join(tmp, "config.toml")
 	statePath := filepath.Join(tmp, "state", "codex-managed.json")
@@ -226,20 +226,20 @@ STEWREADS_CONFIG_PATH = "~/.config/stewreads/config.toml"
 		t.Fatalf("write config fixture: %v", err)
 	}
 
-	result, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+	_, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
 		ConfigPath: configPath,
 		StatePath:  statePath,
 		DryRun:     true,
 	})
-	if err != nil {
-		t.Fatalf("sync disabled unmanaged entry: %v", err)
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected disabled unmanaged entry conflict, got: %v", err)
 	}
-	if !reflect.DeepEqual(result.Unchanged, []string{"stewreads"}) {
-		t.Fatalf("expected native enabled restriction to be preserved, got: %#v", result)
+	if _, statErr := os.Stat(statePath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("unmanaged conflict wrote state: %v", statErr)
 	}
 }
 
-func TestSyncPreservesOwnedDisabledEntry(t *testing.T) {
+func TestSyncReenablesOwnedDisabledEntry(t *testing.T) {
 	tmp := t.TempDir()
 	configPath := filepath.Join(tmp, "config.toml")
 	statePath := filepath.Join(tmp, "state", "codex-managed.json")
@@ -266,11 +266,11 @@ STEWREADS_CONFIG_PATH = "~/.config/stewreads/config.toml"
 	if err != nil {
 		t.Fatalf("sync dry-run failed: %v", err)
 	}
-	if !reflect.DeepEqual(result.Unchanged, []string{"stewreads"}) {
-		t.Fatalf("expected owned native enabled restriction to be preserved, got: %+v", result)
+	if !reflect.DeepEqual(result.Updated, []string{"stewreads"}) {
+		t.Fatalf("expected registry-enabled server to reconcile native enabled=false, got: %+v", result)
 	}
-	if enabled := readServers(t, configPath)["stewreads"].Enabled; enabled == nil || *enabled {
-		t.Fatalf("routine sync silently re-enabled native entry: %#v", enabled)
+	if enabled := readServers(t, configPath)["stewreads"].Enabled; enabled != nil {
+		t.Fatalf("reconciled entry should use Codex's enabled-by-default state: %#v", enabled)
 	}
 }
 

--- a/internal/clients/codex/sync_test.go
+++ b/internal/clients/codex/sync_test.go
@@ -211,7 +211,7 @@ STEWREADS_CONFIG_PATH = "~/.config/stewreads/config.toml"
 	}
 }
 
-func TestSyncConflictsOnDisabledUnmanagedEntry(t *testing.T) {
+func TestSyncPreservesDisabledUnmanagedEntry(t *testing.T) {
 	tmp := t.TempDir()
 	configPath := filepath.Join(tmp, "config.toml")
 	statePath := filepath.Join(tmp, "state", "codex-managed.json")
@@ -226,17 +226,20 @@ STEWREADS_CONFIG_PATH = "~/.config/stewreads/config.toml"
 		t.Fatalf("write config fixture: %v", err)
 	}
 
-	_, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
+	result, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
 		ConfigPath: configPath,
 		StatePath:  statePath,
 		DryRun:     true,
 	})
-	if !errors.Is(err, clients.ErrConflict) {
-		t.Fatalf("expected disabled unmanaged entry to conflict, got: %v", err)
+	if err != nil {
+		t.Fatalf("sync disabled unmanaged entry: %v", err)
+	}
+	if !reflect.DeepEqual(result.Unchanged, []string{"stewreads"}) {
+		t.Fatalf("expected native enabled restriction to be preserved, got: %#v", result)
 	}
 }
 
-func TestSyncUpdatesOwnedDisabledEntry(t *testing.T) {
+func TestSyncPreservesOwnedDisabledEntry(t *testing.T) {
 	tmp := t.TempDir()
 	configPath := filepath.Join(tmp, "config.toml")
 	statePath := filepath.Join(tmp, "state", "codex-managed.json")
@@ -259,13 +262,15 @@ STEWREADS_CONFIG_PATH = "~/.config/stewreads/config.toml"
 	result, err := Sync([]registry.Manifest{newStewreadsManifest()}, SyncOptions{
 		ConfigPath: configPath,
 		StatePath:  statePath,
-		DryRun:     true,
 	})
 	if err != nil {
 		t.Fatalf("sync dry-run failed: %v", err)
 	}
-	if !reflect.DeepEqual(result.Updated, []string{"stewreads"}) {
-		t.Fatalf("expected owned disabled entry to be reported updated, got: %+v", result)
+	if !reflect.DeepEqual(result.Unchanged, []string{"stewreads"}) {
+		t.Fatalf("expected owned native enabled restriction to be preserved, got: %+v", result)
+	}
+	if enabled := readServers(t, configPath)["stewreads"].Enabled; enabled == nil || *enabled {
+		t.Fatalf("routine sync silently re-enabled native entry: %#v", enabled)
 	}
 }
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -116,6 +116,9 @@ type DriftReport struct {
 	// Stale are managed entries whose materialized values differ from the
 	// manifest.
 	Stale []string
+	// PolicyStale is the subset of Stale whose declared access policy differs
+	// from the target's materialized policy.
+	PolicyStale []string
 	// Missing are managed entries absent from the client config.
 	Missing []string
 	// Orphaned are managed entries no longer desired; the next sync removes
@@ -302,13 +305,14 @@ func checkDrift(manifests []registry.Manifest, targets []DriftTarget, rings []re
 
 		dr.ConfigPath = plan.ConfigPath
 		dr.Stale = append([]string(nil), plan.Updated...)
+		dr.PolicyStale = append([]string(nil), plan.PolicyUpdated...)
 		for _, name := range plan.Added {
 			if _, managed := state[name]; managed {
 				dr.Missing = append(dr.Missing, name)
 			}
 		}
 		dr.Orphaned = append([]string(nil), plan.Removed...)
-		if len(dr.Stale)+len(dr.Missing)+len(dr.Orphaned) > 0 {
+		if len(dr.Stale)+len(dr.PolicyStale)+len(dr.Missing)+len(dr.Orphaned) > 0 {
 			dr.Status = StatusWarning
 		}
 		reports = append(reports, dr)

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -18,13 +18,14 @@ type testAdapter struct {
 	target         string
 	configPath     string
 	supportsRemote bool
+	syncResult     clients.SyncResult
 }
 
 func (a testAdapter) Target() string                     { return a.target }
 func (a testAdapter) DefaultConfigPath() (string, error) { return a.configPath, nil }
 func (a testAdapter) SupportsRemote(string) bool         { return a.supportsRemote }
 func (a testAdapter) Sync(_ []registry.Manifest, _ clients.SyncOptions) (clients.SyncResult, error) {
-	return clients.SyncResult{}, nil
+	return a.syncResult, nil
 }
 func (a testAdapter) AttachRing(_ registry.Ring, _ []registry.Manifest, _ clients.SyncOptions) (clients.SyncResult, error) {
 	return clients.SyncResult{}, nil
@@ -720,6 +721,56 @@ func TestRunDriftDetection(t *testing.T) {
 	}
 	if report.Summary.Warning < 1 {
 		t.Fatalf("expected drift to count as warning, got summary: %#v", report.Summary)
+	}
+}
+
+func TestRunDriftReportsPolicyStaleAsSubset(t *testing.T) {
+	tmp := t.TempDir()
+	store := registry.NewStore(filepath.Join(tmp, "servers"))
+	configPath := filepath.Join(tmp, "config.toml")
+	statePath := filepath.Join(tmp, "state", "codex-managed.json")
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o755); err != nil {
+		t.Fatalf("create state dir: %v", err)
+	}
+	state := `{"version":2,"managed_servers":{"core-drift":["standalone"],"policy-drift":["standalone"]}}`
+	if err := os.WriteFile(statePath, []byte(state), 0o644); err != nil {
+		t.Fatalf("write state fixture: %v", err)
+	}
+
+	adapter := testAdapter{
+		target:     "codex",
+		configPath: configPath,
+		syncResult: clients.SyncResult{
+			ConfigPath:    configPath,
+			Updated:       []string{"core-drift", "policy-drift"},
+			PolicyUpdated: []string{"policy-drift"},
+		},
+	}
+	report, err := Run(store, Options{
+		DriftTargets: []DriftTarget{{
+			Adapter:    adapter,
+			StatePath:  statePath,
+			ConfigPath: configPath,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("doctor run failed: %v", err)
+	}
+	if len(report.Drift) != 1 {
+		t.Fatalf("expected one drift report, got: %#v", report.Drift)
+	}
+	dr := report.Drift[0]
+	if dr.Status != StatusWarning {
+		t.Fatalf("expected policy drift warning, got: %#v", dr)
+	}
+	if len(dr.Stale) != 2 || dr.Stale[0] != "core-drift" || dr.Stale[1] != "policy-drift" {
+		t.Fatalf("unexpected stale entries: %#v", dr.Stale)
+	}
+	if len(dr.PolicyStale) != 1 || dr.PolicyStale[0] != "policy-drift" {
+		t.Fatalf("expected policy-drift as policy stale subset, got: %#v", dr.PolicyStale)
+	}
+	if report.Summary.Warning != 1 {
+		t.Fatalf("expected one drift warning without double counting policy subset, got: %#v", report.Summary)
 	}
 }
 

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -3,13 +3,16 @@ package doctor
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/ankitvg/madari/internal/clients"
 	"github.com/ankitvg/madari/internal/clients/claudecode"
+	"github.com/ankitvg/madari/internal/clients/codex"
 	"github.com/ankitvg/madari/internal/clients/gemini"
+	"github.com/ankitvg/madari/internal/clients/syncshared"
 	"github.com/ankitvg/madari/internal/registry"
 )
 
@@ -771,6 +774,42 @@ func TestRunDriftReportsPolicyStaleAsSubset(t *testing.T) {
 	}
 	if report.Summary.Warning != 1 {
 		t.Fatalf("expected one drift warning without double counting policy subset, got: %#v", report.Summary)
+	}
+}
+
+func TestRunDriftUsesCodexDeclaredPolicyComparator(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix fixture mode bits are used in this test")
+	}
+	tmp := t.TempDir()
+	store := registry.NewStore(filepath.Join(tmp, "servers"))
+	commandPath := writeTestExecutable(t, tmp, "policy-mcp")
+	allowed := []string{"read"}
+	if err := store.Save(registry.Manifest{
+		Name: "docs", Command: commandPath, Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{AllowedTools: &allowed},
+	}); err != nil {
+		t.Fatalf("save policy manifest: %v", err)
+	}
+	configPath := filepath.Join(tmp, "config.toml")
+	config := "[mcp_servers.docs]\ncommand = \"" + commandPath + "\"\nenabled_tools = [\"write\"]\n"
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatalf("write Codex config: %v", err)
+	}
+	statePath := filepath.Join(tmp, "state", "codex-managed.json")
+	if err := syncshared.SaveManagedState(statePath, map[string][]string{"docs": {syncshared.SourceStandalone}}); err != nil {
+		t.Fatalf("write managed state: %v", err)
+	}
+
+	adapter := codex.Adapter{}
+	report, err := Run(store, Options{DriftTargets: []DriftTarget{{
+		Adapter: adapter, StatePath: statePath, ConfigPath: configPath,
+	}}})
+	if err != nil {
+		t.Fatalf("doctor run: %v", err)
+	}
+	if len(report.Drift) != 1 || !reflect.DeepEqual(report.Drift[0].Stale, []string{"docs"}) || !reflect.DeepEqual(report.Drift[0].PolicyStale, []string{"docs"}) {
+		t.Fatalf("Codex policy drift was not propagated: %#v", report.Drift)
 	}
 }
 

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -99,6 +99,10 @@ var targetCapabilities = map[string]TargetCapabilities{
 			Compiler: true, ToolAllowlist: true, ToolDenylist: true,
 			OAuthScopes: true, DefaultApproval: true, ToolApprovals: true,
 		},
+		Run: Capabilities{
+			Compiler: true, ToolAllowlist: true, ToolDenylist: true,
+			OAuthScopes: true, DefaultApproval: true, ToolApprovals: true,
+		},
 	},
 	"gemini": {Target: "gemini"},
 	"vibe":   {Target: "vibe"},

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/ankitvg/madari/internal/clients"
 	"github.com/ankitvg/madari/internal/registry"
 )
 
@@ -62,8 +63,8 @@ func (c Capabilities) Supports(feature Feature) bool {
 }
 
 // TargetCapabilities is the central declaration for one supported Madari
-// target. PR 1A intentionally declares every policy feature unsupported; a
-// later compiler enables only the surface it implements losslessly.
+// target. A compiler enables only the surface and features it implements
+// losslessly; every unspecified surface remains unsupported.
 type TargetCapabilities struct {
 	Target     string       `json:"target"`
 	Persistent Capabilities `json:"persistent"`
@@ -88,9 +89,19 @@ func (c TargetCapabilities) ForSurface(surface Surface) (Capabilities, bool) {
 var targetCapabilities = map[string]TargetCapabilities{
 	"claude-desktop": {Target: "claude-desktop"},
 	"claude-code":    {Target: "claude-code"},
-	"codex":          {Target: "codex"},
-	"gemini":         {Target: "gemini"},
-	"vibe":           {Target: "vibe"},
+	"codex": {
+		Target: "codex",
+		Persistent: Capabilities{
+			Compiler: true, ToolAllowlist: true, ToolDenylist: true,
+			OAuthScopes: true, DefaultApproval: true, ToolApprovals: true,
+		},
+		Render: Capabilities{
+			Compiler: true, ToolAllowlist: true, ToolDenylist: true,
+			OAuthScopes: true, DefaultApproval: true, ToolApprovals: true,
+		},
+	},
+	"gemini": {Target: "gemini"},
+	"vibe":   {Target: "vibe"},
 }
 
 // Targets returns all centrally declared targets in deterministic order.
@@ -132,14 +143,17 @@ const (
 type IssueCode string
 
 const (
-	IssueUnknownTarget       IssueCode = "unknown-target"
-	IssueUnknownSurface      IssueCode = "unknown-surface"
-	IssueMissingMember       IssueCode = "missing-member"
-	IssueDisabledMember      IssueCode = "disabled-member"
-	IssueWrongTarget         IssueCode = "wrong-target"
-	IssueUnboundedMember     IssueCode = "unbounded-member"
-	IssueUnsupportedCompiler IssueCode = "unsupported-compiler"
-	IssueUnsupportedFeature  IssueCode = "unsupported-feature"
+	IssueUnknownTarget          IssueCode = "unknown-target"
+	IssueUnknownSurface         IssueCode = "unknown-surface"
+	IssueMissingMember          IssueCode = "missing-member"
+	IssueDisabledMember         IssueCode = "disabled-member"
+	IssueWrongTarget            IssueCode = "wrong-target"
+	IssueUnboundedMember        IssueCode = "unbounded-member"
+	IssueUnsupportedCompiler    IssueCode = "unsupported-compiler"
+	IssueUnsupportedFeature     IssueCode = "unsupported-feature"
+	IssueUnsupportedTransport   IssueCode = "unsupported-transport"
+	IssueUnsupportedServerField IssueCode = "unsupported-server-field"
+	IssueInvalidCommand         IssueCode = "invalid-command"
 )
 
 // Issue is one actionable policy-preflight failure.
@@ -272,6 +286,7 @@ func ValidateRequiredRing(ring registry.Ring, manifests []registry.Manifest, tar
 				Message: fmt.Sprintf("member %q does not target %q; add that client target or remove the member from the ring", member, target),
 			})
 		}
+		result.Issues = append(result.Issues, targetRepresentationIssues(manifest, target, surface)...)
 		if !manifest.HasExplicitToolAllowlist() {
 			result.Issues = append(result.Issues, Issue{
 				Code:    IssueUnboundedMember,
@@ -296,6 +311,39 @@ func ValidateRequiredRing(ring registry.Ring, manifests []registry.Manifest, tar
 
 	result.Classification = classify(result.Issues)
 	return result
+}
+
+func targetRepresentationIssues(manifest registry.Manifest, target string, surface Surface) []Issue {
+	if target != "codex" {
+		return nil
+	}
+	issues := []Issue{}
+	if manifest.IsRemote() {
+		if manifest.TransportType() != registry.TransportHTTP {
+			issues = append(issues, Issue{
+				Code: IssueUnsupportedTransport, Member: manifest.Name,
+				Message: fmt.Sprintf("member %q uses %s transport, which Codex %s cannot represent", manifest.Name, manifest.TransportType(), surface),
+			})
+		}
+	} else if commandErr := clients.ValidateCommandPath(manifest.Command); commandErr != nil {
+		issues = append(issues, Issue{
+			Code: IssueInvalidCommand, Member: manifest.Name,
+			Message: fmt.Sprintf("member %q cannot execute on Codex: %s", manifest.Name, commandErr.Message),
+		})
+	}
+	if manifest.TimeoutMS > 0 {
+		issues = append(issues, Issue{
+			Code: IssueUnsupportedServerField, Member: manifest.Name,
+			Message: fmt.Sprintf("member %q declares timeout_ms, which Codex %s cannot represent exactly", manifest.Name, surface),
+		})
+	}
+	if surface == SurfaceRender && len(manifest.SecretHeaderNames()) > 0 {
+		issues = append(issues, Issue{
+			Code: IssueUnsupportedServerField, Member: manifest.Name,
+			Message: fmt.Sprintf("member %q declares secret_headers whose values Codex render intentionally omits", manifest.Name),
+		})
+	}
+	return issues
 }
 
 func declaredFeatures(access *registry.AccessProfile) []Feature {
@@ -343,7 +391,8 @@ func classify(issues []Issue) SupportClassification {
 		return SupportSupported
 	}
 	for _, issue := range issues {
-		if issue.Code != IssueUnsupportedCompiler && issue.Code != IssueUnsupportedFeature {
+		if issue.Code != IssueUnsupportedCompiler && issue.Code != IssueUnsupportedFeature &&
+			issue.Code != IssueUnsupportedTransport && issue.Code != IssueUnsupportedServerField {
 			return SupportInvalid
 		}
 	}

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -29,7 +29,7 @@ func TestCapabilitiesDeclareEveryTargetSurfaceFailClosed(t *testing.T) {
 			if !ok {
 				t.Fatalf("missing declaration for %s %s", target, surface)
 			}
-			expectCodexCompiler := target == "codex" && (surface == SurfacePersistent || surface == SurfaceRender)
+			expectCodexCompiler := target == "codex"
 			if capabilities.Compiler != expectCodexCompiler {
 				t.Fatalf("unexpected compiler declaration for %s %s: %#v", target, surface, capabilities)
 			}
@@ -164,10 +164,10 @@ func TestValidateRequiredRingTreatsExplicitEmptyAllowlistAsUnbounded(t *testing.
 		Access:  &registry.AccessProfile{AllowedTools: &empty},
 	}
 	result := ValidateRequiredRing(requiredRing("research", "docs"), []registry.Manifest{manifest}, "codex", SurfaceRun)
-	if result.Classification != SupportInvalid || len(result.Issues) != 3 {
-		t.Fatalf("expected unbounded plus unsupported explicit-clear issues, got: %#v", result)
+	if result.Classification != SupportInvalid || len(result.Issues) != 1 {
+		t.Fatalf("expected explicit-clear allowlist to remain unbounded, got: %#v", result)
 	}
-	if result.Issues[0].Code != IssueUnsupportedCompiler || result.Issues[1].Code != IssueUnboundedMember || result.Issues[2].Code != IssueUnsupportedFeature {
+	if result.Issues[0].Code != IssueUnboundedMember {
 		t.Fatalf("unexpected explicit-clear issue order: %#v", result.Issues)
 	}
 }
@@ -181,18 +181,15 @@ func currentExecutable(t *testing.T) string {
 	return path
 }
 
-func TestValidateRequiredRingBlocksSkillOnlyWithoutCompiler(t *testing.T) {
+func TestValidateRequiredRingAllowsSkillOnlyWithCompiler(t *testing.T) {
 	ring := registry.Ring{
 		Name:   "workflow",
 		Skills: []string{"release"},
 		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
 	}
 	result := ValidateRequiredRing(ring, nil, "codex", SurfaceRun)
-	if result.Classification != SupportUnsupported || result.Ready() || len(result.Issues) != 1 {
-		t.Fatalf("skill-only required ring must still require a compiler: %#v", result)
-	}
-	if result.Issues[0].Code != IssueUnsupportedCompiler {
-		t.Fatalf("unexpected skill-only issue: %#v", result.Issues)
+	if result.Classification != SupportSupported || !result.Ready() || len(result.Issues) != 0 {
+		t.Fatalf("skill-only required ring should use the Codex run compiler: %#v", result)
 	}
 }
 

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -2,6 +2,7 @@ package policy
 
 import (
 	"errors"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -28,12 +29,13 @@ func TestCapabilitiesDeclareEveryTargetSurfaceFailClosed(t *testing.T) {
 			if !ok {
 				t.Fatalf("missing declaration for %s %s", target, surface)
 			}
-			if capabilities.Compiler {
-				t.Fatalf("PR 1A must not enable the %s %s policy compiler", target, surface)
+			expectCodexCompiler := target == "codex" && (surface == SurfacePersistent || surface == SurfaceRender)
+			if capabilities.Compiler != expectCodexCompiler {
+				t.Fatalf("unexpected compiler declaration for %s %s: %#v", target, surface, capabilities)
 			}
 			for _, feature := range features {
-				if capabilities.Supports(feature) {
-					t.Fatalf("PR 1A must fail closed, but %s %s supports %s", target, surface, feature)
+				if capabilities.Supports(feature) != expectCodexCompiler {
+					t.Fatalf("unexpected %s support for %s %s: %#v", feature, target, surface, capabilities)
 				}
 			}
 		}
@@ -61,7 +63,7 @@ func TestValidateRequiredRingClassifiesUnsupportedDeclaredFeatures(t *testing.T)
 	manifest := registry.Manifest{
 		Name:    "docs",
 		Enabled: true,
-		Clients: []string{"codex"},
+		Clients: []string{"gemini"},
 		Access: &registry.AccessProfile{
 			AllowedTools:    &allowed,
 			DeniedTools:     &denied,
@@ -71,7 +73,7 @@ func TestValidateRequiredRingClassifiesUnsupportedDeclaredFeatures(t *testing.T)
 		},
 	}
 
-	result := ValidateRequiredRing(requiredRing("research", "docs"), []registry.Manifest{manifest}, "codex", SurfacePersistent)
+	result := ValidateRequiredRing(requiredRing("research", "docs"), []registry.Manifest{manifest}, "gemini", SurfacePersistent)
 	if result.Classification != SupportUnsupported || result.Ready() {
 		t.Fatalf("expected unsupported result, got: %#v", result)
 	}
@@ -100,7 +102,7 @@ func TestValidateRequiredRingClassifiesUnsupportedDeclaredFeatures(t *testing.T)
 	if !errors.As(result.Err(), &validationErr) {
 		t.Fatalf("expected structured validation error, got: %v", result.Err())
 	}
-	if validationErr.Result.Classification != SupportUnsupported || !strings.Contains(validationErr.Error(), "codex persistent policy support is unsupported") {
+	if validationErr.Result.Classification != SupportUnsupported || !strings.Contains(validationErr.Error(), "gemini persistent policy support is unsupported") {
 		t.Fatalf("unexpected actionable error: %v", validationErr)
 	}
 }
@@ -109,12 +111,12 @@ func TestValidateRequiredRingReportsMemberProblemsDeterministically(t *testing.T
 	allowed := []string{"read"}
 	ring := requiredRing("research", "wrong", "missing", "disabled", "unbounded")
 	manifests := []registry.Manifest{
-		{Name: "wrong", Enabled: true, Clients: []string{"gemini"}, Access: &registry.AccessProfile{AllowedTools: &allowed}},
-		{Name: "disabled", Enabled: false, Clients: []string{"codex"}},
-		{Name: "unbounded", Enabled: true, Clients: []string{"codex"}},
+		{Name: "wrong", Enabled: true, Clients: []string{"codex"}, Access: &registry.AccessProfile{AllowedTools: &allowed}},
+		{Name: "disabled", Enabled: false, Clients: []string{"gemini"}},
+		{Name: "unbounded", Enabled: true, Clients: []string{"gemini"}},
 	}
 
-	result := ValidateRequiredRing(ring, manifests, "codex", SurfaceRender)
+	result := ValidateRequiredRing(ring, manifests, "gemini", SurfaceRender)
 	if result.Classification != SupportInvalid || result.Ready() {
 		t.Fatalf("expected invalid member result, got: %#v", result)
 	}
@@ -144,7 +146,7 @@ func TestValidateRequiredRingReportsMemberProblemsDeterministically(t *testing.T
 		`member "disabled" is disabled`,
 		`member "missing" is missing from the registry`,
 		`member "unbounded" is unbounded`,
-		`member "wrong" does not target "codex"`,
+		`member "wrong" does not target "gemini"`,
 	} {
 		if !strings.Contains(message, fragment) {
 			t.Fatalf("error missing actionable detail %q: %s", fragment, message)
@@ -156,6 +158,7 @@ func TestValidateRequiredRingTreatsExplicitEmptyAllowlistAsUnbounded(t *testing.
 	empty := []string{}
 	manifest := registry.Manifest{
 		Name:    "docs",
+		Command: currentExecutable(t),
 		Enabled: true,
 		Clients: []string{"codex"},
 		Access:  &registry.AccessProfile{AllowedTools: &empty},
@@ -167,6 +170,15 @@ func TestValidateRequiredRingTreatsExplicitEmptyAllowlistAsUnbounded(t *testing.
 	if result.Issues[0].Code != IssueUnsupportedCompiler || result.Issues[1].Code != IssueUnboundedMember || result.Issues[2].Code != IssueUnsupportedFeature {
 		t.Fatalf("unexpected explicit-clear issue order: %#v", result.Issues)
 	}
+}
+
+func currentExecutable(t *testing.T) string {
+	t.Helper()
+	path, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve test executable: %v", err)
+	}
+	return path
 }
 
 func TestValidateRequiredRingBlocksSkillOnlyWithoutCompiler(t *testing.T) {
@@ -181,6 +193,45 @@ func TestValidateRequiredRingBlocksSkillOnlyWithoutCompiler(t *testing.T) {
 	}
 	if result.Issues[0].Code != IssueUnsupportedCompiler {
 		t.Fatalf("unexpected skill-only issue: %#v", result.Issues)
+	}
+}
+
+func TestValidateRequiredCodexRingBlocksUnrepresentableServerFields(t *testing.T) {
+	allowed := []string{"read"}
+	base := registry.Manifest{
+		Name: "docs", Transport: registry.TransportHTTP, URL: "https://example.com/mcp",
+		Enabled: true, Clients: []string{"codex"}, Access: &registry.AccessProfile{AllowedTools: &allowed},
+	}
+	cases := []struct {
+		name     string
+		surface  Surface
+		mutate   func(*registry.Manifest)
+		fragment string
+	}{
+		{
+			name: "timeout persistent", surface: SurfacePersistent, fragment: "timeout_ms",
+			mutate: func(manifest *registry.Manifest) { manifest.TimeoutMS = 5000 },
+		},
+		{
+			name: "secret header render", surface: SurfaceRender, fragment: "secret_headers",
+			mutate: func(manifest *registry.Manifest) {
+				manifest.Headers = map[string]string{"x-private-token": "secret"}
+				manifest.SecretHeaders = registry.SecretHeaders{Keys: []string{"x-private-token"}}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			manifest := base
+			tc.mutate(&manifest)
+			result := ValidateRequiredRing(requiredRing("restricted", "docs"), []registry.Manifest{manifest}, "codex", tc.surface)
+			if result.Ready() || result.Classification != SupportUnsupported || len(result.Issues) != 1 || result.Issues[0].Code != IssueUnsupportedServerField {
+				t.Fatalf("expected unsupported server field: %#v", result)
+			}
+			if !strings.Contains(result.Issues[0].Message, tc.fragment) {
+				t.Fatalf("issue missing %q: %#v", tc.fragment, result.Issues[0])
+			}
+		})
 	}
 }
 

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -253,6 +253,7 @@ func TestValidateAttachedRequiredRingsChecksOnlyRecordedSources(t *testing.T) {
 	allowed := []string{"read"}
 	manifest := registry.Manifest{
 		Name:    "docs",
+		Command: currentExecutable(t),
 		Enabled: true,
 		Clients: []string{"codex"},
 		Access:  &registry.AccessProfile{AllowedTools: &allowed},
@@ -265,8 +266,8 @@ func TestValidateAttachedRequiredRingsChecksOnlyRecordedSources(t *testing.T) {
 	if err := ValidateAttachedRequiredRings(rings, []string{"advisory"}, []registry.Manifest{manifest}, "codex", SurfacePersistent); err != nil {
 		t.Fatalf("advisory attached ring should remain compatible: %v", err)
 	}
-	if err := ValidateAttachedRequiredRings(rings, []string{"required", "required"}, []registry.Manifest{manifest}, "codex", SurfacePersistent); err == nil || !strings.Contains(err.Error(), "codex persistent policy support is unsupported") {
-		t.Fatalf("required attached ring should fail closed: %v", err)
+	if err := ValidateAttachedRequiredRings(rings, []string{"required", "required"}, []registry.Manifest{manifest}, "codex", SurfacePersistent); err != nil {
+		t.Fatalf("supported required attached ring should compile: %v", err)
 	}
 	if err := ValidateAttachedRequiredRings(rings, []string{"missing"}, []registry.Manifest{manifest}, "codex", SurfacePersistent); err == nil || !strings.Contains(err.Error(), `attached ring "missing" is missing`) {
 		t.Fatalf("missing attached ring should fail closed: %v", err)


### PR DESCRIPTION
## What changed

- compile portable access profiles into Codex enabled/disabled tools, requested scopes, default approvals, and per-tool approvals
- patch cloned native server tables so routine sync preserves undeclared restrictions and explicit clears remove only their declared override
- fail required attach/sync before config, state, or skill mutation on unsupported transports, omitted semantics, unmanaged members, native disabled entries, unknown behavior-affecting fields, or version-skew approval values
- render deterministic Codex policy TOML, including dotted/control-bearing tool names
- report policy-only drift through sync JSON, doctor JSON, doctor text, and status text
- retain unmanaged-entry and overlapping server/skill refcount guarantees

## Safety notes

OAuth scopes are reported as requested/client-configured, not provider-proven. Approval behavior remains a client prompt control rather than an authorization boundary. Codex run policy remains fail-closed for PR 1C.

## Validation

- `go test ./internal/registry`
- `go test ./internal/clients/codex`
- `go test ./cmd/madari`
- `go test ./internal/doctor`
- `make build`
- `go test ./...`
- `go vet ./...`
- `git diff --check`

Stacked on #71.
