### PR TITLE
Capability Policy V1: compile policy for Codex runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,12 +154,17 @@ MCP servers still receive the caller's non-secret `HOME`, `USERPROFILE`, and
 `CODEX_HOME` values when present so home-based server credentials keep working;
 secret declarations for those isolated env keys are blocked. Other clients
 remain dry-run only for now.
+Every access-bearing Codex run requires a stable Codex CLI 0.139.x release and
+passes the complete profile through one strict ephemeral config override. A
+required ring upgrades that supported profile from advisory to exact
+enforcement and blocks before temporary skill materialization on any downgrade.
 
 Capability Policy Contract V1 preserves existing behavior for manifests without
-`[access]` and rings without `[policy]`. Codex persistent sync/attach and render
-compile all five V1 access fields. Required operations fail during preflight if
-a member or native field cannot be represented exactly; Codex run and all other
-target policy surfaces remain unsupported until their own compilers land.
+`[access]` and rings without `[policy]`. Codex compiles all five V1 access fields
+for persistent sync/attach, render, and ephemeral run. Required operations fail
+during preflight if a member, native field, or installed Codex version cannot
+represent the contract exactly. Other target policy surfaces remain unsupported
+until their own compilers land.
 
 ## Safety Model
 
@@ -200,8 +205,8 @@ remote manifests and report them as pending. Remote entries that require
 `codex`.
 
 Transport, auth, and skill support are separate from capability-policy support.
-Codex supports exact policy compilation on persistent sync/attach and render.
-Codex run and every policy surface for other clients remain unsupported. Legacy
+Codex supports exact policy compilation on persistent sync/attach, render, and
+run. Every policy surface for other clients remains unsupported. Legacy
 operations remain available; rings with `[policy] enforcement = "required"`
 block whenever the selected target surface lacks an exact compiler.
 

--- a/cmd/madari/policy_preflight_test.go
+++ b/cmd/madari/policy_preflight_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -260,8 +261,9 @@ func TestPolicyRequiredAttachedRingSyncFailsBeforeConfigStateOrSkillMutation(t *
 	}
 }
 
-func TestPolicyRequiredRingMakesRunPlanNotReady(t *testing.T) {
+func TestPolicyRequiredRingMakesCodexRunPlanExact(t *testing.T) {
 	store := newTestStore(t)
+	installFakeCodex(t, 0)
 	savePolicyTestManifest(t, store, "docs", "codex")
 	savePolicyTestRing(t, store, "restricted", []string{"docs"}, nil, true)
 
@@ -269,16 +271,20 @@ func TestPolicyRequiredRingMakesRunPlanNotReady(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build run plan: %v", err)
 	}
-	if plan.Ready {
-		t.Fatalf("required policy must block execution while run compiler is unsupported: %#v", plan)
+	if !plan.Ready {
+		t.Fatalf("required Codex policy run should be ready: %#v", plan)
 	}
-	if !containsPolicyTestSubstring(plan.Errors, "codex run policy support is unsupported") {
-		t.Fatalf("run plan missing policy support error: %#v", plan.Errors)
+	if len(plan.Servers) != 1 || plan.Servers[0].Policy.SupportState != "supported" || plan.Servers[0].Policy.EnforcementClassification != "exact" {
+		t.Fatalf("run plan missing exact policy classification: %#v", plan.Servers)
+	}
+	if plan.Servers[0].Policy.Effective == nil || !reflect.DeepEqual(plan.Servers[0].Policy.Effective.EnabledTools, []string{"read"}) {
+		t.Fatalf("run plan missing effective policy: %#v", plan.Servers[0].Policy)
 	}
 }
 
-func TestPolicyRequiredSkillOnlyRingAttachesButRunRemainsBlocked(t *testing.T) {
+func TestPolicyRequiredSkillOnlyRingAttachesAndRunCompilesAfterMemberEdit(t *testing.T) {
 	store := newTestStore(t)
+	installFakeCodex(t, 0)
 	projectDir := t.TempDir()
 	chdirForTest(t, projectDir)
 	skillSource := writeSkillFile(t, t.TempDir(), "release.md", "# Release\n")
@@ -310,8 +316,8 @@ func TestPolicyRequiredSkillOnlyRingAttachesButRunRemainsBlocked(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build run plan: %v", err)
 	}
-	if plan.Ready || !containsPolicyTestSubstring(plan.Errors, "codex run has no lossless policy compiler yet") {
-		t.Fatalf("skill-only required run must be blocked: %#v", plan)
+	if !plan.Ready || len(plan.Servers) != 1 || plan.Servers[0].Policy.EnforcementClassification != "exact" {
+		t.Fatalf("required run should compile independently of persistent ownership: %#v", plan)
 	}
 }
 

--- a/cmd/madari/run_codex.go
+++ b/cmd/madari/run_codex.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	codexclient "github.com/ankitvg/madari/internal/clients/codex"
 	"github.com/ankitvg/madari/internal/clients/syncshared"
 	"github.com/ankitvg/madari/internal/registry"
 )
@@ -19,6 +20,11 @@ func runCodex(a cliApp, plan runLaunchPlan, prompt string) error {
 	codexPath, err := exec.LookPath("codex")
 	if err != nil {
 		return fmt.Errorf("codex not found in PATH; install Codex CLI or use --dry-run to inspect the launch plan")
+	}
+	if runPlanUsesPolicyContract(plan) {
+		if err := validateCodexPolicyRunCompatibility(); err != nil {
+			return err
+		}
 	}
 
 	workingDir, err := os.Getwd()
@@ -48,7 +54,11 @@ func runCodex(a cliApp, plan runLaunchPlan, prompt string) error {
 		return err
 	}
 
-	args := []string{"exec", "--ephemeral", "--ignore-user-config", "--skip-git-repo-check", "--sandbox", "read-only", "--cd", runRoot}
+	args := []string{"exec"}
+	if runPlanHasDeclaredAccess(plan) {
+		args = append(args, "--strict-config")
+	}
+	args = append(args, "--ephemeral", "--ignore-user-config", "--skip-git-repo-check", "--sandbox", "read-only", "--cd", runRoot)
 	for _, override := range overrides {
 		args = append(args, "-c", override)
 	}
@@ -63,6 +73,22 @@ func runCodex(a cliApp, plan runLaunchPlan, prompt string) error {
 		return fmt.Errorf("run codex exec: %w", err)
 	}
 	return nil
+}
+
+func runPlanUsesPolicyContract(plan runLaunchPlan) bool {
+	if plan.PolicyRequired {
+		return true
+	}
+	return runPlanHasDeclaredAccess(plan)
+}
+
+func runPlanHasDeclaredAccess(plan runLaunchPlan) bool {
+	for _, server := range plan.Servers {
+		if server.Policy.Declared != nil || server.Manifest.Access != nil {
+			return true
+		}
+	}
+	return false
 }
 
 var codexAdminSkillRoots = []string{
@@ -189,17 +215,29 @@ func withEnvValue(env []string, key, value string) []string {
 }
 
 func codexRunConfigOverrides(store *registry.Store, plan runLaunchPlan, workingDir string) ([]string, error) {
-	manifests, err := store.List()
-	if err != nil {
-		return nil, err
-	}
 	callerEnv, err := codexCallerIsolatedEnv()
 	if err != nil {
 		return nil, err
 	}
-	byName := make(map[string]registry.Manifest, len(manifests))
-	for _, manifest := range manifests {
-		byName[manifest.Name] = manifest
+	byName := make(map[string]registry.Manifest, len(plan.Servers))
+	needsStoreFallback := false
+	for _, server := range plan.Servers {
+		if server.Manifest.Name == server.Name {
+			byName[server.Name] = server.Manifest
+		} else {
+			needsStoreFallback = true
+		}
+	}
+	if needsStoreFallback {
+		manifests, err := store.List()
+		if err != nil {
+			return nil, err
+		}
+		for _, manifest := range manifests {
+			if _, planned := byName[manifest.Name]; !planned {
+				byName[manifest.Name] = manifest
+			}
+		}
 	}
 
 	names := make([]string, 0, len(plan.Servers))
@@ -261,6 +299,7 @@ func codexRunServerConfigValue(manifest registry.Manifest, workingDir string, ca
 		if len(manifest.Headers) > 0 {
 			fields = append(fields, fmt.Sprintf("http_headers = %s", tomlInlineStringMap(manifest.Headers)))
 		}
+		fields = append(fields, codexRunAccessConfigFields(manifest.Access)...)
 		return "{ " + strings.Join(fields, ", ") + " }", nil
 	}
 	if issues := codexRunServerPlanIssues(manifest); len(issues) > 0 {
@@ -278,7 +317,39 @@ func codexRunServerConfigValue(manifest registry.Manifest, workingDir string, ca
 	if env := codexRunStaticEnv(manifest, callerEnv); len(env) > 0 {
 		fields = append(fields, fmt.Sprintf("env = %s", tomlInlineStringMap(env)))
 	}
+	fields = append(fields, codexRunAccessConfigFields(manifest.Access)...)
 	return "{ " + strings.Join(fields, ", ") + " }", nil
+}
+
+func codexRunAccessConfigFields(access *registry.AccessProfile) []string {
+	compiled := codexclient.CompileAccess(access)
+	fields := make([]string, 0, 5)
+	if compiled.EnabledTools != nil && len(*compiled.EnabledTools) > 0 {
+		fields = append(fields, fmt.Sprintf("enabled_tools = %s", tomlStringArray(*compiled.EnabledTools)))
+	}
+	if compiled.DisabledTools != nil && len(*compiled.DisabledTools) > 0 {
+		fields = append(fields, fmt.Sprintf("disabled_tools = %s", tomlStringArray(*compiled.DisabledTools)))
+	}
+	if compiled.Scopes != nil && len(*compiled.Scopes) > 0 {
+		fields = append(fields, fmt.Sprintf("scopes = %s", tomlStringArray(*compiled.Scopes)))
+	}
+	if compiled.DefaultApproval != nil && *compiled.DefaultApproval != "" {
+		fields = append(fields, fmt.Sprintf("default_tools_approval_mode = %s", tomlString(*compiled.DefaultApproval)))
+	}
+	if compiled.ToolApprovals != nil {
+		tools := make([]string, 0, len(*compiled.ToolApprovals))
+		for _, tool := range sortedMapKeys(*compiled.ToolApprovals) {
+			approval := (*compiled.ToolApprovals)[tool]
+			if approval == "" {
+				continue
+			}
+			tools = append(tools, fmt.Sprintf("%s = { approval_mode = %s }", tomlKey(tool), tomlString(approval)))
+		}
+		if len(tools) > 0 {
+			fields = append(fields, "tools = { "+strings.Join(tools, ", ")+" }")
+		}
+	}
+	return fields
 }
 
 func codexRunServerPlanIssues(manifest registry.Manifest) []string {

--- a/cmd/madari/run_codex_test.go
+++ b/cmd/madari/run_codex_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/ankitvg/madari/internal/registry"
+	"github.com/pelletier/go-toml/v2"
 )
 
 func TestRunWithStoreCodexRunExecutesWithRingServersAndPrompt(t *testing.T) {
@@ -423,6 +424,60 @@ func TestCodexRunServerConfigValueBlocksSecretIsolatedEnvKeys(t *testing.T) {
 	}
 }
 
+func TestCodexRunConfigOverridesCompilePolicyDeterministically(t *testing.T) {
+	store := newTestStore(t)
+	allowed := []string{"tools.write", "tools.inherit", "tools.read\x7f"}
+	denied := []string{"tools.remove", "tools.delete"}
+	scopes := []string{"repo.write", "repo.read"}
+	defaultApproval := registry.ApprovalBehaviorAlwaysPrompt
+	toolApprovals := map[string]registry.ApprovalBehavior{
+		"tools.write":    registry.ApprovalBehaviorAlwaysAllow,
+		"tools.inherit":  registry.ApprovalBehaviorInherit,
+		"tools.read\x7f": registry.ApprovalBehaviorAutomatic,
+	}
+	if err := store.Save(registry.Manifest{
+		Name: "docs.server", Transport: registry.TransportHTTP, URL: "https://example.com/mcp",
+		Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{
+			AllowedTools: &allowed, DeniedTools: &denied, OAuthScopes: &scopes,
+			DefaultApproval: &defaultApproval, ToolApprovals: &toolApprovals,
+		},
+	}); err != nil {
+		t.Fatalf("save policy server: %v", err)
+	}
+	empty := []string{}
+	inherit := registry.ApprovalBehaviorInherit
+	clearApprovals := map[string]registry.ApprovalBehavior{"tools.clear": registry.ApprovalBehaviorInherit}
+	if err := store.Save(registry.Manifest{
+		Name: "z-last", Transport: registry.TransportHTTP, URL: "https://example.com/last",
+		Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{
+			AllowedTools: &empty, DeniedTools: &empty, OAuthScopes: &empty,
+			DefaultApproval: &inherit, ToolApprovals: &clearApprovals,
+		},
+	}); err != nil {
+		t.Fatalf("save explicit-clear server: %v", err)
+	}
+
+	overrides, err := codexRunConfigOverrides(store, runLaunchPlan{
+		Servers: []runPlanServer{{Name: "z-last"}, {Name: "docs.server"}},
+	}, t.TempDir())
+	if err != nil {
+		t.Fatalf("compile Codex run overrides: %v", err)
+	}
+	want := `mcp_servers={ "docs.server" = { url = "https://example.com/mcp", required = true, enabled_tools = ["tools.inherit", "tools.read\u007F", "tools.write"], disabled_tools = ["tools.delete", "tools.remove"], scopes = ["repo.read", "repo.write"], default_tools_approval_mode = "prompt", tools = { "tools.read\u007F" = { approval_mode = "auto" }, "tools.write" = { approval_mode = "approve" } } }, z-last = { url = "https://example.com/last", required = true } }`
+	if len(overrides) != 1 || overrides[0] != want {
+		t.Fatalf("unexpected deterministic policy override:\nwant %#v\ngot  %#v", []string{want}, overrides)
+	}
+	if strings.ContainsRune(overrides[0], '\x7f') || strings.Contains(overrides[0], `approval_mode = ""`) {
+		t.Fatalf("override did not omit inherit or escape controls: %q", overrides[0])
+	}
+	var parsed map[string]any
+	if err := toml.Unmarshal([]byte(overrides[0]), &parsed); err != nil {
+		t.Fatalf("compiled policy override is not valid TOML: %v\n%s", err, overrides[0])
+	}
+}
+
 func withCodexAdminSkillRoots(t *testing.T, roots []string) {
 	t.Helper()
 	previous := codexAdminSkillRoots
@@ -448,6 +503,7 @@ func installFakeCodex(t *testing.T, exitCode int) string {
 	logPath := filepath.Join(t.TempDir(), "codex-args.bin")
 	name := "codex"
 	script := []byte("#!/bin/sh\n" +
+		"if [ \"$1\" = \"--version\" ]; then printf 'codex-cli 0.139.0\\n'; exit 0; fi\n" +
 		"printf '%s' \"$PWD\" > '" + logPath + ".pwd'\n" +
 		"printf '%s' \"$HOME\" > '" + logPath + ".home'\n" +
 		"printf '%s' \"$CODEX_HOME\" > '" + logPath + ".codexhome'\n" +
@@ -464,7 +520,7 @@ func installFakeCodex(t *testing.T, exitCode int) string {
 		"exit " + strconv.Itoa(exitCode) + "\n")
 	if runtime.GOOS == "windows" {
 		name = "codex.bat"
-		script = []byte("@echo off\r\nexit /b " + strconv.Itoa(exitCode) + "\r\n")
+		script = []byte("@echo off\r\nif \"%1\"==\"--version\" (\r\n  echo codex-cli 0.139.0\r\n  exit /b 0\r\n)\r\nexit /b " + strconv.Itoa(exitCode) + "\r\n")
 	}
 	codexPath := filepath.Join(binDir, name)
 	if err := os.WriteFile(codexPath, script, 0o755); err != nil {

--- a/cmd/madari/run_codex_version.go
+++ b/cmd/madari/run_codex_version.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const minimumCodexPolicyRunVersion = "0.139.0"
+
+var codexSemanticVersionPattern = regexp.MustCompile(`([0-9]+)\.([0-9]+)\.([0-9]+)(-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?`)
+
+type codexSemanticVersion struct {
+	major      int
+	minor      int
+	patch      int
+	prerelease string
+}
+
+func validateCodexPolicyRunCompatibility() error {
+	return validateCodexPolicyRunVersion()
+}
+
+func validateCodexPolicyRunVersion() error {
+	path, err := exec.LookPath("codex")
+	if err != nil {
+		return fmt.Errorf("codex executable not found in PATH; install a stable Codex CLI 0.139.x release (minimum %s) for capability policy runs", minimumCodexPolicyRunVersion)
+	}
+	output, err := exec.Command(path, "--version").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("inspect Codex version for capability policy run: %w", err)
+	}
+	current, err := parseCodexSemanticVersion(string(output))
+	if err != nil {
+		return fmt.Errorf("cannot verify Codex capability policy support from version output %q: %w", strings.TrimSpace(string(output)), err)
+	}
+	minimum, _ := parseCodexSemanticVersion(minimumCodexPolicyRunVersion)
+	if current.lessThan(minimum) || current.major != 0 || current.minor != 139 || current.prerelease != "" {
+		return fmt.Errorf("Codex %s is outside the validated capability policy run range; install a stable Codex CLI 0.139.x release (minimum %s)", current, minimumCodexPolicyRunVersion)
+	}
+	return nil
+}
+
+func parseCodexSemanticVersion(output string) (codexSemanticVersion, error) {
+	match := codexSemanticVersionPattern.FindStringSubmatch(strings.TrimSpace(output))
+	if len(match) != 5 {
+		return codexSemanticVersion{}, fmt.Errorf("expected MAJOR.MINOR.PATCH")
+	}
+	parts := [3]int{}
+	for i := range parts {
+		value, err := strconv.Atoi(match[i+1])
+		if err != nil {
+			return codexSemanticVersion{}, fmt.Errorf("parse version component %q: %w", match[i+1], err)
+		}
+		parts[i] = value
+	}
+	return codexSemanticVersion{major: parts[0], minor: parts[1], patch: parts[2], prerelease: match[4]}, nil
+}
+
+func (v codexSemanticVersion) lessThan(other codexSemanticVersion) bool {
+	if v.major != other.major {
+		return v.major < other.major
+	}
+	if v.minor != other.minor {
+		return v.minor < other.minor
+	}
+	if v.patch != other.patch {
+		return v.patch < other.patch
+	}
+	return v.prerelease != "" && other.prerelease == ""
+}
+
+func (v codexSemanticVersion) String() string {
+	return fmt.Sprintf("%d.%d.%d%s", v.major, v.minor, v.patch, v.prerelease)
+}

--- a/cmd/madari/run_codex_version_test.go
+++ b/cmd/madari/run_codex_version_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestParseCodexSemanticVersion(t *testing.T) {
+	cases := []struct {
+		output string
+		want   string
+	}{
+		{"codex-cli 0.139.0", "0.139.0"},
+		{"codex-cli 0.140.1-beta.2", "0.140.1-beta.2"},
+		{"1.0.0", "1.0.0"},
+	}
+	for _, tc := range cases {
+		got, err := parseCodexSemanticVersion(tc.output)
+		if err != nil {
+			t.Fatalf("parse %q: %v", tc.output, err)
+		}
+		if got.String() != tc.want {
+			t.Fatalf("parse %q: got %s want %s", tc.output, got, tc.want)
+		}
+	}
+	if _, err := parseCodexSemanticVersion("codex development build"); err == nil {
+		t.Fatalf("expected unversioned build to fail closed")
+	}
+	minimum, _ := parseCodexSemanticVersion("0.139.0")
+	boundaries := []struct {
+		version string
+		older   bool
+	}{
+		{"0.138.9", true},
+		{"0.139.0-beta.1", true},
+		{"0.139.0", false},
+		{"0.140.0-beta.1", false},
+	}
+	for _, boundary := range boundaries {
+		version, err := parseCodexSemanticVersion(boundary.version)
+		if err != nil {
+			t.Fatalf("parse boundary %s: %v", boundary.version, err)
+		}
+		if got := version.lessThan(minimum); got != boundary.older {
+			t.Fatalf("boundary %s older=%t want %t", boundary.version, got, boundary.older)
+		}
+	}
+}
+
+func TestValidateCodexPolicyRunVersionRejectsOlderCLI(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-specific")
+	}
+	binDir := t.TempDir()
+	path := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nprintf 'codex-cli 0.138.9\\n'\n"), 0o755); err != nil {
+		t.Fatalf("write fake Codex: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+	err := validateCodexPolicyRunVersion()
+	if err == nil || !strings.Contains(err.Error(), "stable Codex CLI 0.139.x") {
+		t.Fatalf("expected old Codex refusal, got: %v", err)
+	}
+}
+
+func TestValidateCodexPolicyRunCompatibilityRejectsUnvalidatedNewerSeries(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-specific")
+	}
+	binDir := t.TempDir()
+	path := filepath.Join(binDir, "codex")
+	script := "#!/bin/sh\nprintf 'codex-cli 0.140.0\\n'\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake Codex: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+	err := validateCodexPolicyRunCompatibility()
+	if err == nil || !strings.Contains(err.Error(), "stable Codex CLI 0.139.x") {
+		t.Fatalf("expected unvalidated version refusal, got: %v", err)
+	}
+}

--- a/cmd/madari/run_plan.go
+++ b/cmd/madari/run_plan.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/ankitvg/madari/internal/clients"
+	codexclient "github.com/ankitvg/madari/internal/clients/codex"
 	"github.com/ankitvg/madari/internal/policy"
 	"github.com/ankitvg/madari/internal/registry"
 )
@@ -18,18 +19,20 @@ import (
 const runDryRunOnlyMessage = "madari run execution is only implemented for codex; pass --dry-run to inspect the launch plan"
 
 type runPlanJSON struct {
-	SchemaVersion   int             `json:"schema_version"`
-	Command         string          `json:"command"`
-	Target          string          `json:"target"`
-	Rings           []string        `json:"rings"`
-	Ready           bool            `json:"ready"`
-	RunnerAvailable bool            `json:"runner_available"`
-	PromptProvided  bool            `json:"prompt_provided"`
-	Servers         []runPlanServer `json:"servers"`
-	Skills          []runPlanSkill  `json:"skills"`
-	Env             []runPlanEnv    `json:"env"`
-	Warnings        []string        `json:"warnings"`
-	Errors          []string        `json:"errors"`
+	SchemaVersion   int               `json:"schema_version"`
+	Command         string            `json:"command"`
+	Target          string            `json:"target"`
+	Rings           []string          `json:"rings"`
+	Ready           bool              `json:"ready"`
+	RunnerAvailable bool              `json:"runner_available"`
+	PromptProvided  bool              `json:"prompt_provided"`
+	PolicyRequired  bool              `json:"policy_required"`
+	PolicyControls  runPolicyControls `json:"policy_controls"`
+	Servers         []runPlanServer   `json:"servers"`
+	Skills          []runPlanSkill    `json:"skills"`
+	Env             []runPlanEnv      `json:"env"`
+	Warnings        []string          `json:"warnings"`
+	Errors          []string          `json:"errors"`
 }
 
 type runLaunchPlan struct {
@@ -38,6 +41,8 @@ type runLaunchPlan struct {
 	Ready           bool
 	RunnerAvailable bool
 	PromptProvided  bool
+	PolicyRequired  bool
+	PolicyControls  runPolicyControls
 	Servers         []runPlanServer
 	Skills          []runPlanSkill
 	Env             []runPlanEnv
@@ -46,14 +51,40 @@ type runLaunchPlan struct {
 }
 
 type runPlanServer struct {
-	Name       string   `json:"name"`
-	Transport  string   `json:"transport"`
-	Endpoint   string   `json:"endpoint"`
-	Status     string   `json:"status"`
-	Auth       string   `json:"auth,omitempty"`
-	RuntimeEnv []string `json:"runtime_env"`
-	Rings      []string `json:"rings"`
-	Issues     []string `json:"issues"`
+	Name       string              `json:"name"`
+	Transport  string              `json:"transport"`
+	Endpoint   string              `json:"endpoint"`
+	Status     string              `json:"status"`
+	Auth       string              `json:"auth,omitempty"`
+	RuntimeEnv []string            `json:"runtime_env"`
+	Rings      []string            `json:"rings"`
+	Issues     []string            `json:"issues"`
+	Policy     runPlanServerPolicy `json:"policy"`
+	Manifest   registry.Manifest   `json:"-"`
+}
+
+type runPolicyControls struct {
+	ToolFiltering string `json:"tool_filtering"`
+	OAuthScopes   string `json:"oauth_scopes"`
+	Approvals     string `json:"approvals"`
+	Instructions  string `json:"instructions"`
+}
+
+type runPlanServerPolicy struct {
+	Declared                  *accessJSON                  `json:"declared,omitempty"`
+	RingEnforcement           string                       `json:"ring_enforcement"`
+	RequiredBy                []string                     `json:"required_by"`
+	Effective                 *runPlanEffectiveCodexPolicy `json:"effective,omitempty"`
+	SupportState              string                       `json:"support_state"`
+	EnforcementClassification string                       `json:"enforcement_classification"`
+}
+
+type runPlanEffectiveCodexPolicy struct {
+	EnabledTools             []string          `json:"enabled_tools"`
+	DisabledTools            []string          `json:"disabled_tools"`
+	RequestedOAuthScopes     []string          `json:"requested_oauth_scopes"`
+	DefaultToolsApprovalMode string            `json:"default_tools_approval_mode,omitempty"`
+	ToolApprovalModes        map[string]string `json:"tool_approval_modes"`
 }
 
 type runPlanSkill struct {
@@ -146,6 +177,12 @@ func (a cliApp) buildRunPlan(target string, ringNames []string, prompt string) (
 		Rings:           nonNilStrings(normalizedRingNames(ringNames)),
 		RunnerAvailable: false,
 		PromptProvided:  strings.TrimSpace(prompt) != "",
+		PolicyControls: runPolicyControls{
+			ToolFiltering: "client-enforced",
+			OAuthScopes:   "requested/client-configured/provider-unverified",
+			Approvals:     "client-control/not-authorization",
+			Instructions:  "contracts-and-skills-advisory",
+		},
 	}
 	addPlanError := func(message string) {
 		plan.Errors = append(plan.Errors, message)
@@ -188,6 +225,8 @@ func (a cliApp) buildRunPlan(target string, ringNames []string, prompt string) (
 
 	serverRings := map[string][]string{}
 	skillRings := map[string][]string{}
+	requiredByServer := map[string][]string{}
+	policySupportByServer := map[string]string{}
 	for _, name := range plan.Rings {
 		ring, err := a.store.GetRing(name)
 		if err != nil {
@@ -197,8 +236,32 @@ func (a cliApp) buildRunPlan(target string, ringNames []string, prompt string) (
 			}
 			return runLaunchPlan{}, err
 		}
-		if err := preflightRequiredRingPolicy(ring, manifests, target, policy.SurfaceRun); err != nil {
+		validation := policy.ValidateRequiredRing(ring, manifests, target, policy.SurfaceRun)
+		if err := validation.Err(); err != nil {
 			addPlanError(err.Error())
+		}
+		if ring.RequiresPolicyEnforcement() {
+			plan.PolicyRequired = true
+			for _, member := range ring.Members {
+				member = strings.TrimSpace(member)
+				if member != "" {
+					requiredByServer[member] = appendUniqueName(requiredByServer[member], name)
+					policySupportByServer[member] = strongestPolicySupport(policySupportByServer[member], "supported")
+				}
+			}
+			for _, issue := range validation.Issues {
+				state := policySupportForIssue(issue)
+				if issue.Member != "" {
+					policySupportByServer[issue.Member] = strongestPolicySupport(policySupportByServer[issue.Member], state)
+					continue
+				}
+				for _, member := range ring.Members {
+					member = strings.TrimSpace(member)
+					if member != "" {
+						policySupportByServer[member] = strongestPolicySupport(policySupportByServer[member], state)
+					}
+				}
+			}
 		}
 		for _, member := range ring.Members {
 			member = strings.TrimSpace(member)
@@ -210,6 +273,29 @@ func (a cliApp) buildRunPlan(target string, ringNames []string, prompt string) (
 			skill = strings.TrimSpace(skill)
 			if skill != "" {
 				skillRings[skill] = appendUniqueName(skillRings[skill], name)
+			}
+		}
+	}
+	declaredAccessServers := map[string]bool{}
+	for name := range serverRings {
+		if manifest, exists := manifestByName[name]; exists && manifest.Access != nil {
+			declaredAccessServers[name] = true
+		}
+	}
+	policyRuntimeBlocked := false
+	if target == codexclient.Target && (plan.PolicyRequired || len(declaredAccessServers) > 0) {
+		if !plan.RunnerAvailable {
+			policyRuntimeBlocked = true
+		} else if err := validateCodexPolicyRunCompatibility(); err != nil {
+			policyRuntimeBlocked = true
+			addPlanError(err.Error())
+		}
+		if policyRuntimeBlocked {
+			for name := range requiredByServer {
+				policySupportByServer[name] = strongestPolicySupport(policySupportByServer[name], "unsupported")
+			}
+			for name := range declaredAccessServers {
+				policySupportByServer[name] = strongestPolicySupport(policySupportByServer[name], "unsupported")
 			}
 		}
 	}
@@ -229,10 +315,13 @@ func (a cliApp) buildRunPlan(target string, ringNames []string, prompt string) (
 		if !exists {
 			server.Status = "blocked"
 			server.Issues = append(server.Issues, "server is missing from the registry")
+			policySupportByServer[name] = strongestPolicySupport(policySupportByServer[name], "invalid")
+			server.Policy = buildRunPlanServerPolicy(nil, target, requiredByServer[name], policySupportByServer[name], true)
 			plan.Servers = append(plan.Servers, server)
 			addPlanError(fmt.Sprintf("ring member %s no longer exists in the registry", name))
 			continue
 		}
+		server.Manifest = manifest
 		server.Transport = manifest.TransportType()
 		server.Endpoint = manifestEndpoint(manifest)
 		server.Auth = runPlanAuth(manifest)
@@ -279,6 +368,13 @@ func (a cliApp) buildRunPlan(target string, ringNames []string, prompt string) (
 			for _, issue := range server.Issues {
 				addPlanError(fmt.Sprintf("server %s: %s", name, issue))
 			}
+		}
+		server.Policy = buildRunPlanServerPolicy(&manifest, target, requiredByServer[name], policySupportByServer[name], policyRuntimeBlocked || server.Status == "blocked")
+		if server.Policy.EnforcementClassification == "blocked" && server.Status != "blocked" {
+			server.Status = "blocked"
+			issue := fmt.Sprintf("capability policy enforcement is blocked: support=%s", server.Policy.SupportState)
+			server.Issues = append(server.Issues, issue)
+			addPlanError(fmt.Sprintf("server %s: %s", name, issue))
 		}
 		plan.Servers = append(plan.Servers, server)
 	}
@@ -341,6 +437,8 @@ func (p runLaunchPlan) toJSON() runPlanJSON {
 		Ready:           p.Ready,
 		RunnerAvailable: p.RunnerAvailable,
 		PromptProvided:  p.PromptProvided,
+		PolicyRequired:  p.PolicyRequired,
+		PolicyControls:  p.PolicyControls,
 		Servers:         nonNilRunPlanServers(p.Servers),
 		Skills:          nonNilRunPlanSkills(p.Skills),
 		Env:             nonNilRunPlanEnv(p.Env),
@@ -358,6 +456,96 @@ func runPlanAuth(manifest registry.Manifest) string {
 	default:
 		return ""
 	}
+}
+
+func strongestPolicySupport(current, candidate string) string {
+	rank := map[string]int{"": 0, "not-declared": 1, "supported": 2, "unsupported": 3, "invalid": 4}
+	if rank[candidate] > rank[current] {
+		return candidate
+	}
+	return current
+}
+
+func policySupportForIssue(issue policy.Issue) string {
+	switch issue.Code {
+	case policy.IssueUnsupportedCompiler, policy.IssueUnsupportedFeature,
+		policy.IssueUnsupportedTransport, policy.IssueUnsupportedServerField:
+		return "unsupported"
+	default:
+		return "invalid"
+	}
+}
+
+func buildRunPlanServerPolicy(manifest *registry.Manifest, target string, requiredBy []string, support string, blocked bool) runPlanServerPolicy {
+	requiredBy = nonNilStrings(sortedUniqueStrings(requiredBy))
+	out := runPlanServerPolicy{
+		RingEnforcement: "none",
+		RequiredBy:      requiredBy,
+		SupportState:    support,
+	}
+	if manifest != nil {
+		out.Declared = accessToJSON(manifest.Access)
+	}
+	if len(requiredBy) > 0 {
+		out.RingEnforcement = registry.PolicyEnforcementRequired
+		if out.SupportState == "" {
+			out.SupportState = "supported"
+		}
+		if blocked || out.SupportState != "supported" {
+			out.EnforcementClassification = "blocked"
+		} else {
+			out.EnforcementClassification = "exact"
+		}
+	} else if manifest != nil && manifest.Access != nil {
+		capabilities, known := policy.CapabilitiesFor(target, policy.SurfaceRun)
+		if !known || !capabilities.Compiler {
+			out.SupportState = "unsupported"
+		} else {
+			out.SupportState = strongestPolicySupport(out.SupportState, "supported")
+		}
+		if blocked && out.SupportState != "supported" {
+			out.EnforcementClassification = "blocked"
+		} else {
+			out.EnforcementClassification = "advisory"
+		}
+	} else {
+		out.EnforcementClassification = "none"
+		out.SupportState = "not-declared"
+	}
+
+	if manifest != nil && manifest.Access != nil && target == codexclient.Target {
+		capabilities, known := policy.CapabilitiesFor(target, policy.SurfaceRun)
+		if known && capabilities.Compiler {
+			compiled := codexclient.CompileAccess(manifest.Access)
+			effective := &runPlanEffectiveCodexPolicy{
+				EnabledTools:         []string{},
+				DisabledTools:        []string{},
+				RequestedOAuthScopes: []string{},
+				ToolApprovalModes:    map[string]string{},
+			}
+			if compiled.EnabledTools != nil {
+				effective.EnabledTools = append([]string(nil), (*compiled.EnabledTools)...)
+			}
+			if compiled.DisabledTools != nil {
+				effective.DisabledTools = append([]string(nil), (*compiled.DisabledTools)...)
+			}
+			if compiled.Scopes != nil {
+				effective.RequestedOAuthScopes = append([]string(nil), (*compiled.Scopes)...)
+			}
+			if compiled.DefaultApproval != nil {
+				effective.DefaultToolsApprovalMode = *compiled.DefaultApproval
+			}
+			if compiled.ToolApprovals != nil {
+				for tool, approval := range *compiled.ToolApprovals {
+					if approval != "" {
+						effective.ToolApprovalModes[tool] = approval
+					}
+				}
+			}
+			out.Effective = effective
+		}
+	}
+	return out
 }
 
 func normalizedRingNames(names []string) []string {
@@ -444,6 +632,12 @@ func printRunPlan(out io.Writer, plan runLaunchPlan) {
 	} else {
 		fmt.Fprintln(out, "runner: unavailable")
 	}
+	fmt.Fprintf(out, "policy controls: tool-filtering=%s oauth-scopes=%s approvals=%s instructions=%s\n",
+		plan.PolicyControls.ToolFiltering,
+		plan.PolicyControls.OAuthScopes,
+		plan.PolicyControls.Approvals,
+		plan.PolicyControls.Instructions,
+	)
 	fmt.Fprintln(out)
 
 	fmt.Fprintln(out, "servers:")
@@ -465,6 +659,7 @@ func printRunPlan(out io.Writer, plan runLaunchPlan) {
 			for _, issue := range server.Issues {
 				fmt.Fprintf(out, "    issue: %s\n", issue)
 			}
+			printRunPlanServerPolicy(out, server.Policy)
 		}
 	}
 
@@ -521,6 +716,90 @@ func printRunPlan(out io.Writer, plan runLaunchPlan) {
 	}
 }
 
+func printRunPlanServerPolicy(out io.Writer, policyPlan runPlanServerPolicy) {
+	fmt.Fprintf(out, "    policy: support=%s enforcement=%s ring_enforcement=%s",
+		policyPlan.SupportState,
+		policyPlan.EnforcementClassification,
+		policyPlan.RingEnforcement,
+	)
+	if len(policyPlan.RequiredBy) > 0 {
+		fmt.Fprintf(out, " required_by=%s", formatNameList(policyPlan.RequiredBy))
+	}
+	fmt.Fprintln(out)
+	if policyPlan.Declared == nil {
+		fmt.Fprintln(out, "    declared policy: none")
+	} else {
+		fmt.Fprintf(out, "    declared policy: allowed_tools=%s denied_tools=%s oauth_scopes=%s default_approval=%s tool_approvals=%s\n",
+			formatOptionalStringList(policyPlan.Declared.AllowedTools),
+			formatOptionalStringList(policyPlan.Declared.DeniedTools),
+			formatOptionalStringList(policyPlan.Declared.OAuthScopes),
+			formatOptionalString(policyPlan.Declared.DefaultApproval),
+			formatOptionalStringMap(policyPlan.Declared.ToolApprovals),
+		)
+	}
+	if policyPlan.Effective == nil {
+		fmt.Fprintln(out, "    effective policy: none")
+		return
+	}
+	fmt.Fprintf(out, "    effective policy: enabled_tools=%s disabled_tools=%s requested_oauth_scopes=%s default_tools_approval_mode=%s tool_approval_modes=%s\n",
+		formatEffectiveStringList(policyPlan.Effective.EnabledTools),
+		formatEffectiveStringList(policyPlan.Effective.DisabledTools),
+		formatEffectiveStringList(policyPlan.Effective.RequestedOAuthScopes),
+		formatOptionalEffectiveString(policyPlan.Effective.DefaultToolsApprovalMode),
+		formatStringMap(policyPlan.Effective.ToolApprovalModes),
+	)
+}
+
+func formatEffectiveStringList(values []string) string {
+	if len(values) == 0 {
+		return "target-default"
+	}
+	return strings.Join(values, ",")
+}
+
+func formatOptionalStringList(values *[]string) string {
+	if values == nil {
+		return "absent"
+	}
+	if len(*values) == 0 {
+		return "[]"
+	}
+	return "[" + strings.Join(*values, ",") + "]"
+}
+
+func formatOptionalString(value *string) string {
+	if value == nil {
+		return "absent"
+	}
+	return *value
+}
+
+func formatOptionalEffectiveString(value string) string {
+	if value == "" {
+		return "target-default"
+	}
+	return value
+}
+
+func formatOptionalStringMap(values *map[string]string) string {
+	if values == nil {
+		return "absent"
+	}
+	return formatStringMap(*values)
+}
+
+func formatStringMap(values map[string]string) string {
+	if len(values) == 0 {
+		return "{}"
+	}
+	keys := sortedMapKeys(values)
+	pairs := make([]string, 0, len(keys))
+	for _, key := range keys {
+		pairs = append(pairs, key+"="+values[key])
+	}
+	return "{" + strings.Join(pairs, ",") + "}"
+}
+
 func printRunHelp(out io.Writer) {
 	fmt.Fprintln(out, "Usage:")
 	fmt.Fprintln(out, "  madari run <client> --ring <ring> [--ring <ring> ...] [--dry-run] -- <prompt>")
@@ -540,6 +819,10 @@ func printRunHelp(out io.Writer) {
 	fmt.Fprintln(out, "  working directory and caller HOME/USERPROFILE; Codex gets temporary")
 	fmt.Fprintln(out, "  HOME/CODEX_HOME roots with auth copied in. Other clients are dry-run only")
 	fmt.Fprintln(out, "  for now.")
+	fmt.Fprintln(out, "  Access-bearing Codex runs add --strict-config; legacy no-access runs omit it.")
+	fmt.Fprintln(out, "  Codex policy runs require a validated stable CLI 0.139.x release; dry-run")
+	fmt.Fprintln(out, "  reports declared/effective policy separately from client enforcement and")
+	fmt.Fprintln(out, "  advisory instructions.")
 	fmt.Fprintln(out, "  Run never writes client config, managed state, or permanent skill files.")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Examples:")

--- a/cmd/madari/run_policy_test.go
+++ b/cmd/madari/run_policy_test.go
@@ -1,0 +1,449 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/ankitvg/madari/internal/registry"
+)
+
+func TestRunDryRunReportsDeclaredEffectiveAndStrongestRequiredPolicy(t *testing.T) {
+	store := newTestStore(t)
+	installFakeCodex(t, 0)
+	manifest := registry.Manifest{
+		Name: "docs.server", Transport: registry.TransportHTTP, URL: "https://example.com/mcp",
+		Enabled: true, Clients: []string{"codex"}, Access: codexPolicyRenderAccess(),
+	}
+	if err := store.Save(manifest); err != nil {
+		t.Fatalf("save policy manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{Name: "advisory", Members: []string{manifest.Name}}); err != nil {
+		t.Fatalf("save advisory ring: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{
+		Name: "required", Members: []string{manifest.Name},
+		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
+	}); err != nil {
+		t.Fatalf("save required ring: %v", err)
+	}
+
+	result := runCmd(store, "run", "codex", "--ring", "advisory", "--ring", "required", "--dry-run", "--json", "--", "inspect")
+	if result.code != 0 {
+		t.Fatalf("required policy dry-run failed: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	plan := decodeRunPlan(t, result.stdout)
+	if !plan.Ready || len(plan.Servers) != 1 {
+		t.Fatalf("unexpected plan: %#v", plan)
+	}
+	server := plan.Servers[0]
+	if server.Policy.RingEnforcement != registry.PolicyEnforcementRequired ||
+		server.Policy.SupportState != "supported" ||
+		server.Policy.EnforcementClassification != "exact" ||
+		!reflect.DeepEqual(server.Policy.RequiredBy, []string{"required"}) {
+		t.Fatalf("required ring did not win for shared server: %#v", server.Policy)
+	}
+	if server.Policy.Declared == nil || server.Policy.Declared.DefaultApproval == nil || *server.Policy.Declared.DefaultApproval != string(registry.ApprovalBehaviorAlwaysPrompt) {
+		t.Fatalf("portable declared policy missing: %#v", server.Policy.Declared)
+	}
+	effective := server.Policy.Effective
+	if effective == nil ||
+		!reflect.DeepEqual(effective.EnabledTools, []string{"tools.inherit", "tools.read", "tools.write"}) ||
+		!reflect.DeepEqual(effective.DisabledTools, []string{"tools.delete", "tools.remove"}) ||
+		!reflect.DeepEqual(effective.RequestedOAuthScopes, []string{"repo.read", "repo.write"}) ||
+		effective.DefaultToolsApprovalMode != "prompt" ||
+		effective.ToolApprovalModes["tools.read"] != "auto" ||
+		effective.ToolApprovalModes["tools.write"] != "approve" {
+		t.Fatalf("Codex effective policy mismatch: %#v", effective)
+	}
+	if plan.PolicyControls.ToolFiltering != "client-enforced" ||
+		plan.PolicyControls.OAuthScopes != "requested/client-configured/provider-unverified" ||
+		plan.PolicyControls.Approvals != "client-control/not-authorization" ||
+		plan.PolicyControls.Instructions != "contracts-and-skills-advisory" {
+		t.Fatalf("policy controls are ambiguous: %#v", plan.PolicyControls)
+	}
+
+	textResult := runCmd(store, "run", "codex", "--ring", "required", "--dry-run", "--", "inspect")
+	if textResult.code != 0 {
+		t.Fatalf("text dry-run failed: %s", textResult.stderr)
+	}
+	for _, want := range []string{
+		"policy controls: tool-filtering=client-enforced",
+		"oauth-scopes=requested/client-configured/provider-unverified",
+		"approvals=client-control/not-authorization",
+		"instructions=contracts-and-skills-advisory",
+		"policy: support=supported enforcement=exact",
+		"declared policy: allowed_tools=[tools.inherit,tools.read,tools.write]",
+		"effective policy: enabled_tools=tools.inherit,tools.read,tools.write",
+	} {
+		if !strings.Contains(textResult.stdout, want) {
+			t.Fatalf("text policy report missing %q:\n%s", want, textResult.stdout)
+		}
+	}
+}
+
+func TestRunDryRunReportsAdvisoryPolicyWithoutMandatoryClaim(t *testing.T) {
+	store := newTestStore(t)
+	installFakeCodex(t, 0)
+	allowed := []string{"read"}
+	if err := store.Save(registry.Manifest{
+		Name: "docs", Command: mustCurrentExecutable(t), Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{AllowedTools: &allowed},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{Name: "advisory", Members: []string{"docs"}}); err != nil {
+		t.Fatalf("save ring: %v", err)
+	}
+	result := runCmd(store, "run", "codex", "--ring", "advisory", "--dry-run", "--json", "--", "inspect")
+	if result.code != 0 {
+		t.Fatalf("advisory dry-run failed: %s", result.stderr)
+	}
+	policy := decodeRunPlan(t, result.stdout).Servers[0].Policy
+	if policy.SupportState != "supported" || policy.EnforcementClassification != "advisory" || policy.RingEnforcement != "none" || len(policy.RequiredBy) != 0 {
+		t.Fatalf("advisory policy made a mandatory claim: %#v", policy)
+	}
+}
+
+func TestRunAdvisoryPolicyReportsUnsupportedOldCodexTruthfully(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-specific")
+	}
+	store := newTestStore(t)
+	marker := filepath.Join(t.TempDir(), "executed")
+	installPolicyVersionCodex(t, "0.138.9", marker)
+	allowed := []string{"read"}
+	if err := store.Save(registry.Manifest{
+		Name: "docs", Command: mustCurrentExecutable(t), Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{AllowedTools: &allowed},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{Name: "advisory", Members: []string{"docs"}}); err != nil {
+		t.Fatalf("save ring: %v", err)
+	}
+	result := runCmd(store, "run", "codex", "--ring", "advisory", "--dry-run", "--json", "--", "inspect")
+	if result.code == 0 {
+		t.Fatalf("old Codex should not report a runnable advisory policy: %s", result.stdout)
+	}
+	plan := decodeRunPlan(t, result.stdout)
+	policy := plan.Servers[0].Policy
+	if plan.PolicyRequired || policy.RingEnforcement != "none" || policy.SupportState != "unsupported" || policy.EnforcementClassification != "blocked" {
+		t.Fatalf("advisory support state was not truthful: %#v", policy)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("old Codex executed advisory policy: %v", err)
+	}
+}
+
+func TestRunLegacyNoAccessRemainsCompatibleWithOlderCodex(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-specific")
+	}
+	store := newTestStore(t)
+	marker := filepath.Join(t.TempDir(), "executed")
+	installPolicyVersionCodex(t, "0.138.9", marker)
+	if err := store.Save(registry.Manifest{
+		Name: "docs", Command: mustCurrentExecutable(t), Enabled: true, Clients: []string{"codex"},
+	}); err != nil {
+		t.Fatalf("save legacy manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{Name: "legacy", Members: []string{"docs"}}); err != nil {
+		t.Fatalf("save legacy ring: %v", err)
+	}
+	result := runCmd(store, "run", "codex", "--ring", "legacy", "--", "inspect")
+	if result.code != 0 {
+		t.Fatalf("legacy run was broken by policy compatibility checks: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("legacy Codex did not execute: %v", err)
+	}
+}
+
+func TestRunDryRunPreservesDeclaredClearAndReportsTargetDefault(t *testing.T) {
+	store := newTestStore(t)
+	installFakeCodex(t, 0)
+	allowed := []string{"read"}
+	empty := []string{}
+	inherit := registry.ApprovalBehaviorInherit
+	toolApprovals := map[string]registry.ApprovalBehavior{"read": registry.ApprovalBehaviorInherit}
+	if err := store.Save(registry.Manifest{
+		Name: "docs", Command: mustCurrentExecutable(t), Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{
+			AllowedTools: &allowed, DeniedTools: &empty, OAuthScopes: &empty,
+			DefaultApproval: &inherit, ToolApprovals: &toolApprovals,
+		},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{
+		Name: "required", Members: []string{"docs"},
+		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
+	}); err != nil {
+		t.Fatalf("save ring: %v", err)
+	}
+	result := runCmd(store, "run", "codex", "--ring", "required", "--dry-run", "--json", "--", "inspect")
+	if result.code != 0 {
+		t.Fatalf("clear policy dry-run failed: %s", result.stderr)
+	}
+	policy := decodeRunPlan(t, result.stdout).Servers[0].Policy
+	if policy.Declared == nil || policy.Declared.DeniedTools == nil || len(*policy.Declared.DeniedTools) != 0 ||
+		policy.Declared.OAuthScopes == nil || len(*policy.Declared.OAuthScopes) != 0 ||
+		policy.Declared.DefaultApproval == nil || *policy.Declared.DefaultApproval != string(registry.ApprovalBehaviorInherit) ||
+		policy.Declared.ToolApprovals == nil || (*policy.Declared.ToolApprovals)["read"] != string(registry.ApprovalBehaviorInherit) {
+		t.Fatalf("declared clear presence was lost: %#v", policy.Declared)
+	}
+	if policy.Effective == nil || !reflect.DeepEqual(policy.Effective.EnabledTools, []string{"read"}) ||
+		len(policy.Effective.DisabledTools) != 0 || len(policy.Effective.RequestedOAuthScopes) != 0 ||
+		policy.Effective.DefaultToolsApprovalMode != "" || len(policy.Effective.ToolApprovalModes) != 0 {
+		t.Fatalf("effective clear did not resolve to target defaults: %#v", policy.Effective)
+	}
+	textResult := runCmd(store, "run", "codex", "--ring", "required", "--dry-run", "--", "inspect")
+	if textResult.code != 0 || !strings.Contains(textResult.stdout, "disabled_tools=target-default requested_oauth_scopes=target-default default_tools_approval_mode=target-default tool_approval_modes={}") {
+		t.Fatalf("text clear reporting is ambiguous: code=%d stdout=%s stderr=%s", textResult.code, textResult.stdout, textResult.stderr)
+	}
+}
+
+func TestRunRequiredPolicyBlocksOldCodexBeforeExecution(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-specific")
+	}
+	store := newTestStore(t)
+	projectDir := t.TempDir()
+	chdirForTest(t, projectDir)
+	marker := filepath.Join(t.TempDir(), "executed")
+	installPolicyVersionCodex(t, "0.138.9", marker)
+	allowed := []string{"read"}
+	if err := store.Save(registry.Manifest{
+		Name: "docs", Command: mustCurrentExecutable(t), Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{AllowedTools: &allowed},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	saveTestSkillPackage(t, store, "release", "Release workflow")
+	if err := store.SaveRing(registry.Ring{
+		Name: "required", Members: []string{"docs"}, Skills: []string{"release"},
+		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
+	}); err != nil {
+		t.Fatalf("save ring: %v", err)
+	}
+	result := runCmd(store, "run", "codex", "--ring", "required", "--dry-run", "--json", "--", "inspect")
+	if result.code == 0 || !strings.Contains(result.stderr, "launch plan is not ready") {
+		t.Fatalf("old Codex should block readiness: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	plan := decodeRunPlan(t, result.stdout)
+	server := plan.Servers[0]
+	if plan.Ready || server.Status != "blocked" || server.Policy.SupportState != "unsupported" || server.Policy.EnforcementClassification != "blocked" {
+		t.Fatalf("old Codex downgrade was not classified: %#v", plan)
+	}
+	if !strings.Contains(strings.Join(plan.Errors, "\n"), "stable Codex CLI 0.139.x") {
+		t.Fatalf("old Codex error is not actionable: %#v", plan.Errors)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("old Codex was executed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(projectDir, ".agents", "skills", "release", registry.SkillFileName)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("required run materialized a permanent skill before readiness: %v", err)
+	}
+	nonDry := runCmd(store, "run", "codex", "--ring", "required", "--", "inspect")
+	if nonDry.code == 0 || !strings.Contains(nonDry.stderr, "launch plan is not ready") {
+		t.Fatalf("non-dry old Codex run crossed readiness boundary: stdout=%s stderr=%s", nonDry.stdout, nonDry.stderr)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("non-dry old Codex executed: %v", err)
+	}
+}
+
+func TestRunSkillOnlyRequiredPolicyStillGatesCodexCompatibility(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-specific")
+	}
+	store := newTestStore(t)
+	projectDir := t.TempDir()
+	chdirForTest(t, projectDir)
+	marker := filepath.Join(t.TempDir(), "executed")
+	installPolicyVersionCodex(t, "0.138.9", marker)
+	saveTestSkillPackage(t, store, "release", "Release workflow")
+	if err := store.SaveRing(registry.Ring{
+		Name: "workflow", Skills: []string{"release"},
+		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
+	}); err != nil {
+		t.Fatalf("save skill-only ring: %v", err)
+	}
+	result := runCmd(store, "run", "codex", "--ring", "workflow", "--dry-run", "--json", "--", "release")
+	if result.code == 0 {
+		t.Fatalf("skill-only required policy bypassed compatibility gate: %s", result.stdout)
+	}
+	plan := decodeRunPlan(t, result.stdout)
+	if !plan.PolicyRequired || plan.Ready || !strings.Contains(strings.Join(plan.Errors, "\n"), "stable Codex CLI 0.139.x") {
+		t.Fatalf("skill-only policy gate was not reported: %#v", plan)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("old Codex was executed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(projectDir, ".agents", "skills", "release", registry.SkillFileName)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("skill-only required run materialized before compatibility: %v", err)
+	}
+}
+
+func TestRunRequiredPolicyReportsUnrepresentableTimeoutBlocked(t *testing.T) {
+	store := newTestStore(t)
+	installFakeCodex(t, 0)
+	allowed := []string{"read"}
+	if err := store.Save(registry.Manifest{
+		Name: "docs", Transport: registry.TransportHTTP, URL: "https://example.com/mcp", TimeoutMS: 1000,
+		Enabled: true, Clients: []string{"codex"}, Access: &registry.AccessProfile{AllowedTools: &allowed},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{
+		Name: "required", Members: []string{"docs"},
+		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
+	}); err != nil {
+		t.Fatalf("save ring: %v", err)
+	}
+	result := runCmd(store, "run", "codex", "--ring", "required", "--dry-run", "--json", "--", "inspect")
+	if result.code == 0 {
+		t.Fatalf("unrepresentable timeout should block: %s", result.stdout)
+	}
+	server := decodeRunPlan(t, result.stdout).Servers[0]
+	if server.Policy.SupportState != "unsupported" || server.Policy.EnforcementClassification != "blocked" || server.Status != "blocked" {
+		t.Fatalf("timeout downgrade not classified: %#v", server)
+	}
+}
+
+func TestCodexRunOverridesUsePlannedManifestSnapshot(t *testing.T) {
+	store := newTestStore(t)
+	installFakeCodex(t, 0)
+	allowed := []string{"read"}
+	manifest := registry.Manifest{
+		Name: "docs", Command: mustCurrentExecutable(t), Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{AllowedTools: &allowed},
+	}
+	if err := store.Save(manifest); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{
+		Name: "required", Members: []string{"docs"},
+		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
+	}); err != nil {
+		t.Fatalf("save ring: %v", err)
+	}
+	plan, err := (cliApp{store: store}).buildRunPlan("codex", []string{"required"}, "inspect")
+	if err != nil || !plan.Ready {
+		t.Fatalf("build plan: ready=%t err=%v errors=%v", plan.Ready, err, plan.Errors)
+	}
+	changed := []string{"write"}
+	manifest.Access.AllowedTools = &changed
+	if err := store.Save(manifest); err != nil {
+		t.Fatalf("mutate store after plan: %v", err)
+	}
+	overrides, err := codexRunConfigOverrides(store, plan, t.TempDir())
+	if err != nil {
+		t.Fatalf("compile planned overrides: %v", err)
+	}
+	if len(overrides) != 1 || !strings.Contains(overrides[0], `enabled_tools = ["read"]`) || strings.Contains(overrides[0], `enabled_tools = ["write"]`) {
+		t.Fatalf("override re-read a changed manifest instead of using the plan snapshot: %#v", overrides)
+	}
+}
+
+func TestRunRequiredPolicyExecutesWithStrictCompiledOverride(t *testing.T) {
+	store := newTestStore(t)
+	logPath := installFakeCodex(t, 0)
+	allowed := []string{"read"}
+	defaultApproval := registry.ApprovalBehaviorAlwaysPrompt
+	if err := store.Save(registry.Manifest{
+		Name: "docs.server", Command: mustCurrentExecutable(t), Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{AllowedTools: &allowed, DefaultApproval: &defaultApproval},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	if err := store.SaveRing(registry.Ring{
+		Name: "required", Members: []string{"docs.server"},
+		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
+	}); err != nil {
+		t.Fatalf("save ring: %v", err)
+	}
+	result := runCmd(store, "run", "codex", "--ring", "required", "--", "inspect")
+	if result.code != 0 {
+		t.Fatalf("required policy execution failed: stdout=%s stderr=%s", result.stdout, result.stderr)
+	}
+	args := readNULArgs(t, logPath)
+	if len(args) < 2 || args[0] != "exec" || args[1] != "--strict-config" {
+		t.Fatalf("required run did not enable strict config: %#v", args)
+	}
+	overrides := collectConfigOverrides(args)
+	if len(overrides) != 1 || !strings.Contains(overrides[0], `"docs.server"`) ||
+		!strings.Contains(overrides[0], `enabled_tools = ["read"]`) ||
+		!strings.Contains(overrides[0], `default_tools_approval_mode = "prompt"`) {
+		t.Fatalf("required run omitted compiled policy: %#v", overrides)
+	}
+}
+
+func TestRunCodexRechecksPolicyCompatibilityBeforeSkillMaterialization(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-specific")
+	}
+	store := newTestStore(t)
+	installFakeCodex(t, 0)
+	allowed := []string{"read"}
+	if err := store.Save(registry.Manifest{
+		Name: "docs", Command: mustCurrentExecutable(t), Enabled: true, Clients: []string{"codex"},
+		Access: &registry.AccessProfile{AllowedTools: &allowed},
+	}); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	saveTestSkillPackage(t, store, "release", "Release workflow")
+	if err := store.SaveRing(registry.Ring{
+		Name: "required", Members: []string{"docs"}, Skills: []string{"release"},
+		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
+	}); err != nil {
+		t.Fatalf("save ring: %v", err)
+	}
+	plan, err := (cliApp{store: store}).buildRunPlan("codex", []string{"required"}, "inspect")
+	if err != nil || !plan.Ready {
+		t.Fatalf("build exact plan: ready=%t err=%v errors=%v", plan.Ready, err, plan.Errors)
+	}
+	codexPath, err := exec.LookPath("codex")
+	if err != nil {
+		t.Fatalf("locate fake Codex: %v", err)
+	}
+	marker := filepath.Join(t.TempDir(), "executed")
+	replaced := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--version\" ]; then printf 'codex-cli 0.138.9\\n'; exit 0; fi\n" +
+		"printf executed > '" + marker + "'\n"
+	if err := os.WriteFile(codexPath, []byte(replaced), 0o755); err != nil {
+		t.Fatalf("replace Codex after plan: %v", err)
+	}
+	if err := store.RemoveSkill("release"); err != nil {
+		t.Fatalf("remove planned skill to detect materialization: %v", err)
+	}
+	err = runCodex(cliApp{store: store}, plan, "inspect")
+	if err == nil || !strings.Contains(err.Error(), "stable Codex CLI 0.139.x") {
+		t.Fatalf("executor did not recheck compatibility first: %v", err)
+	}
+	if strings.Contains(err.Error(), "skill") {
+		t.Fatalf("skill materialization happened before compatibility check: %v", err)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("replaced Codex executed: %v", err)
+	}
+}
+
+func installPolicyVersionCodex(t *testing.T, version, executionMarker string) {
+	t.Helper()
+	binDir := t.TempDir()
+	path := filepath.Join(binDir, "codex")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--version\" ]; then printf 'codex-cli " + version + "\\n'; exit 0; fi\n" +
+		"printf executed > '" + executionMarker + "'\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write versioned Codex fixture: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}

--- a/docs/adr/003-capability-policy-contract-v1.md
+++ b/docs/adr/003-capability-policy-contract-v1.md
@@ -134,9 +134,11 @@ stale attachment can always be cleaned up.
 Target support is declared centrally and separately for persistent sync/attach,
 render, and run. A compiler must opt into a surface; an unspecified compiler is
 unsupported. The policy-schema PR initially left every compiler disabled. The
-Codex compiler now opts into persistent sync/attach and render for all five V1
-access fields; Codex run and other target surfaces remain disabled until their
-corresponding lossless compilers land.
+Codex compiler now opts into persistent sync/attach, render, and run for all
+five V1 access fields; other target surfaces remain disabled until their
+corresponding lossless compilers land. Codex run support is additionally bounded
+to stable CLI 0.139.x releases; other runtime versions fail closed until their
+complete field semantics are validated.
 
 For persistent sync, undeclared native policy fields are preserved. Declared
 fields are compiled exactly. A required operation blocks on unknown
@@ -182,5 +184,6 @@ write.
   narrow serializer.
 - Supporting another client requires an explicit compiler and fidelity tests;
   approximate mappings are not accepted for required rings.
-- Environment sanitization, TTLs, receipts, credential brokers, audit, and
-  runtime `[policy.execution]` semantics remain outside this decision.
+- Environment sanitization, TTLs, receipts, credential brokers, audit,
+  OpenCode support, production examples, and runtime `[policy.execution]`
+  semantics remain outside this decision.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,9 +64,10 @@ member profiles. `[contract]` and skill content remain advisory, while
 - Translate registry entries into client-specific config.
 - Current adapters: Claude Desktop, Claude Code, Gemini, Codex, and Vibe.
 - Adapters own read/merge/write behavior for their client format.
-- An unspecified policy compiler is unsupported. Codex persistent sync/attach
-  and render opt into all five V1 access features; Codex run and every other
-  target policy surface remain fail-closed.
+- An unspecified policy compiler is unsupported. Codex persistent sync/attach,
+  render, and run opt into all five V1 access features; every other target
+  policy surface remains fail-closed. Access-bearing Codex runs additionally
+  require a validated stable CLI 0.139.x release.
 
 3. Sync Engine
 - Reads registry + client config.
@@ -151,8 +152,9 @@ member profiles. `[contract]` and skill content remain advisory, while
   and required operations reject unknown behavior-affecting fields.
 - OAuth scopes are requested and client-configured, not proof of a provider
   grant. Approval behavior is a client prompt control, not authorization.
-- Environment sanitization, TTLs, receipts, credential brokers, audit, and
-  `[policy.execution]` are outside V1.
+- Environment sanitization, TTLs, receipts, credential brokers, audit,
+  OpenCode support, production examples, and `[policy.execution]` are outside
+  V1.
 
 7. Skills
 - Standalone Agent Skill packages stored at `skills/<name>/` with `SKILL.md`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -81,8 +81,8 @@ unsupported, and unrepresentable members are errors; Madari never substitutes
 an advisory prompt or a weaker native control.
 
 Policy support is declared independently for persistent sync/attach, render,
-and run. Codex persistent sync/attach and render compile all five V1 fields.
-Codex run and every policy surface for other targets remain unsupported.
+and run. Codex compiles all five V1 fields on all three surfaces. Every policy
+surface for other targets remains unsupported.
 Required sync or attach fails before config, managed state, or skill mutation;
 required render fails before partial output; and required run fails before skill
 materialization or client execution. Detach remains available for cleanup.
@@ -212,9 +212,9 @@ behavior, or render output.
 
 Ring policy is distinct from the advisory contract. A ring file may set
 `[policy] enforcement = "required"`, but each referenced server remains the
-source of truth for its own `[access]` profile. Codex required attach and render
-are supported when every member compiles exactly. Required Codex run and all
-other unsupported target surfaces fail during preflight.
+source of truth for its own `[access]` profile. Codex required attach, render,
+and run are supported when every member compiles exactly. Unsupported target
+surfaces fail during preflight.
 
 ```toml
 summary = "Collect source context and prepare a research brief."
@@ -315,6 +315,12 @@ checks runtime env keys by name, and reports the launch plan. Run never writes
 client config, creates managed state, or permanently materializes skill
 packages.
 
+When any selected server declares `[access]`, Codex execution also adds
+`--strict-config` and requires a stable Codex CLI 0.139.x release. This applies
+to advisory profiles as well as policy-required rings so Madari never drops a
+declared restriction. Legacy runs with no access declarations omit the newer
+flag and version gate, preserving their existing compatibility behavior.
+
 Unlike `ring render`, `run` is fail-closed. A disabled member, missing member,
 unsupported remote transport or auth mode, missing runtime env key, or
 unsupported skill target blocks the plan instead of silently omitting that
@@ -324,8 +330,19 @@ present, because Madari cannot guarantee ring-only skill isolation in that
 case.
 Policy-required run adds a stricter preflight boundary: every declared member
 restriction must compile exactly before any temporary skill package is
-materialized or the client starts. No run policy compiler is enabled yet, so
-required runs are currently blocked while legacy runs remain unchanged.
+materialized or the client starts. Codex maps every V1 access field into the
+single ephemeral `mcp_servers={...}` override. The plan and executor both check
+the bounded version range Madari has validated for this complete contract.
+`--strict-config` is an additional config-parser safeguard, not proof that
+nested MCP policy fields retain their semantics outside the validated range.
+
+Dry-run text and JSON report each server's portable declared policy, the
+Codex-native effective policy, support state, and enforcement classification.
+If a server is shared, any selected required ring wins and is listed in
+`required_by`. The control labels are intentionally distinct: tool filtering is
+client-enforced; OAuth scopes are requested/client-configured and
+provider-unverified; approval modes are client controls rather than an
+authorization boundary; contracts and skills remain advisory instructions.
 
 ## Skills
 
@@ -600,6 +617,13 @@ do not appear as policy drift.
   "ready": true,
   "runner_available": true,
   "prompt_provided": true,
+  "policy_required": true,
+  "policy_controls": {
+    "tool_filtering": "client-enforced",
+    "oauth_scopes": "requested/client-configured/provider-unverified",
+    "approvals": "client-control/not-authorization",
+    "instructions": "contracts-and-skills-advisory"
+  },
   "servers": [
     {
       "name": "cloud-sql",
@@ -609,7 +633,20 @@ do not appear as policy drift.
       "auth": "bearer_token_env_var",
       "runtime_env": ["CLOUDSQL_MCP_TOKEN"],
       "rings": ["cloudsql-readonly"],
-      "issues": []
+      "issues": [],
+      "policy": {
+        "declared": {"allowed_tools": ["query"]},
+        "ring_enforcement": "required",
+        "required_by": ["cloudsql-readonly"],
+        "effective": {
+          "enabled_tools": ["query"],
+          "disabled_tools": [],
+          "requested_oauth_scopes": [],
+          "tool_approval_modes": {}
+        },
+        "support_state": "supported",
+        "enforcement_classification": "exact"
+      }
     }
   ],
   "skills": [],

--- a/docs/manifest-spec.md
+++ b/docs/manifest-spec.md
@@ -253,8 +253,9 @@ wrong-target, unbounded, unsupported, or unrepresentable members block the
 operation.
 
 Policy capability support is declared separately for persistent sync/attach,
-render, and run. Codex persistent sync/attach and render compile every V1 access
-field. Codex run and all other target policy surfaces remain unsupported. Any
+render, and run. Codex compiles every V1 access field on all three surfaces.
+Access-bearing Codex runs additionally require a validated stable CLI 0.139.x
+release. All other target policy surfaces remain unsupported. Any
 required operation that cannot compile exactly fails during preflight: sync and
 attach before config, state, or skills change; render before partial output; and
 run before skill materialization or client execution. Detach remains available

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -99,6 +99,10 @@ var targetCapabilities = map[string]TargetCapabilities{
 			Compiler: true, ToolAllowlist: true, ToolDenylist: true,
 			OAuthScopes: true, DefaultApproval: true, ToolApprovals: true,
 		},
+		Run: Capabilities{
+			Compiler: true, ToolAllowlist: true, ToolDenylist: true,
+			OAuthScopes: true, DefaultApproval: true, ToolApprovals: true,
+		},
 	},
 	"gemini": {Target: "gemini"},
 	"vibe":   {Target: "vibe"},

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -29,7 +29,7 @@ func TestCapabilitiesDeclareEveryTargetSurfaceFailClosed(t *testing.T) {
 			if !ok {
 				t.Fatalf("missing declaration for %s %s", target, surface)
 			}
-			expectCodexCompiler := target == "codex" && (surface == SurfacePersistent || surface == SurfaceRender)
+			expectCodexCompiler := target == "codex"
 			if capabilities.Compiler != expectCodexCompiler {
 				t.Fatalf("unexpected compiler declaration for %s %s: %#v", target, surface, capabilities)
 			}
@@ -164,10 +164,10 @@ func TestValidateRequiredRingTreatsExplicitEmptyAllowlistAsUnbounded(t *testing.
 		Access:  &registry.AccessProfile{AllowedTools: &empty},
 	}
 	result := ValidateRequiredRing(requiredRing("research", "docs"), []registry.Manifest{manifest}, "codex", SurfaceRun)
-	if result.Classification != SupportInvalid || len(result.Issues) != 3 {
-		t.Fatalf("expected unbounded plus unsupported explicit-clear issues, got: %#v", result)
+	if result.Classification != SupportInvalid || len(result.Issues) != 1 {
+		t.Fatalf("expected explicit-clear allowlist to remain unbounded, got: %#v", result)
 	}
-	if result.Issues[0].Code != IssueUnsupportedCompiler || result.Issues[1].Code != IssueUnboundedMember || result.Issues[2].Code != IssueUnsupportedFeature {
+	if result.Issues[0].Code != IssueUnboundedMember {
 		t.Fatalf("unexpected explicit-clear issue order: %#v", result.Issues)
 	}
 }
@@ -181,18 +181,15 @@ func currentExecutable(t *testing.T) string {
 	return path
 }
 
-func TestValidateRequiredRingBlocksSkillOnlyWithoutCompiler(t *testing.T) {
+func TestValidateRequiredRingAllowsSkillOnlyWithCompiler(t *testing.T) {
 	ring := registry.Ring{
 		Name:   "workflow",
 		Skills: []string{"release"},
 		Policy: &registry.RingPolicy{Enforcement: registry.PolicyEnforcementRequired},
 	}
 	result := ValidateRequiredRing(ring, nil, "codex", SurfaceRun)
-	if result.Classification != SupportUnsupported || result.Ready() || len(result.Issues) != 1 {
-		t.Fatalf("skill-only required ring must still require a compiler: %#v", result)
-	}
-	if result.Issues[0].Code != IssueUnsupportedCompiler {
-		t.Fatalf("unexpected skill-only issue: %#v", result.Issues)
+	if result.Classification != SupportSupported || !result.Ready() || len(result.Issues) != 0 {
+		t.Fatalf("skill-only required ring should use the Codex run compiler: %#v", result)
 	}
 }
 


### PR DESCRIPTION
## What changed

- enables the centralized Codex run policy compiler for all five Capability Policy V1 access fields
- compiles declared policy into one deterministic ephemeral `mcp_servers` override, including dotted/control-bearing server and tool names
- adds declared/effective policy, support state, enforcement classification, required-ring provenance, and control-boundary labels to dry-run text and JSON
- gates every access-bearing run on the validated stable Codex CLI 0.139.x series and rechecks immediately before any skill materialization or execution
- preserves legacy no-access run behavior while using `--strict-config` as an additional parser safeguard for access-bearing runs
- documents advisory versus exact enforcement and the V1 non-goals

## Why

A policy-required ring must either compile every declared restriction exactly for the selected runtime or fail before any mutation or execution. The run path now has the same fail-closed contract as persistent Codex sync/render, without treating requested OAuth scopes, approval prompts, or advisory instructions as authorization boundaries.

This PR is stacked on #72 and should remain unmerged for review.

## Validation

- `go test ./internal/registry`
- `go test ./internal/clients/codex`
- `go test ./cmd/madari`
- `go test ./internal/doctor`
- `make build`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
